### PR TITLE
Added content type header parameter

### DIFF
--- a/src/OpenApiRuntime/Client/Psr7HttplugEndpointTrait.php
+++ b/src/OpenApiRuntime/Client/Psr7HttplugEndpointTrait.php
@@ -10,12 +10,17 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 trait Psr7HttplugEndpointTrait
 {
-    abstract protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer);
+    abstract protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
 
     public function parsePSR7Response(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
         if ($fetchMode === Client::FETCH_OBJECT) {
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer);
+            return $this->transformResponseBody(
+                (string) $response->getBody(),
+                $response->getStatusCode(),
+                $serializer,
+                $response->getHeader('Content-Type')[0] ?? ''
+            );
         }
 
         if ($fetchMode === Client::FETCH_RESPONSE) {

--- a/src/OpenApiRuntime/Tests/Fakes/EndpointFake.php
+++ b/src/OpenApiRuntime/Tests/Fakes/EndpointFake.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\OpenApiRuntime\Tests\Fakes;
+
+use Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class EndpointFake
+{
+    use Psr7HttplugEndpointTrait;
+
+    /**
+     * @var string
+     */
+    protected $contentType = '';
+
+    protected function transformResponseBody(
+        string $body,
+        int $status,
+        SerializerInterface $serializer,
+        ?string $contentType = null
+    ): ?string {
+        if ($contentType === $this->contentType && $status === 200) {
+            return $body;
+        }
+
+        return null;
+    }
+
+    public function setContentType(string $contentType): self
+    {
+        $this->contentType = $contentType;
+
+        return $this;
+    }
+}

--- a/src/OpenApiRuntime/Tests/Fakes/Response.php
+++ b/src/OpenApiRuntime/Tests/Fakes/Response.php
@@ -1,0 +1,301 @@
+<?php
+
+namespace Jane\OpenApiRuntime\Tests\Fakes;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class Response implements ResponseInterface
+{
+    /**
+     * @var array
+     */
+    protected $headers = [];
+
+    /**
+     * @var string
+     */
+    protected $body;
+
+    /**
+     * @var int
+     */
+    protected $status;
+
+    /**
+     * @var string
+     */
+    protected $reasonPhrase;
+
+    /**
+     * Retrieves the HTTP protocol version as a string.
+     *
+     * The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").
+     *
+     * @return string HTTP protocol version.
+     */
+    public function getProtocolVersion()
+    {
+        return '1.0';
+    }
+
+    /**
+     * Return an instance with the specified HTTP protocol version.
+     *
+     * The version string MUST contain only the HTTP version number (e.g.,
+     * "1.1", "1.0").
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new protocol version.
+     *
+     * @param string $version HTTP protocol version
+     * @return static
+     */
+    public function withProtocolVersion($version)
+    {
+        return $this;
+    }
+
+    /**
+     * Retrieves all message header values.
+     *
+     * The keys represent the header name as it will be sent over the wire, and
+     * each value is an array of strings associated with the header.
+     *
+     *     // Represent the headers as a string
+     *     foreach ($message->getHeaders() as $name => $values) {
+     *         echo $name . ": " . implode(", ", $values);
+     *     }
+     *
+     *     // Emit headers iteratively:
+     *     foreach ($message->getHeaders() as $name => $values) {
+     *         foreach ($values as $value) {
+     *             header(sprintf('%s: %s', $name, $value), false);
+     *         }
+     *     }
+     *
+     * While header names are not case-sensitive, getHeaders() will preserve the
+     * exact case in which headers were originally specified.
+     *
+     * @return string[][] Returns an associative array of the message's headers. Each
+     *     key MUST be a header name, and each value MUST be an array of strings
+     *     for that header.
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Checks if a header exists by the given case-insensitive name.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return bool Returns true if any header names match the given header
+     *     name using a case-insensitive string comparison. Returns false if
+     *     no matching header name is found in the message.
+     */
+    public function hasHeader($name)
+    {
+        return in_array($name, array_keys($this->headers));
+    }
+
+    /**
+     * Retrieves a message header value by the given case-insensitive name.
+     *
+     * This method returns an array of all the header values of the given
+     * case-insensitive header name.
+     *
+     * If the header does not appear in the message, this method MUST return an
+     * empty array.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return string[] An array of string values as provided for the given
+     *    header. If the header does not appear in the message, this method MUST
+     *    return an empty array.
+     */
+    public function getHeader($name)
+    {
+        return $this->headers[$name] ?? [];
+    }
+
+    /**
+     * Retrieves a comma-separated string of the values for a single header.
+     *
+     * This method returns all of the header values of the given
+     * case-insensitive header name as a string concatenated together using
+     * a comma.
+     *
+     * NOTE: Not all header values may be appropriately represented using
+     * comma concatenation. For such headers, use getHeader() instead
+     * and supply your own delimiter when concatenating.
+     *
+     * If the header does not appear in the message, this method MUST return
+     * an empty string.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return string A string of values as provided for the given header
+     *    concatenated together using a comma. If the header does not appear in
+     *    the message, this method MUST return an empty string.
+     */
+    public function getHeaderLine($name)
+    {
+        // TODO: Implement getHeaderLine() method.
+    }
+
+    /**
+     * Return an instance with the provided value replacing the specified header.
+     *
+     * While header names are case-insensitive, the casing of the header will
+     * be preserved by this function, and returned from getHeaders().
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new and/or updated header and value.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @param string|string[] $value Header value(s).
+     * @return static
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function withHeader($name, $value)
+    {
+        $this->headers[$name] = (array) $value;
+
+        return $this;
+    }
+
+    /**
+     * Return an instance with the specified header appended with the given value.
+     *
+     * Existing values for the specified header will be maintained. The new
+     * value(s) will be appended to the existing list. If the header did not
+     * exist previously, it will be added.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new header and/or value.
+     *
+     * @param string $name Case-insensitive header field name to add.
+     * @param string|string[] $value Header value(s).
+     * @return static
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function withAddedHeader($name, $value)
+    {
+        return $this;
+    }
+
+    /**
+     * Return an instance without the specified header.
+     *
+     * Header resolution MUST be done without case-sensitivity.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that removes
+     * the named header.
+     *
+     * @param string $name Case-insensitive header field name to remove.
+     * @return static
+     */
+    public function withoutHeader($name)
+    {
+        return $this;
+    }
+
+    /**
+     * Gets the body of the message.
+     *
+     * @return StreamInterface Returns the body as a stream.
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * Return an instance with the specified message body.
+     *
+     * The body MUST be a StreamInterface object.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * new body stream.
+     *
+     * @param StreamInterface $body Body.
+     * @return static
+     * @throws \InvalidArgumentException When the body is not valid.
+     */
+    public function withBody(StreamInterface $body)
+    {
+        $this->body = $body->getContents();
+
+        return $this;
+    }
+
+    public function setBody(string $body)
+    {
+        $this->body = $body;
+
+        return $this;
+    }
+
+    /**
+     * Gets the response status code.
+     *
+     * The status code is a 3-digit integer result code of the server's attempt
+     * to understand and satisfy the request.
+     *
+     * @return int Status code.
+     */
+    public function getStatusCode()
+    {
+        return $this->status;
+    }
+
+    /**
+     * Return an instance with the specified status code and, optionally, reason phrase.
+     *
+     * If no reason phrase is specified, implementations MAY choose to default
+     * to the RFC 7231 or IANA recommended reason phrase for the response's
+     * status code.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * updated status and reason phrase.
+     *
+     * @link http://tools.ietf.org/html/rfc7231#section-6
+     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+     * @param int $code The 3-digit integer result code to set.
+     * @param string $reasonPhrase The reason phrase to use with the
+     *     provided status code; if none is provided, implementations MAY
+     *     use the defaults as suggested in the HTTP specification.
+     * @return static
+     * @throws \InvalidArgumentException For invalid status code arguments.
+     */
+    public function withStatus($code, $reasonPhrase = '')
+    {
+        $this->status = $code;
+        $this->reasonPhrase = $reasonPhrase;
+
+        return $this;
+    }
+
+    /**
+     * Gets the response reason phrase associated with the status code.
+     *
+     * Because a reason phrase is not a required element in a response
+     * status line, the reason phrase value MAY be null. Implementations MAY
+     * choose to return the default RFC 7231 recommended reason phrase (or those
+     * listed in the IANA HTTP Status Code Registry) for the response's
+     * status code.
+     *
+     * @link http://tools.ietf.org/html/rfc7231#section-6
+     * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+     * @return string Reason phrase; must return an empty string if none present.
+     */
+    public function getReasonPhrase()
+    {
+        return $this->reasonPhrase;
+    }
+}

--- a/src/OpenApiRuntime/Tests/Psr7HttplugEndpointTraitTest.php
+++ b/src/OpenApiRuntime/Tests/Psr7HttplugEndpointTraitTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApiRuntime\Tests;
+
+use Jane\OpenApiRuntime\Tests\Fakes\EndpointFake;
+use Jane\OpenApiRuntime\Tests\Fakes\Response;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Serializer;
+
+class Psr7HttplugEndpointTraitTest extends TestCase
+{
+    public function testCanParseBody()
+    {
+        $endpoint = (new EndpointFake)->setContentType('application/json');
+
+        $response = (new Response)->withStatus(200)
+            ->setBody('Testing')
+            ->withHeader('Content-Type', 'application/json');
+
+        $result = $endpoint->parsePSR7Response($response, $this->makeSerializer());
+
+        $this->assertEquals('Testing', $result);
+    }
+
+    /** @test */
+    public function testCanHandleMissingContentTypeHeader()
+    {
+        $endpoint = (new EndpointFake)->setContentType('application/json');
+
+        $response = (new Response)->withStatus(200)
+            ->setBody('Testing');
+
+        $result = $endpoint->parsePSR7Response($response, $this->makeSerializer());
+
+        $this->assertNull($result);
+    }
+
+    private function makeSerializer(): Serializer
+    {
+        return new Serializer();
+    }
+}


### PR DESCRIPTION
This is a bug fix to the generation of endpoints as it requires that a content type header is provided in the `transformResponseBody` method. Below is the line I think creates the content type parameter.

https://github.com/janephp/janephp/blob/master/src/OpenApi/Generator/EndpointGenerator.php#L498

Currently no parameter is passed through so this pull request adds it in.