### PR TITLE
 Remove fitbug/symfony-yaml-serializer-encoder-decoder in place of default YAML serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     "require": {
         "php": ">=7.1",
         "doctrine/inflector": "^1.0",
-        "fitbug/symfony-yaml-serializer-encoder-decoder": "^0.1.1",
         "league/uri": "^4.2",
         "nikic/php-parser": "^3.0",
         "php-http/httplug": "^1.0",
@@ -33,7 +32,7 @@
         "symfony/property-access": "^3.1|^4.0",
         "symfony/console": "^3.1|^4.0",
         "symfony/options-resolver": "^3.1|^4.0",
-        "symfony/serializer": "^3.1|^4.0",
+        "symfony/serializer": "^3.2|^4.0",
         "symfony/yaml": "^3.1|^4.0"
     },
     "require-dev": {

--- a/src/OpenApi/JaneOpenApi.php
+++ b/src/OpenApi/JaneOpenApi.php
@@ -2,9 +2,6 @@
 
 namespace Jane\OpenApi;
 
-use Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlDecode;
-use Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlEncode;
-use Fitbug\SymfonySerializer\YamlEncoderDecoder\YamlEncoder;
 use Jane\JsonSchema\Generator\Context\Context;
 use Jane\JsonSchema\Generator\File;
 use Jane\JsonSchema\Generator\ModelGenerator;
@@ -20,12 +17,14 @@ use Jane\OpenApi\SchemaParser\SchemaParser;
 use Jane\JsonSchema\Registry;
 use Jane\JsonSchema\Schema;
 use PhpCsFixer\ConfigInterface;
-use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use PhpParser\PrettyPrinterAbstract;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\YamlEncoder;
 use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Yaml\Dumper;
+use Symfony\Component\Yaml\Parser;
 
 class JaneOpenApi
 {
@@ -156,8 +155,8 @@ class JaneOpenApi
                 new JsonDecode(false)
             ),
             new YamlEncoder(
-                new YamlEncode(),
-                new YamlDecode(false, true, true, true)
+                new Dumper(),
+                new Parser()
             ),
         ];
         $normalizers = NormalizerFactory::create();

--- a/src/OpenApi/composer.json
+++ b/src/OpenApi/composer.json
@@ -24,8 +24,8 @@
         "jane-php/json-schema-runtime": "^4.0",
         "jane-php/open-api-runtime": "^4.0",
         "nikic/php-parser": "^3.0",
-        "symfony/yaml": "^3.1|^4.0",
-        "fitbug/symfony-yaml-serializer-encoder-decoder": "^0.1.1"
+        "symfony/serializer": "^3.2|^4.0",
+        "symfony/yaml": "^3.1|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",


### PR DESCRIPTION
Create this PR after discussing about https://github.com/janephp/openapi/pull/70.

Replace `fitbug/symfony-yaml-serializer-encoder-decoder` seems because to be not maintened anymore and the Symfony Serializer component implements its own YAML encoder/decoder.