### PR TITLE
Enhancement: Reference phpunit.xsd as installed with composer

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,8 @@
 
 <!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
         backupGlobals               = "false"
         backupStaticAttributes      = "false"
         colors                      = "true"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,6 @@
         convertWarningsToExceptions = "true"
         processIsolation            = "false"
         stopOnFailure               = "false"
-        syntaxCheck                 = "false"
         bootstrap                   = "bootstrap.php" >
 
     <testsuites>


### PR DESCRIPTION
This PR

* [x] references `phpunit.xsd` as installed with `composer`
* [x] removes an invalid configuration attribute