### PR TITLE
Fix issue with endpoint url containing an '?'

### DIFF
--- a/src/OpenApiRuntime/Client/Psr7HttplugClient.php
+++ b/src/OpenApiRuntime/Client/Psr7HttplugClient.php
@@ -41,7 +41,8 @@ abstract class Psr7HttplugClient extends Client
     {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
-        $uri = $queryString !== '' ? $endpoint->getUri() . '?' . $queryString : $endpoint->getUri();
+        $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
         $request = $this->messageFactory->createRequest($endpoint->getMethod(), $uri, $endpoint->getHeaders($bodyHeaders), $body);
 
         return $endpoint->parsePSR7Response($this->httpClient->sendRequest($request), $this->serializer, $fetch);


### PR DESCRIPTION
If the endpoint looks like this 'customer?action=list' and a query
string is passed to executePsr7Endpoint() the resulting
uri is broken.

Endpoint: /customer?action=list
QueryParam: sort=creation_date

Expected result:
/customer?action=list&sort=creation_date

Actual result:
/customer?action=list?sort=creation_date
---------------------^------------------