### PR TITLE
Upgrade league/uri to 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.1",
         "doctrine/inflector": "^1.0",
-        "league/uri": "^4.2",
+        "league/uri": "^5.3",
         "nikic/php-parser": "^3.0",
         "php-http/httplug": "^1.0",
         "php-http/message-factory": "^1.0.2",

--- a/src/JsonSchema/Registry.php
+++ b/src/JsonSchema/Registry.php
@@ -3,7 +3,7 @@
 namespace Jane\JsonSchema;
 
 use Jane\JsonSchema\Guesser\Guess\ClassGuess;
-use League\Uri\Schemes\Http;
+use League\Uri\Http;
 
 class Registry
 {

--- a/src/JsonSchemaRuntime/Reference.php
+++ b/src/JsonSchemaRuntime/Reference.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Jane\JsonSchemaRuntime;
 
-use League\Uri\Schemes\Generic\AbstractUri;
-use League\Uri\Schemes\Http;
-use League\Uri\UriParser;
+use League\Uri\AbstractUri;
+use League\Uri\Http;
+use League\Uri\Parser;
 use Rs\Json\Pointer;
 use Symfony\Component\Yaml\Yaml;
 
@@ -37,7 +37,7 @@ class Reference
 
     public function __construct(string $reference, string $origin)
     {
-        $uriParse = new UriParser();
+        $uriParse = new Parser();
         $originParts = $uriParse->parse($origin);
         $referenceParts = parse_url($reference);
         $mergedParts = array_merge($originParts, $referenceParts);

--- a/src/JsonSchemaRuntime/composer.json
+++ b/src/JsonSchemaRuntime/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.0",
         "symfony/serializer": "^3.1|^4.0",
         "symfony/yaml": "^3.1|^4.0",
-        "league/uri": "^4.2",
+        "league/uri": "^5.3",
         "php-jsonpointer/php-jsonpointer": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi,
As we had a dependency conflict of league/uri with another package, I need janephp to rely on v5 of leage/uri. Quite a simple PR, tests are still running fine, please review and accept.