### PR TITLE
Adding discriminator support for OpenApi

### DIFF
--- a/src/JsonSchema/Generator/ModelGenerator.php
+++ b/src/JsonSchema/Generator/ModelGenerator.php
@@ -7,6 +7,7 @@ use Jane\JsonSchema\Generator\Model\ClassGenerator;
 use Jane\JsonSchema\Generator\Model\GetterSetterGenerator;
 use Jane\JsonSchema\Generator\Model\PropertyGenerator;
 use Jane\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\JsonSchema\Guesser\Guess\Property;
 use Jane\JsonSchema\Schema;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
@@ -69,8 +70,7 @@ class ModelGenerator implements GeneratorInterface
 
             foreach ($class->getProperties() as $property) {
                 $properties[] = $this->createProperty($property, $schema->getNamespace() . '\\Model');
-                $methods[] = $this->createGetter($property, $schema->getNamespace() . '\\Model');
-                $methods[] = $this->createSetter($property, $schema->getNamespace() . '\\Model');
+                $methods = array_merge($methods, $this->doCreateClassMethods($class, $property, $schema->getNamespace() . '\\Model'));
             }
 
             $model = $this->doCreateModel($class, $properties, $methods);
@@ -79,6 +79,15 @@ class ModelGenerator implements GeneratorInterface
 
             $schema->addFile(new File($schema->getDirectory() . '/Model/' . $class->getName() . '.php', $namespace, self::FILE_TYPE_MODEL));
         }
+    }
+
+    protected function doCreateClassMethods(ClassGuess $classGuess, Property $property, string $namespace)
+    {
+        $methods = [];
+        $methods[] = $this->createGetter($property, $namespace);
+        $methods[] = $this->createSetter($property, $namespace);
+
+        return $methods;
     }
 
     protected function doCreateModel(ClassGuess $class, $properties, $methods): Stmt\Class_

--- a/src/JsonSchema/Generator/ModelGenerator.php
+++ b/src/JsonSchema/Generator/ModelGenerator.php
@@ -6,6 +6,7 @@ use Jane\JsonSchema\Generator\Context\Context;
 use Jane\JsonSchema\Generator\Model\ClassGenerator;
 use Jane\JsonSchema\Generator\Model\GetterSetterGenerator;
 use Jane\JsonSchema\Generator\Model\PropertyGenerator;
+use Jane\JsonSchema\Guesser\Guess\ClassGuess;
 use Jane\JsonSchema\Schema;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
@@ -72,16 +73,21 @@ class ModelGenerator implements GeneratorInterface
                 $methods[] = $this->createSetter($property, $schema->getNamespace() . '\\Model');
             }
 
-            $model = $this->createModel(
-                $class->getName(),
-                $properties,
-                $methods,
-                \count($class->getExtensionsType()) > 0
-            );
+            $model = $this->doCreateModel($class, $properties, $methods);
 
             $namespace = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Model'), [$model]);
 
             $schema->addFile(new File($schema->getDirectory() . '/Model/' . $class->getName() . '.php', $namespace, self::FILE_TYPE_MODEL));
         }
+    }
+
+    protected function doCreateModel(ClassGuess $class, $properties, $methods): Stmt\Class_
+    {
+        return $this->createModel(
+            $class->getName(),
+            $properties,
+            $methods,
+            \count($class->getExtensionsType()) > 0
+        );
     }
 }

--- a/src/JsonSchema/Generator/Normalizer/DenormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/DenormalizerGenerator.php
@@ -69,17 +69,7 @@ trait DenormalizerGenerator
             ];
         }
 
-        array_unshift($statements, new Stmt\If_(
-            new Expr\BooleanNot(new Expr\FuncCall(new Name('is_object'), [new Arg(new Expr\Variable('data'))])),
-            [
-                'stmts' => [
-                    $context->isStrict() ?
-                    new Stmt\Throw_(new Expr\New_(new Name('InvalidArgumentException')))
-                    :
-                    new Stmt\Return_(new Expr\ConstFetch(new Name('null'))),
-                ],
-            ]
-        ));
+        array_unshift($statements, ...$this->denormalizeMethodStatements($classGuess, $context));
 
         $unset = \count($classGuess->getExtensionsType()) > 0;
 
@@ -160,5 +150,22 @@ trait DenormalizerGenerator
             ],
             'stmts' => $statements,
         ]);
+    }
+
+    protected function denormalizeMethodStatements(ClassGuess $classGuess, Context $context): array
+    {
+        return [
+            new Stmt\If_(
+                new Expr\BooleanNot(new Expr\FuncCall(new Name('is_object'), [new Arg(new Expr\Variable('data'))])),
+                [
+                    'stmts' => [
+                        $context->isStrict() ?
+                            new Stmt\Throw_(new Expr\New_(new Name('InvalidArgumentException')))
+                            :
+                            new Stmt\Return_(new Expr\ConstFetch(new Name('null'))),
+                    ],
+                ]
+            ),
+        ];
     }
 }

