### PR TITLE
Allow symfony 4 for json schema

### DIFF
--- a/src/JsonSchema/composer.json
+++ b/src/JsonSchema/composer.json
@@ -24,7 +24,7 @@
         "symfony/console": "^3.1|^4.0",
         "symfony/options-resolver": "^3.1|^4.0",
         "symfony/property-access": "^3.1|^4.0",
-        "symfony/yaml": "^3.1"
+        "symfony/yaml": "^3.1|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",


### PR DESCRIPTION
I was unable to install openapi/jsonschema in a Symfony 4 application because of this requirement.