### PR TITLE
Fixed an issue with oneOf normalization/denormalization.

### DIFF
--- a/src/JsonSchema/Normalizer/JsonSchemaNormalizer.php
+++ b/src/JsonSchema/Normalizer/JsonSchemaNormalizer.php
@@ -86,8 +86,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             $value = $data->{'additionalItems'};
             if (is_bool($data->{'additionalItems'})) {
                 $value = $data->{'additionalItems'};
-            }
-            if (is_object($data->{'additionalItems'})) {
+            } elseif (is_object($data->{'additionalItems'})) {
                 $value = $this->denormalizer->denormalize($data->{'additionalItems'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
             }
             $object->setAdditionalItems($value);
@@ -96,8 +95,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             $value_1 = $data->{'items'};
             if (is_object($data->{'items'})) {
                 $value_1 = $this->denormalizer->denormalize($data->{'items'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
-            }
-            if (is_array($data->{'items'})) {
+            } elseif (is_array($data->{'items'})) {
                 $values = [];
                 foreach ($data->{'items'} as $value_2) {
                     $values[] = $this->denormalizer->denormalize($value_2, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -132,8 +130,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             $value_4 = $data->{'additionalProperties'};
             if (is_bool($data->{'additionalProperties'})) {
                 $value_4 = $data->{'additionalProperties'};
-            }
-            if (is_object($data->{'additionalProperties'})) {
+            } elseif (is_object($data->{'additionalProperties'})) {
                 $value_4 = $this->denormalizer->denormalize($data->{'additionalProperties'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
             }
             $object->setAdditionalProperties($value_4);
@@ -165,8 +162,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_9 = $value_8;
                 if (is_object($value_8)) {
                     $value_9 = $this->denormalizer->denormalize($value_8, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
-                }
-                if (is_array($value_8)) {
+                } elseif (is_array($value_8)) {
                     $values_6 = [];
                     foreach ($value_8 as $value_10) {
                         $values_6[] = $value_10;
@@ -186,15 +182,14 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         }
         if (property_exists($data, 'type')) {
             $value_12 = $data->{'type'};
-            if (isset($data->{'type'})) {
-                $value_12 = $data->{'type'};
-            }
             if (is_array($data->{'type'})) {
                 $values_8 = [];
                 foreach ($data->{'type'} as $value_13) {
                     $values_8[] = $value_13;
                 }
                 $value_12 = $values_8;
+            } elseif (isset($data->{'type'})) {
+                $value_12 = $data->{'type'};
             }
             $object->setType($value_12);
         }
@@ -275,8 +270,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             $value = $object->getAdditionalItems();
             if (is_bool($object->getAdditionalItems())) {
                 $value = $object->getAdditionalItems();
-            }
-            if (is_object($object->getAdditionalItems())) {
+            } elseif (is_object($object->getAdditionalItems())) {
                 $value = $this->normalizer->normalize($object->getAdditionalItems(), 'json', $context);
             }
             $data->{'additionalItems'} = $value;
@@ -285,8 +279,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             $value_1 = $object->getItems();
             if (is_object($object->getItems())) {
                 $value_1 = $this->normalizer->normalize($object->getItems(), 'json', $context);
-            }
-            if (is_array($object->getItems())) {
+            } elseif (is_array($object->getItems())) {
                 $values = [];
                 foreach ($object->getItems() as $value_2) {
                     $values[] = $this->normalizer->normalize($value_2, 'json', $context);
@@ -321,8 +314,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             $value_4 = $object->getAdditionalProperties();
             if (is_bool($object->getAdditionalProperties())) {
                 $value_4 = $object->getAdditionalProperties();
-            }
-            if (is_object($object->getAdditionalProperties())) {
+            } elseif (is_object($object->getAdditionalProperties())) {
                 $value_4 = $this->normalizer->normalize($object->getAdditionalProperties(), 'json', $context);
             }
             $data->{'additionalProperties'} = $value_4;
@@ -354,8 +346,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_9 = $value_8;
                 if (is_object($value_8)) {
                     $value_9 = $this->normalizer->normalize($value_8, 'json', $context);
-                }
-                if (is_array($value_8)) {
+                } elseif (is_array($value_8)) {
                     $values_6 = [];
                     foreach ($value_8 as $value_10) {
                         $values_6[] = $value_10;
@@ -375,15 +366,14 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         }
         if (null !== $object->getType()) {
             $value_12 = $object->getType();
-            if (!is_null($object->getType())) {
-                $value_12 = $object->getType();
-            }
             if (is_array($object->getType())) {
                 $values_8 = [];
                 foreach ($object->getType() as $value_13) {
                     $values_8[] = $value_13;
                 }
                 $value_12 = $values_8;
+            } elseif (!is_null($object->getType())) {
+                $value_12 = $object->getType();
             }
             $data->{'type'} = $value_12;
         }

--- a/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
@@ -50,8 +50,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $value = $data->{'dateOrNull'};
             if (is_string($data->{'dateOrNull'}) and false !== \DateTime::createFromFormat('l, d-M-y H:i:s T', $data->{'dateOrNull'})) {
                 $value = \DateTime::createFromFormat('l, d-M-y H:i:s T', $data->{'dateOrNull'});
-            }
-            if (is_null($data->{'dateOrNull'})) {
+            } elseif (is_null($data->{'dateOrNull'})) {
                 $value = $data->{'dateOrNull'};
             }
             $object->setDateOrNull($value);
@@ -60,11 +59,9 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $value_1 = $data->{'dateOrNullOrInt'};
             if (is_string($data->{'dateOrNullOrInt'}) and false !== \DateTime::createFromFormat('l, d-M-y H:i:s T', $data->{'dateOrNullOrInt'})) {
                 $value_1 = \DateTime::createFromFormat('l, d-M-y H:i:s T', $data->{'dateOrNullOrInt'});
-            }
-            if (is_null($data->{'dateOrNullOrInt'})) {
+            } elseif (is_null($data->{'dateOrNullOrInt'})) {
                 $value_1 = $data->{'dateOrNullOrInt'};
-            }
-            if (is_int($data->{'dateOrNullOrInt'})) {
+            } elseif (is_int($data->{'dateOrNullOrInt'})) {
                 $value_1 = $data->{'dateOrNullOrInt'};
             }
             $object->setDateOrNullOrInt($value_1);
@@ -82,19 +79,16 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         $value = $object->getDateOrNull();
         if (is_object($object->getDateOrNull())) {
             $value = $object->getDateOrNull()->format('l, d-M-y H:i:s T');
-        }
-        if (is_null($object->getDateOrNull())) {
+        } elseif (is_null($object->getDateOrNull())) {
             $value = $object->getDateOrNull();
         }
         $data->{'dateOrNull'} = $value;
         $value_1 = $object->getDateOrNullOrInt();
         if (is_object($object->getDateOrNullOrInt())) {
             $value_1 = $object->getDateOrNullOrInt()->format('l, d-M-y H:i:s T');
-        }
-        if (is_null($object->getDateOrNullOrInt())) {
+        } elseif (is_null($object->getDateOrNullOrInt())) {
             $value_1 = $object->getDateOrNullOrInt();
-        }
-        if (is_int($object->getDateOrNullOrInt())) {
+        } elseif (is_int($object->getDateOrNullOrInt())) {
             $value_1 = $object->getDateOrNullOrInt();
         }
         $data->{'dateOrNullOrInt'} = $value_1;

--- a/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
@@ -50,8 +50,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $value = $data->{'dateOrNull'};
             if (is_string($data->{'dateOrNull'}) and false !== \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNull'})) {
                 $value = \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNull'});
-            }
-            if (is_null($data->{'dateOrNull'})) {
+            } elseif (is_null($data->{'dateOrNull'})) {
                 $value = $data->{'dateOrNull'};
             }
             $object->setDateOrNull($value);
@@ -60,11 +59,9 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $value_1 = $data->{'dateOrNullOrInt'};
             if (is_string($data->{'dateOrNullOrInt'}) and false !== \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNullOrInt'})) {
                 $value_1 = \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNullOrInt'});
-            }
-            if (is_null($data->{'dateOrNullOrInt'})) {
+            } elseif (is_null($data->{'dateOrNullOrInt'})) {
                 $value_1 = $data->{'dateOrNullOrInt'};
-            }
-            if (is_int($data->{'dateOrNullOrInt'})) {
+            } elseif (is_int($data->{'dateOrNullOrInt'})) {
                 $value_1 = $data->{'dateOrNullOrInt'};
             }
             $object->setDateOrNullOrInt($value_1);
@@ -82,19 +79,16 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         $value = $object->getDateOrNull();
         if (is_object($object->getDateOrNull())) {
             $value = $object->getDateOrNull()->format("Y-m-d\TH:i:sP");
-        }
-        if (is_null($object->getDateOrNull())) {
+        } elseif (is_null($object->getDateOrNull())) {
             $value = $object->getDateOrNull();
         }
         $data->{'dateOrNull'} = $value;
         $value_1 = $object->getDateOrNullOrInt();
         if (is_object($object->getDateOrNullOrInt())) {
             $value_1 = $object->getDateOrNullOrInt()->format("Y-m-d\TH:i:sP");
-        }
-        if (is_null($object->getDateOrNullOrInt())) {
+        } elseif (is_null($object->getDateOrNullOrInt())) {
             $value_1 = $object->getDateOrNullOrInt();
-        }
-        if (is_int($object->getDateOrNullOrInt())) {
+        } elseif (is_int($object->getDateOrNullOrInt())) {
             $value_1 = $object->getDateOrNullOrInt();
         }
         $data->{'dateOrNullOrInt'} = $value_1;

--- a/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
@@ -49,8 +49,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $value = $data->{'nullOrString'};
             if (is_string($data->{'nullOrString'})) {
                 $value = $data->{'nullOrString'};
-            }
-            if (is_null($data->{'nullOrString'})) {
+            } elseif (is_null($data->{'nullOrString'})) {
                 $value = $data->{'nullOrString'};
             }
             $object->setNullOrString($value);
@@ -80,8 +79,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         $value = $object->getNullOrString();
         if (is_string($object->getNullOrString())) {
             $value = $object->getNullOrString();
-        }
-        if (is_null($object->getNullOrString())) {
+        } elseif (is_null($object->getNullOrString())) {
             $value = $object->getNullOrString();
         }
         $data->{'nullOrString'} = $value;

--- a/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
@@ -50,8 +50,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $value = $data->{'nullOrString'};
             if (is_string($data->{'nullOrString'})) {
                 $value = $data->{'nullOrString'};
-            }
-            if (is_null($data->{'nullOrString'})) {
+            } elseif (is_null($data->{'nullOrString'})) {
                 $value = $data->{'nullOrString'};
             }
             $object->setNullOrString($value);
@@ -67,8 +66,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         $value = $object->getNullOrString();
         if (is_string($object->getNullOrString())) {
             $value = $object->getNullOrString();
-        }
-        if (is_null($object->getNullOrString())) {
+        } elseif (is_null($object->getNullOrString())) {
             $value = $object->getNullOrString();
         }
         $data->{'nullOrString'} = $value;


### PR DESCRIPTION
Some time ago trying to generate models for working with regular docker-compose.yml files I've faced an issue.
"networks" section of the service description is described by this schema fragment(taken from official docker/cli repo)

`"networks": {
          "oneOf": [
            {"$ref": "#/definitions/list_of_strings"},
            {
              "type": "object",
              "patternProperties": {
                "^[a-zA-Z0-9._-]+$": {
                  "oneOf": [
                    {
                      "type": "object",
                      "properties": {
                        "aliases": {"$ref": "#/definitions/list_of_strings"},
                        "ipv4_address": {"type": "string"},
                        "ipv6_address": {"type": "string"}
                      },
                      "additionalProperties": false
                    },
                    {"type": "null"}
                  ]
                }
              },
              "additionalProperties": false
            }
          ]
        },`
janephp had generated such code:
`if (property_exists($data, 'networks') && $data->{'networks'} !== null) {
            $value_34 = $data->{'networks'};
            if (is_array($data->{'networks'})) {
                $values_19 = [];
                foreach ($data->{'networks'} as $value_35) {
                    $values_19[] = $value_35;
                }
                $value_34 = $values_19;
            }
            if (isset($data->{'networks'})) {
                $values_20 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
                foreach ($data->{'networks'} as $key_3 => $value_36) {
                    if (preg_match('/^[a-zA-Z0-9._-]+$/', $key_3) && isset($value_36)) {
                        $value_37 = $value_36;
                        if (is_object($value_36)) {
                            $value_37 = $value_36;
                        } elseif (is_null($value_36)) {
                            $value_37 = $value_36;
                        }
                        $values_20[$key_3] = $value_37;
                        continue;
                    }
                }
                $value_34 = $values_20;
            }
            $object->setNetworks($value_34);
            unset($data->{'networks'});
        }`

Trying to parse docker-compose.yml with service with networks described by the string list lead program to crash. It's not hard to see that for the file

`version: '3.7'

services:
  traefik:
    image: traefik:1.6-alpine
    deploy:
      placement:
        constraints:
          - node.role == manager
    command:
      - --api
      - --docker
      - --docker.watch
      - --docker.exposedByDefault=false
      - --docker.swarmMode
      - --api.statistics
    networks:
      - default
      - regions
    ports:
      - "80:80"
      - "8080:8080"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
`
both statements in generated code become true, but networks array index is an integer, so script crashes on the line

` if (preg_match('/^[a-zA-Z0-9._-]+$/', $key_3) && isset($value_36)) {`
due to strict types check.

I've fixed the issue by changing code generation a bit(there are if/ifelse blocks now) and by placing 'isset' check (for mixed type) to the end.
I hope this will help, thank you.