--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -84,9 +84,7 @@ trait NormalizerGenerator
     {
         $context->refreshScope();
         $dataVariable = new Expr\Variable('data');
-        $statements = [
-            parserExpression(new Expr\Assign($dataVariable, new Expr\New_(new Name('\\stdClass')))),
-        ];
+        $statements = $this->normalizeMethodStatements($dataVariable, $classGuess, $context);
 
         /** @var Property $property */
         foreach ($classGuess->getProperties() as $property) {
@@ -147,6 +145,13 @@ trait NormalizerGenerator
             ],
             'stmts' => $statements,
         ]);
+    }
+
+    protected function normalizeMethodStatements(Expr\Variable $dataVariable, ClassGuess $classGuess, Context $context): array
+    {
+        return [
+            parserExpression(new Expr\Assign($dataVariable, new Expr\New_(new Name('\\stdClass')))),
+        ];
     }
 
     /**

--- a/src/JsonSchema/Guesser/Guess/ClassGuess.php
+++ b/src/JsonSchema/Guesser/Guess/ClassGuess.php
@@ -17,7 +17,7 @@ class ClassGuess
     /**
      * @var Property[]
      */
-    private $properties;
+    private $properties = [];
 
     private $reference;
 

--- a/src/JsonSchema/Guesser/JsonSchema/AllOfGuesser.php
+++ b/src/JsonSchema/Guesser/JsonSchema/AllOfGuesser.php
@@ -23,7 +23,7 @@ class AllOfGuesser implements GuesserInterface, TypeGuesserInterface, ChainGuess
     use ChainGuesserAwareTrait;
     use GuesserResolverTrait;
 
-    private $naming;
+    protected $naming;
 
     public function __construct(SerializerInterface $serializer, Naming $naming)
     {
@@ -69,7 +69,7 @@ class AllOfGuesser implements GuesserInterface, TypeGuesserInterface, ChainGuess
                     }
                 }
 
-                $registry->getSchema($reference)->addClass($reference, new ClassGuess($object, $reference, $this->naming->getClassName($name), $extensions));
+                $registry->getSchema($reference)->addClass($reference, $this->createClassGuess($object, $reference, $name, $extensions));
             }
 
             foreach ($object->getAllOf() as $allOfIndex => $allOf) {
@@ -167,5 +167,10 @@ class AllOfGuesser implements GuesserInterface, TypeGuesserInterface, ChainGuess
     protected function getSchemaClass()
     {
         return JsonSchema::class;
+    }
+
+    protected function createClassGuess($object, $reference, $name, $extensions): ClassGuess
+    {
+        return new ClassGuess($object, $reference, $this->naming->getClassName($name), $extensions);
     }
 }

--- a/src/JsonSchema/Guesser/JsonSchema/ObjectGuesser.php
+++ b/src/JsonSchema/Guesser/JsonSchema/ObjectGuesser.php
@@ -73,7 +73,7 @@ class ObjectGuesser implements GuesserInterface, PropertiesGuesserInterface, Typ
                 }
             }
 
-            $registry->getSchema($reference)->addClass($reference, new ClassGuess($object, $reference, $this->naming->getClassName($name), $extensions));
+            $registry->getSchema($reference)->addClass($reference, $this->createClassGuess($object, $reference, $name, $extensions));
         }
 
         foreach ($object->getProperties() as $key => $property) {
@@ -149,5 +149,10 @@ class ObjectGuesser implements GuesserInterface, PropertiesGuesserInterface, Typ
     protected function getSchemaClass()
     {
         return JsonSchema::class;
+    }
+
+    protected function createClassGuess($object, $reference, $name, $extensions): ClassGuess
+    {
+        return new ClassGuess($object, $reference, $this->naming->getClassName($name), $extensions);
     }
 }

--- a/src/OpenApi/Generator/Model/ClassGenerator.php
+++ b/src/OpenApi/Generator/Model/ClassGenerator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi\Generator\Model;
+
+use Jane\JsonSchema\Generator\Model\ClassGenerator as BaseClassGenerator;
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+
+trait ClassGenerator
+{
+    use BaseClassGenerator {
+        createModel as baseCreateModel;
+    }
+
+    /**
+     * Return a model class.
+     *
+     * @param string $name
+     * @param Node[] $properties
+     * @param Node[] $methods
+     * @param bool   $hasExtensions
+     * @param string $extends
+     *
+     * @return Stmt\Class_
+     */
+    protected function createModel(string $name, $properties, $methods, bool $hasExtensions = false, $extends = null): Stmt\Class_
+    {
+        $classExtends = null;
+        if (null !== $extends) {
+            $classExtends = new Name($extends);
+        } elseif ($hasExtensions) {
+            $classExtends = new Name('\ArrayObject');
+        }
+
+        return new Stmt\Class_(
+            new Name($this->getNaming()->getClassName($name)),
+            [
+                'stmts' => array_merge($properties, $methods),
+                'extends' => $classExtends,
+            ]
+        );
+    }
+}

--- a/src/OpenApi/Generator/ModelGenerator.php
+++ b/src/OpenApi/Generator/ModelGenerator.php
@@ -4,6 +4,7 @@ namespace Jane\OpenApi\Generator;
 
 use Jane\JsonSchema\Generator\ModelGenerator as BaseModelGenerator;
 use Jane\JsonSchema\Guesser\Guess\ClassGuess as BaseClassGuess;
