### PR TITLE
Fix: No need to update composer itself twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
 
 before_install:
-    - travis_retry composer self-update
     - phpenv config-rm xdebug.ini || true
 
 install:


### PR DESCRIPTION
This PR

* [x] stops updating `composer` itself twice

💁‍♂️ See, for example,

* https://travis-ci.org/janephp/janephp/jobs/410736565#L473
* https://travis-ci.org/janephp/janephp/jobs/410736565#L499