### PR TITLE
Invalid schema reference results in fatal error

### DIFF
--- a/src/OpenApi/Generator/Parameter/BodyParameterGenerator.php
+++ b/src/OpenApi/Generator/Parameter/BodyParameterGenerator.php
@@ -91,7 +91,7 @@ class BodyParameterGenerator extends ParameterGenerator
 
         // Happens when reference resolve to a none object
         if (null === $class) {
-            return [$this->convertParameterType($schema->getType(), $schema->getFormat()), null];
+            return [$this->convertParameterType($resolvedSchema->getType(), $resolvedSchema->getFormat()), null];
         }
 
         $class = '\\' . $context->getRegistry()->getSchema($jsonReference)->getNamespace() . '\\Model\\' . $class->getName();


### PR DESCRIPTION
My generated swagger.json has a reference to a none object which results in a fatal error:
```
PHP Fatal error:  Uncaught Error: Call to undefined method Jane\JsonSchemaRuntime\Reference::getType() in /var/www/vendor/jane-php/open-api/Generator/Parameter/BodyParameterGenerator.php:94
```
This PR solved my use case by using the resolved schema to get type and format.