+use Jane\JsonSchema\Guesser\Guess\Property;
 use Jane\OpenApi\Generator\Model\ClassGenerator;
 use Jane\OpenApi\Guesser\Guess\ClassGuess;
 use Jane\OpenApi\Guesser\Guess\MultipleClass;
@@ -12,6 +13,15 @@ use PhpParser\Node\Stmt;
 class ModelGenerator extends BaseModelGenerator
 {
     use ClassGenerator;
+
+    protected function doCreateClassMethods(BaseClassGuess $classGuess, Property $property, string $namespace)
+    {
+        $methods = [];
+        $methods[] = $this->createGetter($property, $namespace);
+        $methods[] = $this->createSetter($property, $namespace, false, $classGuess instanceof MultipleClass ? false : true);
+
+        return $methods;
+    }
 
     protected function doCreateModel(BaseClassGuess $class, $properties, $methods): Stmt\Class_
     {

--- a/src/OpenApi/Generator/ModelGenerator.php
+++ b/src/OpenApi/Generator/ModelGenerator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi\Generator;
+
+use Jane\JsonSchema\Generator\ModelGenerator as BaseModelGenerator;
+use Jane\JsonSchema\Guesser\Guess\ClassGuess as BaseClassGuess;
+use Jane\OpenApi\Generator\Model\ClassGenerator;
+use Jane\OpenApi\Guesser\Guess\ClassGuess;
+use Jane\OpenApi\Guesser\Guess\MultipleClass;
+use PhpParser\Node\Stmt;
+
+class ModelGenerator extends BaseModelGenerator
+{
+    use ClassGenerator;
+
+    protected function doCreateModel(BaseClassGuess $class, $properties, $methods): Stmt\Class_
+    {
+        $extends = null;
+        if ($class instanceof ClassGuess &&
+            $class->getMultipleClass() instanceof MultipleClass) {
+            $extends = $this->getNaming()->getClassName($class->getMultipleClass()->getName());
+        }
+
+        $classModel = $this->createModel(
+            $class->getName(),
+            $properties,
+            $methods,
+            \count($class->getExtensionsType()) > 0,
+            $extends
+        );
+
+        return $classModel;
+    }
+}

--- a/src/OpenApi/Generator/Normalizer/DenormalizerGenerator.php
+++ b/src/OpenApi/Generator/Normalizer/DenormalizerGenerator.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\OpenApi\Generator\Normalizer;
+
+use Jane\JsonSchema\Generator\Normalizer\DenormalizerGenerator as JsonSchemaDenormalizerGenerator;
+use Jane\JsonSchema\Generator\Context\Context;
+use Jane\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\OpenApi\Guesser\Guess\MultipleClass;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Arg;
+
+trait DenormalizerGenerator
+{
+    use JsonSchemaDenormalizerGenerator {
+        denormalizeMethodStatements as jsonSchemaDenormalizeMethodStatements;
+    }
+
+    protected function denormalizeMethodStatements(ClassGuess $classGuess, Context $context): array
+    {
+        $statements = $this->jsonSchemaDenormalizeMethodStatements($classGuess, $context);
+
+        if ($classGuess instanceof MultipleClass) {
+            foreach ($classGuess->getReferences() as $name => $reference) {
+                $statements[] = new Stmt\If_(
+                    new Expr\BinaryOp\LogicalAnd(
+                        new Expr\FuncCall(new Name('property_exists'), [
+                            new Arg(new Expr\Variable('data')),
+                            new Arg(new Scalar\String_($classGuess->getDiscriminator())),
+                        ]),
+                        new Expr\BinaryOp\Identical(
+                            new Scalar\String_($name),
+                            new Expr\PropertyFetch(new Expr\Variable('data'), sprintf("{'%s'}", $classGuess->getDiscriminator()))
+                        )
+                    ),
+                    [
+                        'stmts' => [
+                            new Stmt\Return_(new Expr\MethodCall(
+                                new Expr\PropertyFetch(
+                                    new Expr\Variable('this'),
+                                    'denormalizer'
+                                ),
+                                'denormalize',
+                                [
+                                    new Expr\Variable('data'),
+                                    new Scalar\String_(sprintf('%s\\Model\\%s', $context->getCurrentSchema()->getNamespace(), $name)),
+                                    new Expr\Variable('format'),
+                                    new Expr\Variable('context'),
+                                ]
+                            )),
+                        ],
+                    ]
+                );
+            }
+        }
+
+        return $statements;
+    }
+}

--- a/src/OpenApi/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/OpenApi/Generator/Normalizer/NormalizerGenerator.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\OpenApi\Generator\Normalizer;
+
+use Jane\JsonSchema\Generator\Normalizer\NormalizerGenerator as JsonSchemaNormalizerGenerator;
+use Jane\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\OpenApi\Guesser\Guess\MultipleClass;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar;
+use Jane\JsonSchema\Generator\Context\Context;
+
+trait NormalizerGenerator
+{
+    use JsonSchemaNormalizerGenerator {
+        normalizeMethodStatements as jsonSchemaNormalizeMethodStatements;
+    }
+
+    protected function normalizeMethodStatements(Expr\Variable $dataVariable, ClassGuess $classGuess, Context $context): array
+    {
+        $statements = $this->jsonSchemaNormalizeMethodStatements($dataVariable, $classGuess, $context);
+
+        if ($classGuess instanceof MultipleClass) {
+            foreach ($classGuess->getReferences() as $name => $reference) {
+                $objectVar = new Expr\Variable('object');
+                $propertyVar = new Expr\MethodCall($objectVar, $this->getNaming()->getPrefixedMethodName('get', $classGuess->getDiscriminator()));
+
+                $statements[] = new Stmt\If_(
+                    new Expr\BinaryOp\LogicalAnd(
+                        new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $propertyVar),
+                        new Expr\BinaryOp\Identical(new Scalar\String_($name), $propertyVar)
+                    ),
+                    [
+                        'stmts' => [
+                            new Stmt\Return_(new Expr\MethodCall(
+                                new Expr\PropertyFetch(
+                                    new Expr\Variable('this'),
+                                    'normalizer'
+                                ),
+                                'normalize',
+                                [
+                                    $objectVar,
+                                    new Expr\Variable('format'),
+                                    new Expr\Variable('context'),
+                                ]
+                            )),
+                        ],
+                    ]
+                );
+            }
+        }
+
+        return $statements;
+    }
+}

--- a/src/OpenApi/Generator/NormalizerGenerator.php
+++ b/src/OpenApi/Generator/NormalizerGenerator.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi\Generator;
+
+use Jane\JsonSchema\Generator\NormalizerGenerator as BaseNormalizerGenerator;
+use Jane\OpenApi\Generator\Normalizer\NormalizerGenerator as NormalizerGeneratorTrait;
+use Jane\OpenApi\Generator\Normalizer\DenormalizerGenerator as DenormalizerGeneratorTrait;
+
+class NormalizerGenerator extends BaseNormalizerGenerator
+{
+    use NormalizerGeneratorTrait;
+    use DenormalizerGeneratorTrait;
+}

--- a/src/OpenApi/Guesser/Guess/ClassGuess.php
+++ b/src/OpenApi/Guesser/Guess/ClassGuess.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jane\OpenApi\Guesser\Guess;
+
+use Jane\JsonSchema\Guesser\Guess\ClassGuess as BaseClassGuess;
+
+class ClassGuess extends BaseClassGuess
+{
+    /** @var MultipleClass */
+    private $multipleClass;
+
+    public function getMultipleClass(): ?MultipleClass
+    {
+        return $this->multipleClass;
+    }
+
+    public function setMultipleClass(?MultipleClass $multipleClass): void
+    {
+        $this->multipleClass = $multipleClass;
+    }
+}

--- a/src/OpenApi/Guesser/Guess/MultipleClass.php
+++ b/src/OpenApi/Guesser/Guess/MultipleClass.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Jane\OpenApi\Guesser\Guess;
+
+use Jane\JsonSchema\Guesser\Guess\ClassGuess;
+
+class MultipleClass extends ClassGuess
+{
+    protected $discriminator;
+
+    protected $references;
+
+    public function __construct(ClassGuess $classGuess, string $discriminator, array $references = [])
+    {
+        parent::__construct($classGuess->getObject(), $classGuess->getReference(), $classGuess->getName(), $classGuess->getExtensionsObject());
+        $this->setProperties($classGuess->getProperties());
+        $this->setExtensionsType($classGuess->getExtensionsType());
+        $this->setConstraints($classGuess->getConstraints());
+
+        $this->discriminator = $discriminator;
+        $this->references = $references;
+    }
+
+    public function setDiscriminator(string $discriminator): self
+    {
+        $this->discriminator = $discriminator;
+
+        return $this;
+    }
+
+    public function getDiscriminator(): string
+    {
+        return $this->discriminator;
+    }
+
+    /**
+     * Add a reference.
+     *
+     * @param string $className
+     * @param string $reference
+     *
+     * @return $this
+     */
+    public function addReference(string $className, string $reference): self
+    {
+        $this->references[$className] = $reference;
+
+        return $this;
+    }
+
+    /**
+     * Return a list of references.
+     *
+     * @return string[]
+     */
+    public function getReferences()
+    {
+        return $this->references;
+    }
+}

--- a/src/OpenApi/Guesser/Guess/MultipleClass.php
+++ b/src/OpenApi/Guesser/Guess/MultipleClass.php
@@ -2,8 +2,6 @@
 
 namespace Jane\OpenApi\Guesser\Guess;
 
-use Jane\JsonSchema\Guesser\Guess\ClassGuess;
-
 class MultipleClass extends ClassGuess
 {
     protected $discriminator;
@@ -13,6 +11,7 @@ class MultipleClass extends ClassGuess
     public function __construct(ClassGuess $classGuess, string $discriminator, array $references = [])
     {
         parent::__construct($classGuess->getObject(), $classGuess->getReference(), $classGuess->getName(), $classGuess->getExtensionsObject());
+        $this->setMultipleClass($classGuess->getMultipleClass());
         $this->setProperties($classGuess->getProperties());
         $this->setExtensionsType($classGuess->getExtensionsType());
         $this->setConstraints($classGuess->getConstraints());

--- a/src/OpenApi/Guesser/OpenApiSchema/AllOfGuesser.php
+++ b/src/OpenApi/Guesser/OpenApiSchema/AllOfGuesser.php
@@ -2,6 +2,8 @@
 
 namespace Jane\OpenApi\Guesser\OpenApiSchema;
 
+use Jane\JsonSchema\Guesser\Guess\ClassGuess as BaseClassGuess;
+use Jane\OpenApi\Guesser\Guess\ClassGuess;
 use Jane\JsonSchema\Guesser\JsonSchema\AllOfGuesser as BaseAllOfGuesser;
 use Jane\OpenApi\Model\Schema;
 
@@ -21,5 +23,13 @@ class AllOfGuesser extends BaseAllOfGuesser
     protected function getSchemaClass()
     {
         return Schema::class;
+    }
+
+    /**
+     * @param Schema $object
+     */
+    protected function createClassGuess($object, $reference, $name, $extensions): BaseClassGuess
+    {
+        return new ClassGuess($object, $reference, $this->naming->getClassName($name), $extensions);
     }
 }

--- a/src/OpenApi/Guesser/OpenApiSchema/SchemaGuesser.php
+++ b/src/OpenApi/Guesser/OpenApiSchema/SchemaGuesser.php
@@ -2,8 +2,9 @@
 
 namespace Jane\OpenApi\Guesser\OpenApiSchema;
 
-use Jane\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\JsonSchema\Guesser\Guess\ClassGuess as BaseClassGuess;
 use Jane\JsonSchema\Guesser\JsonSchema\ObjectGuesser;
+use Jane\OpenApi\Guesser\Guess\ClassGuess;
 use Jane\OpenApi\Guesser\Guess\MultipleClass;
 use Jane\OpenApi\Model\Schema;
 
@@ -20,9 +21,9 @@ class SchemaGuesser extends ObjectGuesser
     /**
      * @param Schema $object
      */
-    protected function createClassGuess($object, $reference, $name, $extensions): ClassGuess
+    protected function createClassGuess($object, $reference, $name, $extensions): BaseClassGuess
     {
-        $classGuess = parent::createClassGuess($object, $reference, $name, $extensions);
+        $classGuess = new ClassGuess($object, $reference, $this->naming->getClassName($name), $extensions);
 
         if (\is_string($object->getDiscriminator()) &&
             \is_array($object->getEnum()) && \count($object->getEnum()) > 0) {

--- a/src/OpenApi/Guesser/OpenApiSchema/SchemaGuesser.php
+++ b/src/OpenApi/Guesser/OpenApiSchema/SchemaGuesser.php
@@ -2,7 +2,9 @@
 
 namespace Jane\OpenApi\Guesser\OpenApiSchema;
 
+use Jane\JsonSchema\Guesser\Guess\ClassGuess;
 use Jane\JsonSchema\Guesser\JsonSchema\ObjectGuesser;
+use Jane\OpenApi\Guesser\Guess\MultipleClass;
 use Jane\OpenApi\Model\Schema;
 
 class SchemaGuesser extends ObjectGuesser
@@ -13,6 +15,26 @@ class SchemaGuesser extends ObjectGuesser
     public function supportObject($object)
     {
         return ($object instanceof Schema) && ('object' === $object->getType() || null === $object->getType()) && null !== $object->getProperties();
+    }
+
+    /**
+     * @param Schema $object
+     */
+    protected function createClassGuess($object, $reference, $name, $extensions): ClassGuess
+    {
+        $classGuess = parent::createClassGuess($object, $reference, $name, $extensions);
+
+        if (\is_string($object->getDiscriminator()) &&
+            \is_array($object->getEnum()) && \count($object->getEnum()) > 0) {
+            $classGuess = new MultipleClass($classGuess, $object->getDiscriminator());
+
+            foreach ($object->getEnum() as $subClassName) {
+                $subReference = preg_replace('#definitions\/.+$#', sprintf('definitions/%s', $subClassName), $reference);
+                $classGuess->addReference($subClassName, $subReference);
+            }
+        }
+
+        return $classGuess;
     }
 
     /**

--- a/src/OpenApi/JaneOpenApi.php
+++ b/src/OpenApi/JaneOpenApi.php
@@ -4,11 +4,13 @@ namespace Jane\OpenApi;
 
 use Jane\JsonSchema\Generator\ChainGenerator;
 use Jane\JsonSchema\Generator\Context\Context;
-use Jane\JsonSchema\Generator\ModelGenerator;
+use Jane\OpenApi\Generator\ModelGenerator;
 use Jane\JsonSchema\Generator\Naming;
 use Jane\OpenApi\Generator\NormalizerGenerator;
 use Jane\JsonSchema\Guesser\ChainGuesser;
 use Jane\OpenApi\Generator\GeneratorFactory;
+use Jane\OpenApi\Guesser\Guess\ClassGuess;
+use Jane\OpenApi\Guesser\Guess\MultipleClass;
 use Jane\OpenApi\Guesser\OpenApiSchema\GuesserFactory;
 use Jane\OpenApi\Normalizer\NormalizerFactory;
 use Jane\OpenApi\SchemaParser\SchemaParser;
@@ -93,9 +95,25 @@ class JaneOpenApi extends ChainGenerator
 
                 $class->setExtensionsType($extensionsTypes);
             }
+
+            $this->hydrateDiscriminatedClasses($schema, $registry);
         }
 
         return new Context($registry, $this->strict);
+    }
+
+    protected function hydrateDiscriminatedClasses(Schema $schema, Registry $registry)
+    {
+        foreach ($schema->getClasses() as $class) {
+            if ($class instanceof MultipleClass) { // is parent class
+                foreach ($class->getReferences() as $reference) {
+                    $guess = $registry->getClass($reference);
+                    if ($guess instanceof ClassGuess) { // is child class
+                        $guess->setMultipleClass($class);
+                    }
+                }
+            }
+        }
     }
 
     public static function build(array $options = [])

--- a/src/OpenApi/JaneOpenApi.php
+++ b/src/OpenApi/JaneOpenApi.php
@@ -6,7 +6,7 @@ use Jane\JsonSchema\Generator\ChainGenerator;
 use Jane\JsonSchema\Generator\Context\Context;
 use Jane\JsonSchema\Generator\ModelGenerator;
 use Jane\JsonSchema\Generator\Naming;
-use Jane\JsonSchema\Generator\NormalizerGenerator;
+use Jane\OpenApi\Generator\NormalizerGenerator;
 use Jane\JsonSchema\Guesser\ChainGuesser;
 use Jane\OpenApi\Generator\GeneratorFactory;
 use Jane\OpenApi\Guesser\OpenApiSchema\GuesserFactory;

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/BarNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/BarNormalizer.php
@@ -20,7 +20,7 @@ class BarNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Bar;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Bar';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FooNormalizer.php
@@ -20,7 +20,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Foo;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Foo';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FuzNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FuzNormalizer.php
@@ -20,7 +20,7 @@ class FuzNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Fuz;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Fuz';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/array-definition/expected/Normalizer/BarItemNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/array-definition/expected/Normalizer/BarItemNormalizer.php
@@ -20,7 +20,7 @@ class BarItemNormalizer implements DenormalizerInterface, NormalizerInterface, D
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\BarItem;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\BarItem';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Normalizer/ErrorNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Normalizer/ErrorNormalizer.php
@@ -20,7 +20,7 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Error;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Normalizer/SchemaNormalizer.php
@@ -20,7 +20,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Schema;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Schema';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -20,7 +20,7 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\SchemaObjectProperty;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\SchemaObjectProperty';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Normalizer/TestIdGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Normalizer/TestIdGetResponse200Normalizer.php
@@ -20,7 +20,7 @@ class TestIdGetResponse200Normalizer implements DenormalizerInterface, Normalize
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\TestIdGetResponse200;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\TestIdGetResponse200';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
@@ -20,7 +20,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Schema;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Schema';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -20,7 +20,7 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\SchemaObjectProperty;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\SchemaObjectProperty';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
@@ -20,7 +20,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Schema;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Schema';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -20,7 +20,7 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\SchemaObjectProperty;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\SchemaObjectProperty';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/discriminator/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/discriminator/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Client.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Cat.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Cat.php
@@ -2,7 +2,7 @@
 
 namespace Jane\OpenApi\Tests\Expected\Model;
 
-class Cat
+class Cat extends Pet
 {
     /**
      * 

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Cat.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Cat.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Cat
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $petType;
+    /**
+     * The measured skill for hunting
+     *
+     * @var string
+     */
+    protected $huntingSkill = 'lazy';
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getName() : ?string
+    {
+        return $this->name;
+    }
+    /**
+     * 
+     *
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(?string $name) : self
+    {
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getPetType() : ?string
+    {
+        return $this->petType;
+    }
+    /**
+     * 
+     *
+     * @param string $petType
+     *
+     * @return self
+     */
+    public function setPetType(?string $petType) : self
+    {
+        $this->petType = $petType;
+        return $this;
+    }
+    /**
+     * The measured skill for hunting
+     *
+     * @return string
+     */
+    public function getHuntingSkill() : ?string
+    {
+        return $this->huntingSkill;
+    }
+    /**
+     * The measured skill for hunting
+     *
+     * @param string $huntingSkill
+     *
+     * @return self
+     */
+    public function setHuntingSkill(?string $huntingSkill) : self
+    {
+        $this->huntingSkill = $huntingSkill;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Dog.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Dog.php
@@ -2,7 +2,7 @@
 
 namespace Jane\OpenApi\Tests\Expected\Model;
 
-class Dog
+class Dog extends Pet
 {
     /**
      * 

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Dog.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Dog.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Dog
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $petType;
+    /**
+     * the size of the pack the dog is from
+     *
+     * @var int
+     */
+    protected $packSize = 0;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getName() : ?string
+    {
+        return $this->name;
+    }
+    /**
+     * 
+     *
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(?string $name) : self
+    {
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getPetType() : ?string
+    {
+        return $this->petType;
+    }
+    /**
+     * 
+     *
+     * @param string $petType
+     *
+     * @return self
+     */
+    public function setPetType(?string $petType) : self
+    {
+        $this->petType = $petType;
+        return $this;
+    }
+    /**
+     * the size of the pack the dog is from
+     *
+     * @return int
+     */
+    public function getPackSize() : ?int
+    {
+        return $this->packSize;
+    }
+    /**
+     * the size of the pack the dog is from
+     *
+     * @param int $packSize
+     *
+     * @return self
+     */
+    public function setPackSize(?int $packSize) : self
+    {
+        $this->packSize = $packSize;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Pet.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Pet.php
@@ -29,13 +29,10 @@ class Pet
      * 
      *
      * @param string $name
-     *
-     * @return self
      */
-    public function setName(?string $name) : self
+    public function setName(?string $name)
     {
         $this->name = $name;
-        return $this;
     }
     /**
      * 
@@ -50,12 +47,9 @@ class Pet
      * 
      *
      * @param string $petType
-     *
-     * @return self
      */
-    public function setPetType(?string $petType) : self
+    public function setPetType(?string $petType)
     {
         $this->petType = $petType;
-        return $this;
     }
 }

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Pet.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Model/Pet.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Pet
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $petType;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getName() : ?string
+    {
+        return $this->name;
+    }
+    /**
+     * 
+     *
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(?string $name) : self
+    {
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getPetType() : ?string
+    {
+        return $this->petType;
+    }
+    /**
+     * 
+     *
+     * @param string $petType
+     *
+     * @return self
+     */
+    public function setPetType(?string $petType) : self
+    {
+        $this->petType = $petType;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/CatNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/CatNormalizer.php
@@ -20,7 +20,7 @@ class CatNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Cat;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Cat';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/CatNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/CatNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class CatNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Cat';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Cat;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Cat();
+        if (property_exists($data, 'name')) {
+            $object->setName($data->{'name'});
+        }
+        if (property_exists($data, 'petType')) {
+            $object->setPetType($data->{'petType'});
+        }
+        if (property_exists($data, 'huntingSkill')) {
+            $object->setHuntingSkill($data->{'huntingSkill'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
+        if (null !== $object->getHuntingSkill()) {
+            $data->{'huntingSkill'} = $object->getHuntingSkill();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/DogNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/DogNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class DogNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Dog';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Dog;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Dog();
+        if (property_exists($data, 'name')) {
+            $object->setName($data->{'name'});
+        }
+        if (property_exists($data, 'petType')) {
+            $object->setPetType($data->{'petType'});
+        }
+        if (property_exists($data, 'packSize')) {
+            $object->setPackSize($data->{'packSize'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
+        if (null !== $object->getPackSize()) {
+            $data->{'packSize'} = $object->getPackSize();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/DogNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/DogNormalizer.php
@@ -20,7 +20,7 @@ class DogNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Dog;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Dog';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new PetNormalizer();
+        $normalizers[] = new CatNormalizer();
+        $normalizers[] = new DogNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/PetNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/PetNormalizer.php
@@ -20,7 +20,7 @@ class PetNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Pet;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Pet';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/PetNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/PetNormalizer.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class PetNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Pet';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Pet;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        if (property_exists($data, 'petType') and 'Cat' === $data->{'petType'}) {
+            return $this->denormalizer->denormalize($data, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Cat', $format, $context);
+        }
+        if (property_exists($data, 'petType') and 'Dog' === $data->{'petType'}) {
+            return $this->denormalizer->denormalize($data, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Dog', $format, $context);
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Pet();
+        if (property_exists($data, 'name')) {
+            $object->setName($data->{'name'});
+        }
+        if (property_exists($data, 'petType')) {
+            $object->setPetType($data->{'petType'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getPetType() and 'Cat' === $object->getPetType()) {
+            return $this->normalizer->normalize($object, $format, $context);
+        }
+        if (null !== $object->getPetType() and 'Dog' === $object->getPetType()) {
+            return $this->normalizer->normalize($object, $format, $context);
+        }
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator/swagger.json
+++ b/src/OpenApi/Tests/fixtures/discriminator/swagger.json
@@ -1,0 +1,77 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Pets",
+        "version": "1.0.0"
+    },
+    "paths": {},
+    "definitions": {
+        "Pet": {
+            "type": "object",
+            "discriminator": "petType",
+            "enum": ["Cat", "Dog"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "petType": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "petType"
+            ]
+        },
+        "Cat": {
+            "description": "A representation of a cat",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Pet"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "huntingSkill": {
+                            "type": "string",
+                            "description": "The measured skill for hunting",
+                            "default": "lazy",
+                            "enum": [
+                                "clueless",
+                                "lazy",
+                                "adventurous",
+                                "aggressive"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "huntingSkill"
+                    ]
+                }
+            ]
+        },
+        "Dog": {
+            "description": "A representation of a dog",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Pet"
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "packSize": {
+                            "type": "integer",
+                            "format": "int32",
+                            "description": "the size of the pack the dog is from",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    "required": [
+                        "packSize"
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Normalizer/TestOneGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Normalizer/TestOneGetResponse200Normalizer.php
@@ -20,7 +20,7 @@ class TestOneGetResponse200Normalizer implements DenormalizerInterface, Normaliz
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\One\Model\TestOneGetResponse200;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\One\\Model\\TestOneGetResponse200';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Normalizer/TestTwoGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Normalizer/TestTwoGetResponse200Normalizer.php
@@ -20,7 +20,7 @@ class TestTwoGetResponse200Normalizer implements DenormalizerInterface, Normaliz
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Two\Model\TestTwoGetResponse200;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Two\\Model\\TestTwoGetResponse200';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Normalizer/ErrorNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Normalizer/ErrorNormalizer.php
@@ -20,7 +20,7 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Error;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/ErrorNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/ErrorNormalizer.php
@@ -20,7 +20,7 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Error;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/PetNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/PetNormalizer.php
@@ -20,7 +20,7 @@ class PetNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Pet;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Pet';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/EmptySpaceNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/EmptySpaceNormalizer.php
@@ -20,7 +20,7 @@ class EmptySpaceNormalizer implements DenormalizerInterface, NormalizerInterface
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\EmptySpace;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\EmptySpace';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/ErrorNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/ErrorNormalizer.php
@@ -20,7 +20,7 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Error;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
@@ -20,7 +20,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Schema;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Schema';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -20,7 +20,7 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\SchemaObjectProperty;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\SchemaObjectProperty';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/TestIdGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/TestIdGetResponse200Normalizer.php
@@ -20,7 +20,7 @@ class TestIdGetResponse200Normalizer implements DenormalizerInterface, Normalize
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\TestIdGetResponse200;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\TestIdGetResponse200';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Normalizer/BodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Normalizer/BodyNormalizer.php
@@ -20,7 +20,7 @@ class BodyNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Api1\Model\Body;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Api1\\Model\\Body';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/BarNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/BarNormalizer.php
@@ -20,7 +20,7 @@ class BarNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Bar;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Bar';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/FooNormalizer.php
@@ -20,7 +20,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Foo;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Foo';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyBazNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyBazNormalizer.php
@@ -20,7 +20,7 @@ class TestGetBodyBazNormalizer implements DenormalizerInterface, NormalizerInter
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\TestGetBodyBaz;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\TestGetBodyBaz';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyNormalizer.php
@@ -20,7 +20,7 @@ class TestGetBodyNormalizer implements DenormalizerInterface, NormalizerInterfac
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\TestGetBody;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\TestGetBody';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestPostBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestPostBodyNormalizer.php
@@ -20,7 +20,7 @@ class TestPostBodyNormalizer implements DenormalizerInterface, NormalizerInterfa
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\TestPostBody;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\TestPostBody';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/no-reference-response/expected/Normalizer/TestPostResponse201Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-response/expected/Normalizer/TestPostResponse201Normalizer.php
@@ -20,7 +20,7 @@ class TestPostResponse201Normalizer implements DenormalizerInterface, Normalizer
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\TestPostResponse201;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\TestPostResponse201';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/operations/expected/Normalizer/ThingNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Normalizer/ThingNormalizer.php
@@ -20,7 +20,7 @@ class ThingNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Thing;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Thing';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/response-reference/expected/Normalizer/ResponseCommonNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/response-reference/expected/Normalizer/ResponseCommonNormalizer.php
@@ -20,7 +20,7 @@ class ResponseCommonNormalizer implements DenormalizerInterface, NormalizerInter
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\ResponseCommon;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\ResponseCommon';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {

--- a/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
@@ -31,7 +31,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
 
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\Schema;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Schema';
     }
 
     public function denormalize($data, $class, $format = null, array $context = [])

--- a/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -31,7 +31,7 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
 
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\OpenApi\Tests\Expected\Model\SchemaObjectProperty;
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\SchemaObjectProperty';
     }
 
     public function denormalize($data, $class, $format = null, array $context = [])


### PR DESCRIPTION
Adding discriminator support for OpenApi

Discriminator added, following https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema-object definition. 

I made a little change: to avoid "magic". Classes that are available with discriminator are listed in enum field as following:
```json
{
    "swagger": "2.0",
    "info": {
        "title": "Pets",
        "version": "1.0.0"
    },
    "paths": {},
    "definitions": {
        "Pet": {
            "type": "object",
            "discriminator": "petType",
            "enum": ["Cat", "Dog"],
            "properties": {
                "name": {
                    "type": "string"
                },
                "petType": {
                    "type": "string"
                }
            },
            "required": [
                "name",
                "petType"
            ]
        },
        "Cat": {
            "description": "A representation of a cat",
            "allOf": [
                {
                    "$ref": "#/definitions/Pet"
                },
                {
                    "type": "object",
                    "properties": {
                        "huntingSkill": {
                            "type": "string",
                            "description": "The measured skill for hunting",
                            "default": "lazy",
                            "enum": [
                                "clueless",
                                "lazy",
                                "adventurous",
                                "aggressive"
                            ]
                        }
                    },
                    "required": [
                        "huntingSkill"
                    ]
                }
            ]
        },
        "Dog": {
            "description": "A representation of a dog",
            "allOf": [
                {
                    "$ref": "#/definitions/Pet"
                },
                {
                    "type": "object",
                    "properties": {
                        "packSize": {
                            "type": "integer",
                            "format": "int32",
                            "description": "the size of the pack the dog is from",
                            "default": 0,
                            "minimum": 0
                        }
                    },
                    "required": [
                        "packSize"
                    ]
                }
            ]
        }
    }
}

```

# Todo

- [x] Child models should extends parent model