### PR TITLE
Normalizers should be cacheable with CacheableSupportsMethodInterface

### DIFF
--- a/src/JsonSchema/Command/GenerateCommand.php
+++ b/src/JsonSchema/Command/GenerateCommand.php
@@ -72,6 +72,7 @@ class GenerateCommand extends Command
             'reference' => true,
             'strict' => true,
             'date-format' => \DateTime::RFC3339,
+            'use-cacheable-supports-method' => false,
         ]);
 
         if (array_key_exists('json-schema-file', $options)) {
@@ -100,6 +101,7 @@ class GenerateCommand extends Command
             'reference',
             'date-format',
             'strict',
+            'use-cacheable-supports-method',
         ]);
 
         $optionsResolver->setRequired([

--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -21,23 +21,29 @@ trait NormalizerGenerator
      */
     abstract protected function getNaming();
 
-    protected function createNormalizerClass($name, $methods)
+    protected function createNormalizerClass($name, $methods, $useCacheableSupportsMethod = false)
     {
         $traits = [
             new Stmt\TraitUse([new Name('DenormalizerAwareTrait')]),
             new Stmt\TraitUse([new Name('NormalizerAwareTrait')]),
         ];
 
+        $implements = [
+            new Name('DenormalizerInterface'),
+            new Name('NormalizerInterface'),
+            new Name('DenormalizerAwareInterface'),
+            new Name('NormalizerAwareInterface'),
+        ];
+
+        if ($useCacheableSupportsMethod) {
+            $implements[] = new Name('CacheableSupportsMethodInterface');
+        }
+
         return new Stmt\Class_(
             new Name($this->getNaming()->getClassName($name)),
             [
                 'stmts' => array_merge($traits, $methods),
-                'implements' => [
-                    new Name('DenormalizerInterface'),
-                    new Name('NormalizerInterface'),
-                    new Name('DenormalizerAwareInterface'),
-                    new Name('NormalizerAwareInterface'),
-                ],
+                'implements' => $implements,
             ]
         );
     }
@@ -138,6 +144,22 @@ trait NormalizerGenerator
                 new Param('context', new Expr\Array_(), 'array'),
             ],
             'stmts' => $statements,
+        ]);
+    }
+
+    /**
+     * Create method to say that hasCacheableSupportsMethod is supported.
+     *
+     * @return Stmt\ClassMethod
+     */
+    protected function createHasCacheableSupportsMethod()
+    {
+        return new Stmt\ClassMethod('hasCacheableSupportsMethod', [
+            'type' => Stmt\Class_::MODIFIER_PUBLIC,
+            'returnType' => 'bool',
+            'stmts' => [
+                new Stmt\Return_(new Expr\ConstFetch(new Name('true'))),
+            ],
         ]);
     }
 }

--- a/src/JsonSchema/Jane.php
+++ b/src/JsonSchema/Jane.php
@@ -96,7 +96,7 @@ class Jane extends ChainGenerator
         $chainGuesser = JsonSchemaGuesserFactory::create($serializer, $options);
         $naming = new Naming();
         $modelGenerator = new ModelGenerator($naming);
-        $normGenerator = new NormalizerGenerator($naming, $options['reference']);
+        $normGenerator = new NormalizerGenerator($naming, $options['reference'], $options['use-cacheable-supports-method'] ?? false);
 
         $self = new self($serializer, $chainGuesser, $naming, $options['strict']);
         $self->addGenerator($modelGenerator);


### PR DESCRIPTION
With Symfony 4.1, a new interface `CacheableSupportsMethodInterface` was given to explicitly say that: 

> Marker interface for normalizers and denormalizers that use only the type and the format in their supports*() methods.
> By implementing this interface, the return value of the supports*() methods will be cached by type and format

@see https://symfony.com/blog/new-in-symfony-4-1-faster-serializer

It seems that all the normalizers generated by Jane are eligible to this cache and given that on a serious project we have tenth of normalizers, we can get an important performance boost.