### PR TITLE
Add php parser 4.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=7.1",
         "doctrine/inflector": "^1.0",
         "league/uri": "^4.2 || ^5.3",
-        "nikic/php-parser": "^3.0",
+        "nikic/php-parser": "^3.0 || ^4.0",
         "php-http/client-common": "^1.4 || ^2.0",
         "php-http/httplug": "^1.0 || ^2.0",
         "php-http/message-factory": "^1.0.2",
@@ -56,6 +56,9 @@
         "psr-4": {
             "Jane\\": "src/"
         },
+        "files": [
+            "helpers.php"
+        ],
         "exclude-from-classmap": [
             "**/Tests/"
         ]

--- a/helpers.php
+++ b/helpers.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Jane;
+
+use PhpParser\Node;
+
+function parserExpression(Node\Expr $expr): Node
+{
+    if (isPhpParser4()) {
+        return new Node\Stmt\Expression($expr);
+    }
+
+    return $expr;
+}
+
+function parserVariable(string $name)
+{
+    if (isPhpParser4()) {
+        return new Node\Expr\Variable($name);
+    }
+
+    return $name;
+}
+
+function isPhpParser4(): bool
+{
+    return class_exists('PhpParser\\Node\\Stmt\\Expression');
+}

--- a/src/AutoMapper/Compiler/Accessor/ReadAccessor.php
+++ b/src/AutoMapper/Compiler/Accessor/ReadAccessor.php
@@ -2,12 +2,13 @@
 
 namespace Jane\AutoMapper\Compiler\Accessor;
 
+use function Jane\parserVariable;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
 use PhpParser\Node\Scalar;
-use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt;
 
 class ReadAccessor
 {
@@ -68,10 +69,10 @@ class ReadAccessor
         return new Expr\StaticCall(new Name\FullyQualified(\Closure::class), 'bind', [
             new Arg(new Expr\Closure([
                 'params' => [
-                    new Param('object'),
+                    new Param(parserVariable('object')),
                 ],
                 'stmts' => [
-                    new Return_(new Expr\PropertyFetch(new Expr\Variable('object'), $this->name)),
+                    new Stmt\Return_(new Expr\PropertyFetch(new Expr\Variable('object'), $this->name)),
                 ],
             ])),
             new Arg(new Expr\ConstFetch(new Name('null'))),

--- a/src/AutoMapper/Compiler/Accessor/WriteMutator.php
+++ b/src/AutoMapper/Compiler/Accessor/WriteMutator.php
@@ -2,6 +2,8 @@
 
 namespace Jane\AutoMapper\Compiler\Accessor;
 
+use function Jane\parserExpression;
+use function Jane\parserVariable;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
@@ -73,11 +75,11 @@ class WriteMutator
         return new Expr\StaticCall(new Name\FullyQualified(\Closure::class), 'bind', [
             new Arg(new Expr\Closure([
                 'params' => [
-                    new Param('object'),
-                    new Param('value'),
+                    new Param(parserVariable('object')),
+                    new Param(parserVariable('value')),
                 ],
                 'stmts' => [
-                    new Expr\Assign(new Expr\PropertyFetch(new Expr\Variable('object'), $this->name), new Expr\Variable('value')),
+                    parserExpression(new Expr\Assign(new Expr\PropertyFetch(new Expr\Variable('object'), $this->name), new Expr\Variable('value'))),
                 ],
             ])),
             new Arg(new Expr\ConstFetch(new Name('null'))),

--- a/src/AutoMapper/Compiler/Transformer/ArrayTransformer.php
+++ b/src/AutoMapper/Compiler/Transformer/ArrayTransformer.php
@@ -3,6 +3,7 @@
 namespace Jane\AutoMapper\Compiler\Transformer;
 
 use Jane\AutoMapper\Compiler\UniqueVariableScope;
+use function Jane\parserExpression;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 
@@ -20,7 +21,7 @@ class ArrayTransformer implements TransformerInterface
         $valuesVar = new Expr\Variable($uniqueVariableScope->getUniqueName('values'));
         $statements = [
             // $values = [];
-            new Expr\Assign($valuesVar, new Expr\Array_()),
+            parserExpression(new Expr\Assign($valuesVar, new Expr\Array_())),
         ];
 
         $loopValueVar = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
@@ -28,7 +29,7 @@ class ArrayTransformer implements TransformerInterface
         [$output, $itemStatements] = $this->itemTransformer->transform($loopValueVar, $uniqueVariableScope);
 
         $loopStatements = array_merge($itemStatements, [
-            new Expr\Assign(new Expr\ArrayDimFetch($valuesVar), $output),
+            parserExpression(new Expr\Assign(new Expr\ArrayDimFetch($valuesVar), $output)),
         ]);
 
         $statements[] = new Stmt\Foreach_($input, $loopValueVar, [

--- a/src/AutoMapper/Compiler/Transformer/MultipleTransformer.php
+++ b/src/AutoMapper/Compiler/Transformer/MultipleTransformer.php
@@ -3,6 +3,7 @@
 namespace Jane\AutoMapper\Compiler\Transformer;
 
 use Jane\AutoMapper\Compiler\UniqueVariableScope;
+use function Jane\parserExpression;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
@@ -38,7 +39,7 @@ class MultipleTransformer implements TransformerInterface
     {
         $output = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
         $statements = [
-            new Expr\Assign($output, $input),
+            parserExpression(new Expr\Assign($output, $input)),
         ];
 
         foreach ($this->transformers as $transformerData) {
@@ -57,7 +58,7 @@ class MultipleTransformer implements TransformerInterface
                 [
                     'stmts' => array_merge(
                         $transformerStatements, [
-                            new Expr\Assign($output, $transformerOutput),
+                            parserExpression(new Expr\Assign($output, $transformerOutput)),
                         ]
                     ),
                 ]

--- a/src/AutoMapper/composer.json
+++ b/src/AutoMapper/composer.json
@@ -11,12 +11,13 @@
     "autoload": {
         "psr-4": {
             "Jane\\AutoMapper\\": ""
-        }
+        },
+        "files": ["helpers.php"]
     },
     "require": {
         "php": ">=7.1",
         "doctrine/inflector": "^1.3",
-        "nikic/php-parser": "^3.0",
+        "nikic/php-parser": "^3.0 || ^4.0",
         "symfony/options-resolver": "^3.1|^4.0",
         "symfony/property-info": "^3.4|^4.0"
     },

--- a/src/AutoMapper/helpers.php
+++ b/src/AutoMapper/helpers.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Jane;
+
+use PhpParser\Node;
+
+function parserExpression(Node\Expr $expr): Node
+{
+    if (isPhpParser4()) {
+        return new Node\Stmt\Expression($expr);
+    }
+
+    return $expr;
+}
+
+function parserVariable(string $name)
+{
+    if (isPhpParser4()) {
+        return new Node\Expr\Variable($name);
+    }
+
+    return $name;
+}
+
+function isPhpParser4(): bool
+{
+    return class_exists('PhpParser\\Node\\Stmt\\Expression');
+}

--- a/src/JsonSchema/Generator/Model/GetterSetterGenerator.php
+++ b/src/JsonSchema/Generator/Model/GetterSetterGenerator.php
@@ -4,6 +4,8 @@ namespace Jane\JsonSchema\Generator\Model;
 
 use Jane\JsonSchema\Generator\Naming;
 use Jane\JsonSchema\Guesser\Guess\Property;
+use function Jane\parserExpression;
+use function Jane\parserVariable;
 use PhpParser\Comment\Doc;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt;
@@ -61,16 +63,16 @@ trait GetterSetterGenerator
                 'type' => Stmt\Class_::MODIFIER_PUBLIC,
                 // ($property)
                 'params' => [
-                    new Param($this->getNaming()->getPropertyName($property->getPhpName()), null, $setType),
+                    new Param(parserVariable($this->getNaming()->getPropertyName($property->getPhpName())), null, $setType),
                 ],
                 'stmts' => [
                     // $this->property = $property;
-                    new Expr\Assign(
+                    parserExpression(new Expr\Assign(
                         new Expr\PropertyFetch(
                             new Expr\Variable('this'),
                             $this->getNaming()->getPropertyName($property->getPhpName())
                         ), new Expr\Variable($this->getNaming()->getPropertyName($property->getPhpName()))
-                    ),
+                    )),
                     // return $this;
                     new Stmt\Return_(new Expr\Variable('this')),
                 ],

--- a/src/JsonSchema/Generator/Model/PropertyGenerator.php
+++ b/src/JsonSchema/Generator/Model/PropertyGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Jane\JsonSchema\Generator\Model;
 
+use function Jane\isPhpParser4;
 use Jane\JsonSchema\Generator\Naming;
 use Jane\JsonSchema\Guesser\Guess\Property;
 use PhpParser\Comment\Doc;
@@ -58,6 +59,13 @@ EOD
 
     private function getDefaultAsExpr($value)
     {
-        return $this->parser->parse('<?php ' . var_export($value, true) . ';')[0];
+        $expr = $this->parser->parse('<?php ' . var_export($value, true) . ';')[0];
+
+        if (isPhpParser4() &&
+            $expr instanceof Stmt\Expression) {
+            return $expr->expr;
+        }
+
+        return $expr;
     }
 }

--- a/src/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/NormalizerGenerator.php
@@ -6,6 +6,7 @@ use Jane\JsonSchema\Generator\Context\Context;
 use Jane\JsonSchema\Generator\Normalizer\DenormalizerGenerator;
 use Jane\JsonSchema\Generator\Normalizer\NormalizerGenerator as NormalizerGeneratorTrait;
 use Jane\JsonSchema\Schema;
+use function Jane\parserExpression;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
@@ -121,16 +122,16 @@ class NormalizerGenerator implements GeneratorInterface
     protected function createNormalizerFactoryClass($classes)
     {
         $statements = [
-            new Expr\Assign(new Expr\Variable('normalizers'), new Expr\Array_()),
-            new Expr\Assign(new Expr\ArrayDimFetch(new Expr\Variable('normalizers')), new Expr\New_(new Name('\Symfony\Component\Serializer\Normalizer\ArrayDenormalizer'))),
+            parserExpression(new Expr\Assign(new Expr\Variable('normalizers'), new Expr\Array_())),
+            parserExpression(new Expr\Assign(new Expr\ArrayDimFetch(new Expr\Variable('normalizers')), new Expr\New_(new Name('\Symfony\Component\Serializer\Normalizer\ArrayDenormalizer')))),
         ];
 
         if ($this->useReference) {
-            $statements[] = new Expr\Assign(new Expr\ArrayDimFetch(new Expr\Variable('normalizers')), new Expr\New_(new Name('\Jane\JsonSchemaRuntime\Normalizer\ReferenceNormalizer')));
+            $statements[] = parserExpression(new Expr\Assign(new Expr\ArrayDimFetch(new Expr\Variable('normalizers')), new Expr\New_(new Name('\Jane\JsonSchemaRuntime\Normalizer\ReferenceNormalizer'))));
         }
 
         foreach ($classes as $class) {
-            $statements[] = new Expr\Assign(new Expr\ArrayDimFetch(new Expr\Variable('normalizers')), new Expr\New_($class));
+            $statements[] = parserExpression(new Expr\Assign(new Expr\ArrayDimFetch(new Expr\Variable('normalizers')), new Expr\New_($class)));
         }
 
         $statements[] = new Stmt\Return_(new Expr\Variable('normalizers'));

--- a/src/JsonSchema/Guesser/Guess/ArrayType.php
+++ b/src/JsonSchema/Guesser/Guess/ArrayType.php
@@ -3,6 +3,7 @@
 namespace Jane\JsonSchema\Guesser\Guess;
 
 use Jane\JsonSchema\Generator\Context\Context;
+use function Jane\parserExpression;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Expr;
 
@@ -43,7 +44,7 @@ class ArrayType extends Type
         $valuesVar = new Expr\Variable($context->getUniqueVariableName('values'));
         $statements = [
             // $values = [];
-            new Expr\Assign($valuesVar, $this->createArrayValueStatement()),
+            parserExpression(new Expr\Assign($valuesVar, $this->createArrayValueStatement())),
         ];
 
         $loopValueVar = new Expr\Variable($context->getUniqueVariableName('value'));
@@ -52,7 +53,7 @@ class ArrayType extends Type
         list($subStatements, $outputExpr) = $this->itemType->createDenormalizationStatement($context, $loopValueVar);
 
         $loopStatements = array_merge($subStatements, [
-            new Expr\Assign($this->createLoopOutputAssignement($valuesVar, $loopKeyVar), $outputExpr),
+            parserExpression(new Expr\Assign($this->createLoopOutputAssignement($valuesVar, $loopKeyVar), $outputExpr)),
         ]);
 
         $statements[] = new Stmt\Foreach_($input, $loopValueVar, [
@@ -71,7 +72,7 @@ class ArrayType extends Type
         $valuesVar = new Expr\Variable($context->getUniqueVariableName('values'));
         $statements = [
             // $values = [];
-            new Expr\Assign($valuesVar, $this->createNormalizationArrayValueStatement()),
+            parserExpression(new Expr\Assign($valuesVar, $this->createNormalizationArrayValueStatement())),
         ];
 
         $loopValueVar = new Expr\Variable($context->getUniqueVariableName('value'));
@@ -80,7 +81,7 @@ class ArrayType extends Type
         list($subStatements, $outputExpr) = $this->itemType->createNormalizationStatement($context, $loopValueVar);
 
         $loopStatements = array_merge($subStatements, [
-            new Expr\Assign($this->createNormalizationLoopOutputAssignement($valuesVar, $loopKeyVar), $outputExpr),
+            parserExpression(new Expr\Assign($this->createNormalizationLoopOutputAssignement($valuesVar, $loopKeyVar), $outputExpr)),
         ]);
 
         $statements[] = new Stmt\Foreach_($input, $loopValueVar, [

--- a/src/JsonSchema/Guesser/Guess/MultipleType.php
+++ b/src/JsonSchema/Guesser/Guess/MultipleType.php
@@ -3,6 +3,7 @@
 namespace Jane\JsonSchema\Guesser\Guess;
 
 use Jane\JsonSchema\Generator\Context\Context;
+use function Jane\parserExpression;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Expr;
 
@@ -111,7 +112,7 @@ class MultipleType extends Type
     {
         $output = new Expr\Variable($context->getUniqueVariableName('value'));
         $statements = [
-            new Expr\Assign($output, $input),
+            parserExpression(new Expr\Assign($output, $input)),
         ];
 
         /** @var Stmt\If_|null $ifStmt */
@@ -120,7 +121,7 @@ class MultipleType extends Type
             list($typeStatements, $typeOutput) = $type->createDenormalizationStatement($context, $input);
 
             $condition = $type->createConditionStatement($input);
-            $statement = array_merge($typeStatements, [new Expr\Assign($output, $typeOutput)]);
+            $statement = array_merge($typeStatements, [parserExpression(new Expr\Assign($output, $typeOutput))]);
 
             if ($ifStmt === null) {
                 $ifStmt = new Stmt\If_($condition, ['stmts' => $statement]);
@@ -140,7 +141,7 @@ class MultipleType extends Type
     {
         $output = new Expr\Variable($context->getUniqueVariableName('value'));
         $statements = [
-            new Expr\Assign($output, $input),
+            parserExpression(new Expr\Assign($output, $input)),
         ];
 
         /** @var Stmt\If_|null $ifStmt */
@@ -149,7 +150,7 @@ class MultipleType extends Type
             list($typeStatements, $typeOutput) = $type->createNormalizationStatement($context, $input);
 
             $condition = $type->createNormalizationConditionStatement($input);
-            $statement = array_merge($typeStatements, [new Expr\Assign($output, $typeOutput)]);
+            $statement = array_merge($typeStatements, [parserExpression(new Expr\Assign($output, $typeOutput))]);
 
             if ($ifStmt === null) {
                 $ifStmt = new Stmt\If_($condition, ['stmts' => $statement]);

--- a/src/JsonSchema/Guesser/Guess/PatternMultipleType.php
+++ b/src/JsonSchema/Guesser/Guess/PatternMultipleType.php
@@ -3,6 +3,7 @@
 namespace Jane\JsonSchema\Guesser\Guess;
 
 use Jane\JsonSchema\Generator\Context\Context;
+use function Jane\parserExpression;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
@@ -54,7 +55,7 @@ class PatternMultipleType extends Type
         $valuesVar = new Expr\Variable($context->getUniqueVariableName('values'));
         $statements = [
             // $values = [];
-            new Expr\Assign($valuesVar, $this->createArrayValueStatement()),
+            parserExpression(new Expr\Assign($valuesVar, $this->createArrayValueStatement())),
         ];
 
         $loopValueVar = new Expr\Variable($context->getUniqueVariableName('value'));
@@ -74,7 +75,7 @@ class PatternMultipleType extends Type
                     ),
                     [
                         'stmts' => array_merge($typeStatements, [
-                            new Expr\Assign(new Expr\ArrayDimFetch($valuesVar, $loopKeyVar), $typeOutput),
+                            parserExpression(new Expr\Assign(new Expr\ArrayDimFetch($valuesVar, $loopKeyVar), $typeOutput)),
                             new Stmt\Continue_(),
                         ]),
                     ]
@@ -98,7 +99,7 @@ class PatternMultipleType extends Type
         $valuesVar = new Expr\Variable($context->getUniqueVariableName('values'));
         $statements = [
             // $values = [];
-            new Expr\Assign($valuesVar, $this->createNormalizationArrayValueStatement()),
+            parserExpression(new Expr\Assign($valuesVar, $this->createNormalizationArrayValueStatement())),
         ];
 
         $loopValueVar = new Expr\Variable($context->getUniqueVariableName('value'));
@@ -118,7 +119,7 @@ class PatternMultipleType extends Type
                     ),
                     [
                         'stmts' => array_merge($typeStatements, [
-                            new Expr\Assign(new Expr\PropertyFetch($valuesVar, $loopKeyVar), $typeOutput),
+                            parserExpression(new Expr\Assign(new Expr\PropertyFetch($valuesVar, $loopKeyVar), $typeOutput)),
                             new Stmt\Continue_(),
                         ]),
                     ]

--- a/src/JsonSchema/Tests/JaneBaseTest.php
+++ b/src/JsonSchema/Tests/JaneBaseTest.php
@@ -2,6 +2,7 @@
 
 namespace Jane\JsonSchema\tests;
 
+use function Jane\isPhpParser4;
 use Jane\JsonSchema\Command\GenerateCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -54,7 +55,7 @@ class JaneBaseTest extends TestCase
                 sprintf('File %s does not exist for %s', $expectedFile->getRelativePathname(), $testDirectory->getRelativePathname())
             );
 
-            if ($expectedFile->isFile()) {
+            if ($expectedFile->isFile() && !isPhpParser4()) {
                 $this->assertEquals(
                     file_get_contents($expectedFile->getRealPath()),
                     file_get_contents($generatedData[$expectedFile->getRelativePathname()]),

--- a/src/JsonSchema/Tests/LibraryTest.php
+++ b/src/JsonSchema/Tests/LibraryTest.php
@@ -2,6 +2,7 @@
 
 namespace Jane\JsonSchema\Tests;
 
+use function Jane\isPhpParser4;
 use Jane\JsonSchema\Jane;
 use Jane\JsonSchema\Printer;
 use Jane\JsonSchema\Registry;
@@ -42,20 +43,22 @@ class LibraryTest extends TestCase
         $this->assertFileExists(__DIR__ . '/generated/Normalizer/JsonSchemaNormalizer.php');
         $this->assertFileExists(__DIR__ . '/generated/Normalizer/NormalizerFactory.php');
 
-        $this->assertEquals(
-            file_get_contents(__DIR__ . '/../Model/JsonSchema.php'),
-            file_get_contents(__DIR__ . '/generated/Model/JsonSchema.php')
-        );
+        if (!isPhpParser4()) {
+            $this->assertEquals(
+                file_get_contents(__DIR__ . '/../Model/JsonSchema.php'),
+                file_get_contents(__DIR__ . '/generated/Model/JsonSchema.php')
+            );
 
-        $this->assertEquals(
-            file_get_contents(__DIR__ . '/../Normalizer/JsonSchemaNormalizer.php'),
-            file_get_contents(__DIR__ . '/generated/Normalizer/JsonSchemaNormalizer.php')
-        );
+            $this->assertEquals(
+                file_get_contents(__DIR__ . '/../Normalizer/JsonSchemaNormalizer.php'),
+                file_get_contents(__DIR__ . '/generated/Normalizer/JsonSchemaNormalizer.php')
+            );
 
-        $this->assertEquals(
-            file_get_contents(__DIR__ . '/../Normalizer/NormalizerFactory.php'),
-            file_get_contents(__DIR__ . '/generated/Normalizer/NormalizerFactory.php')
-        );
+            $this->assertEquals(
+                file_get_contents(__DIR__ . '/../Normalizer/NormalizerFactory.php'),
+                file_get_contents(__DIR__ . '/generated/Normalizer/NormalizerFactory.php')
+            );
+        }
     }
 
     public function testBothWay()

--- a/src/JsonSchema/composer.json
+++ b/src/JsonSchema/composer.json
@@ -11,7 +11,8 @@
     "autoload": {
         "psr-4": {
             "Jane\\JsonSchema\\": ""
-        }
+        },
+        "files": ["helpers.php"]
     },
     "bin": [
         "bin/jane"
@@ -20,7 +21,7 @@
         "php": ">=7.1",
         "doctrine/inflector": "^1.0",
         "jane-php/json-schema-runtime": "^4.0",
-        "nikic/php-parser": "^3.0",
+        "nikic/php-parser": "^3.0 || ^4.0",
         "symfony/console": "^3.1|^4.0",
         "symfony/options-resolver": "^3.1|^4.0",
         "symfony/property-access": "^3.1|^4.0",

--- a/src/JsonSchema/helpers.php
+++ b/src/JsonSchema/helpers.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Jane;
+
+use PhpParser\Node;
+
+function parserExpression(Node\Expr $expr): Node
+{
+    if (isPhpParser4()) {
+        return new Node\Stmt\Expression($expr);
+    }
+
+    return $expr;
+}
+
+function parserVariable(string $name)
+{
+    if (isPhpParser4()) {
+        return new Node\Expr\Variable($name);
+    }
+
+    return $name;
+}
+
+function isPhpParser4(): bool
+{
+    return class_exists('PhpParser\\Node\\Stmt\\Expression');
+}

--- a/src/OpenApi/Generator/AmpArtaxClientGenerator.php
+++ b/src/OpenApi/Generator/AmpArtaxClientGenerator.php
@@ -5,6 +5,8 @@ namespace Jane\OpenApi\Generator;
 use Amp\Artax\DefaultClient;
 use Jane\JsonSchema\Generator\Context\Context;
 use Jane\OpenApiRuntime\Client\AmpArtaxClient;
+use function Jane\parserExpression;
+use function Jane\parserVariable;
 use PhpParser\Node;
 use PhpParser\Node\Name;
 use PhpParser\Node\Expr;
@@ -32,23 +34,23 @@ class AmpArtaxClientGenerator extends ClientGenerator
     {
         return new Stmt\ClassMethod(
             'create', [
-                'flags' => Stmt\Class_::MODIFIER_STATIC | Stmt\Class_::MODIFIER_PUBLIC,
+                'type' => Stmt\Class_::MODIFIER_STATIC | Stmt\Class_::MODIFIER_PUBLIC,
                 'params' => [
-                    new Node\Param('httpClient', new Expr\ConstFetch(new Name('null'))),
+                    new Node\Param(parserVariable('httpClient'), new Expr\ConstFetch(new Name('null'))),
                 ],
                 'stmts' => [
                     new Stmt\If_(
                         new Expr\BinaryOp\Identical(new Expr\ConstFetch(new Name('null')), new Expr\Variable('httpClient')),
                         [
                             'stmts' => [
-                                new Expr\Assign(
+                                parserExpression(new Expr\Assign(
                                     new Expr\Variable('httpClient'),
                                     new Expr\New_(new Name\FullyQualified(DefaultClient::class))
-                                ),
+                                )),
                             ],
                         ]
                     ),
-                    new Expr\Assign(
+                    parserExpression(new Expr\Assign(
                         new Expr\Variable('serializer'),
                         new Expr\New_(
                             new Name\FullyQualified(Serializer::class),
@@ -71,7 +73,7 @@ class AmpArtaxClientGenerator extends ClientGenerator
                                 ),
                             ]
                         )
-                    ),
+                    )),
                     new Stmt\Return_(
                         new Expr\New_(
                             new Name('static'), [

--- a/src/OpenApi/Generator/ExceptionGenerator.php
+++ b/src/OpenApi/Generator/ExceptionGenerator.php
@@ -7,6 +7,8 @@ use Jane\JsonSchema\Generator\File;
 use Jane\JsonSchema\Guesser\Guess\ClassGuess;
 use Jane\JsonSchema\Schema;
 use Jane\OpenApi\Naming\ExceptionNaming;
+use function Jane\parserExpression;
+use function Jane\parserVariable;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
@@ -61,23 +63,25 @@ class ExceptionGenerator
                                 new Stmt\PropertyProperty($propertyName),
                             ]),
                             new Stmt\ClassMethod('__construct', [
+                                'type' => Stmt\Class_::MODIFIER_PUBLIC,
                                 'params' => [
-                                    new Param($propertyName, null, $isArray ? null : '\\' . $classFqdn),
+                                    new Param(parserVariable($propertyName), null, $isArray ? null : new Name('\\' . $classFqdn)),
                                 ],
                                 'stmts' => [
-                                    new Expr\StaticCall(new Name('parent'), '__construct', [
+                                    parserExpression(new Expr\StaticCall(new Name('parent'), '__construct', [
                                         new Scalar\String_($description),
                                         new Scalar\LNumber($status),
-                                    ]),
-                                    new Expr\Assign(
+                                    ])),
+                                    parserExpression(new Expr\Assign(
                                         new Expr\PropertyFetch(
                                             new Expr\Variable('this'),
                                             $propertyName
                                         ), new Expr\Variable($propertyName)
-                                    ),
+                                    )),
                                 ],
                             ]),
                             new Stmt\ClassMethod($methodName, [
+                                'type' => Stmt\Class_::MODIFIER_PUBLIC,
                                 'stmts' => [
                                     new Stmt\Return_(
                                         new Expr\PropertyFetch(
@@ -107,6 +111,7 @@ class ExceptionGenerator
                     'extends' => new Name('\\RuntimeException'),
                     'stmts' => [
                         new Stmt\ClassMethod('__construct', [
+                            'type' => Stmt\Class_::MODIFIER_PUBLIC,
                             'stmts' => [
                                 new Expr\StaticCall(new Name('parent'), '__construct', [
                                     new Scalar\String_($description),

--- a/src/OpenApi/Generator/OperationGenerator.php
+++ b/src/OpenApi/Generator/OperationGenerator.php
@@ -4,6 +4,8 @@ namespace Jane\OpenApi\Generator;
 
 use Jane\JsonSchema\Generator\Context\Context;
 use Jane\OpenApi\Operation\Operation;
+use function Jane\isPhpParser4;
+use function Jane\parserVariable;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
@@ -40,10 +42,10 @@ abstract class OperationGenerator
 
         /** @var Param $param */
         foreach ($methodParams as $param) {
-            $endpointArgs[] = new Arg(new Expr\Variable($param->name));
+            $endpointArgs[] = new Arg(isPhpParser4() ? $param->var : new Expr\Variable($param->name));
         }
 
-        $methodParams[] = new Param('fetch', new Expr\ClassConstFetch(new Name('self'), 'FETCH_OBJECT'), 'string');
+        $methodParams[] = new Param(parserVariable('fetch'), new Expr\ClassConstFetch(new Name('self'), 'FETCH_OBJECT'), new Name('string'));
 
         return new Stmt\ClassMethod($name, [
             'type' => Stmt\Class_::MODIFIER_PUBLIC,

--- a/src/OpenApi/Generator/Parameter/BodyParameterGenerator.php
+++ b/src/OpenApi/Generator/Parameter/BodyParameterGenerator.php
@@ -7,6 +7,7 @@ use Jane\JsonSchema\Generator\Context\Context;
 use Jane\JsonSchemaRuntime\Reference;
 use Jane\OpenApi\Model\BodyParameter;
 use Jane\OpenApi\Model\Schema;
+use function Jane\parserVariable;
 use PhpParser\Node;
 use PhpParser\Parser;
 use Psr\Http\Message\StreamInterface;
@@ -42,7 +43,7 @@ class BodyParameterGenerator extends ParameterGenerator
             $paramType = 'array';
         }
 
-        return new Node\Param($name, null, $paramType);
+        return new Node\Param(parserVariable($name), null, null === $paramType ? $paramType : new Node\Name($paramType));
     }
 
     /**

--- a/src/OpenApi/Tests/JaneOpenApiResourceTest.php
+++ b/src/OpenApi/Tests/JaneOpenApiResourceTest.php
@@ -2,6 +2,7 @@
 
 namespace Jane\OpenApi\Tests;
 
+use function Jane\isPhpParser4;
 use Jane\OpenApi\Command\GenerateCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -52,7 +53,7 @@ class JaneOpenApiResourceTest extends TestCase
         foreach ($expectedFinder as $expectedFile) {
             $this->assertArrayHasKey($expectedFile->getRelativePathname(), $generatedData);
 
-            if ($expectedFile->isFile()) {
+            if ($expectedFile->isFile() && !isPhpParser4()) {
                 $expectedPath = $expectedFile->getRealPath();
                 $actualPath = $generatedData[$expectedFile->getRelativePathname()];
 

--- a/src/OpenApi/Tests/fixtures/array-definition/expected/Endpoint/TestSimple.php
+++ b/src/OpenApi/Tests/fixtures/array-definition/expected/Endpoint/TestSimple.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestSimple extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-simple';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Endpoint/GetTest.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Endpoint/GetTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\AmpArtaxEndpoint, \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\AmpArtaxEndpointTrait, \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Endpoint/GetTestById.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Endpoint/GetTestById.php
@@ -10,20 +10,20 @@ class GetTestById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
      *
      * @param int $id id
      */
-    function __construct(int $id)
+    public function __construct(int $id)
     {
         $this->id = $id;
     }
     use \Jane\OpenApiRuntime\Client\AmpArtaxEndpointTrait, \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{id}'), array($this->id), '/test/{id}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Endpoint/GetTestList.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Endpoint/GetTestList.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTestList extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\AmpArtaxEndpoint, \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\AmpArtaxEndpointTrait, \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-list';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Exception/GetTestBadRequestException.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Exception/GetTestBadRequestException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestBadRequestException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('bad request', 400);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Exception/GetTestByIdBadRequestException.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Exception/GetTestByIdBadRequestException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestByIdBadRequestException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('bad request', 400);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Exception/GetTestByIdNotFoundException.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Exception/GetTestByIdNotFoundException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestByIdNotFoundException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('not found', 404);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/async-generation/expected/Exception/GetTestNotFoundException.php
+++ b/src/OpenApi/Tests/fixtures/async-generation/expected/Exception/GetTestNotFoundException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestNotFoundException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('not found', 404);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestObjectBodyParameter.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestObjectBodyParameter.php
@@ -9,20 +9,20 @@ class TestObjectBodyParameter extends \Jane\OpenApiRuntime\Client\BaseEndpoint i
      *
      * @param \Jane\OpenApi\Tests\Expected\Model\Schema $testObject 
      */
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Schema $testObject)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Schema $testObject)
     {
         $this->body = $testObject;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-object';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return $this->getSerializedBody($serializer);
     }

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestObjectListBodyParameter.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestObjectListBodyParameter.php
@@ -9,20 +9,20 @@ class TestObjectListBodyParameter extends \Jane\OpenApiRuntime\Client\BaseEndpoi
      *
      * @param \Jane\OpenApi\Tests\Expected\Model\Schema[] $testObjectList 
      */
-    function __construct(array $testObjectList)
+    public function __construct(array $testObjectList)
     {
         $this->body = $testObjectList;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-object-list';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return $this->getSerializedBody($serializer);
     }

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestSimpleBodyParameter.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestSimpleBodyParameter.php
@@ -9,20 +9,20 @@ class TestSimpleBodyParameter extends \Jane\OpenApiRuntime\Client\BaseEndpoint i
      *
      * @param string|resource|\Psr\Http\Message\StreamInterface $testString 
      */
-    function __construct($testString)
+    public function __construct($testString)
     {
         $this->body = $testString;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-simple';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), $this->body);
     }

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
@@ -9,24 +9,24 @@ class BodyParameterTriggersContentTypeBeingSet extends \Jane\OpenApiRuntime\Clie
      *
      * @param string $testString 
      */
-    function __construct(string $testString)
+    public function __construct(string $testString)
     {
         $this->body = $testString;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-simple';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return $this->getSerializedBody($serializer);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Endpoint/ProducesTriggersAcceptBeingSet.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Endpoint/ProducesTriggersAcceptBeingSet.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class ProducesTriggersAcceptBeingSet extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-object';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Endpoint/TestNoTag.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Endpoint/TestNoTag.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestNoTag extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-exception';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagBadRequestException.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagBadRequestException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class TestNoTagBadRequestException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('Bad request on test exception', 400);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagInternalServerErrorException.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagInternalServerErrorException.php
@@ -4,7 +4,7 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 
 class TestNoTagInternalServerErrorException extends \RuntimeException implements ServerException
 {
-    function __construct()
+    public function __construct()
     {
         parent::__construct('Internal server error on test exception', 500);
     }

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagNotFoundException.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagNotFoundException.php
@@ -4,7 +4,7 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 
 class TestNoTagNotFoundException extends \RuntimeException implements ClientException
 {
-    function __construct()
+    public function __construct()
     {
         parent::__construct('Not found get', 404);
     }

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/CreatePets.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/CreatePets.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class CreatePets extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/pets';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
@@ -11,24 +11,24 @@ class ListPets extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane
      *     @var int $limit How many items to return at one time (max 100)
      * }
      */
-    function __construct(array $queryParameters = array())
+    public function __construct(array $queryParameters = array())
     {
         $this->queryParameters = $queryParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/pets';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ShowPetById.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ShowPetById.php
@@ -10,24 +10,24 @@ class ShowPetById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
      *
      * @param string $petId The id of the pet to retrieve
      */
-    function __construct(string $petId)
+    public function __construct(string $petId)
     {
         $this->petId = $petId;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{petId}'), array($this->petId), '/pets/{petId}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/host/expected/Endpoint/TestHost.php
+++ b/src/OpenApi/Tests/fixtures/host/expected/Endpoint/TestHost.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestHost extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-exception';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetEmptyTest.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetEmptyTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetEmptyTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-empty';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTest.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestById.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestById.php
@@ -10,20 +10,20 @@ class GetTestById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
      *
      * @param int $id id
      */
-    function __construct(int $id)
+    public function __construct(int $id)
     {
         $this->id = $id;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{id}'), array($this->id), '/test/{id}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestList.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestList.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTestList extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-list';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestBadRequestException.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestBadRequestException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestBadRequestException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('bad request', 400);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestByIdBadRequestException.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestByIdBadRequestException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestByIdBadRequestException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('bad request', 400);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestByIdNotFoundException.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestByIdNotFoundException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestByIdNotFoundException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('not found', 404);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestNotFoundException.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestNotFoundException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestNotFoundException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('not found', 404);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/multi-resources/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
+++ b/src/OpenApi/Tests/fixtures/multi-resources/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class BodyParameterTriggersContentTypeBeingSet extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-simple';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/multi-resources/expected/Endpoint/ProducesTriggersAcceptBeingSet.php
+++ b/src/OpenApi/Tests/fixtures/multi-resources/expected/Endpoint/ProducesTriggersAcceptBeingSet.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class ProducesTriggersAcceptBeingSet extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-object';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Endpoint/TestReferenceResponse.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Api1\Endpoint;
 class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-query';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/multi-specs/expected/Api2/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/multi-specs/expected/Api2/Endpoint/TestReferenceResponse.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Api2\Endpoint;
 class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-query';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Endpoint/GetTest.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Endpoint/GetTest.php
@@ -9,20 +9,20 @@ class GetTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\
      *
      * @param \Jane\OpenApi\Tests\Expected\Model\TestGetBody $body 
      */
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\TestGetBody $body)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\TestGetBody $body)
     {
         $this->body = $body;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return $this->getSerializedBody($serializer);
     }

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Endpoint/Test.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Endpoint/Test.php
@@ -9,20 +9,20 @@ class Test extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\Ope
      *
      * @param \Jane\OpenApi\Tests\Expected\Model\TestPostBody $body 
      */
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\TestPostBody $body)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\TestPostBody $body)
     {
         $this->body = $body;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return $this->getSerializedBody($serializer);
     }

--- a/src/OpenApi/Tests/fixtures/no-reference-response/expected/Endpoint/Test.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-response/expected/Endpoint/Test.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class Test extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/DeleteTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/DeleteTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class DeleteTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'DELETE';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThing.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThing.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetAnotherThing extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/another-things';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThingById.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThingById.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetAnotherThingById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/another-things/{id}';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrl.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrl.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTestOperationUrl extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-operation-url';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrlById.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrlById.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTestOperationUrlById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-operation-url/{id}';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrlWithExtension.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrlWithExtension.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTestOperationUrlWithExtension extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-operation-url-with-extension.php';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThings.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThings.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetThings extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/things';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThingsById.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThingsById.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetThingsById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/things/{id}';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/HeadTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/HeadTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class HeadTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'HEAD';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/OptionsTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/OptionsTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class OptionsTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'OPTIONS';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PatchTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PatchTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class PatchTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'PATCH';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PostNo200Thing.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PostNo200Thing.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class PostNo200Thing extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/no-200-things';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PostTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PostTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class PostTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PutTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PutTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class PutTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'PUT';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/TestNoTag.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/TestNoTag.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestNoTag extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-no-tag';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/GetByTestInteger.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/GetByTestInteger.php
@@ -10,20 +10,20 @@ class GetByTestInteger extends \Jane\OpenApiRuntime\Client\BaseEndpoint implemen
      *
      * @param int $testInteger 
      */
-    function __construct(int $testInteger)
+    public function __construct(int $testInteger)
     {
         $this->testInteger = $testInteger;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{test_integer}'), array($this->test_integer), '/{test_integer}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestBinaryBody.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestBinaryBody.php
@@ -9,20 +9,20 @@ class TestBinaryBody extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements
      *
      * @param string|resource|\Psr\Http\Message\StreamInterface $testBinary 
      */
-    function __construct($testBinary)
+    public function __construct($testBinary)
     {
         $this->body = $testBinary;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-binary-body';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), $this->body);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestFormFileParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestFormFileParameters.php
@@ -11,20 +11,20 @@ class TestFormFileParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint im
      *     @var string|resource|\Psr\Http\Message\StreamInterface $testFile 
      * }
      */
-    function __construct(array $formParameters = array())
+    public function __construct(array $formParameters = array())
     {
         $this->formParameters = $formParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-form-file';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return $this->getMultipartBody($streamFactory);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestFormParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestFormParameters.php
@@ -16,20 +16,20 @@ class TestFormParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint implem
      *     @var string $testDefault 
      * }
      */
-    function __construct(array $formParameters = array())
+    public function __construct(array $formParameters = array())
     {
         $this->formParameters = $formParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-form';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return $this->getFormBody();
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestGetWithPathParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestGetWithPathParameters.php
@@ -15,22 +15,22 @@ class TestGetWithPathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint
      *     @var string $testHeader 
      * }
      */
-    function __construct(array $testBody, array $queryParameters = array(), array $headerParameters = array())
+    public function __construct(array $testBody, array $queryParameters = array(), array $headerParameters = array())
     {
         $this->body = $testBody;
         $this->queryParameters = $queryParameters;
         $this->headerParameters = $headerParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-path-parameters/{testPath}';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return $this->getSerializedBody($serializer);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
@@ -16,20 +16,20 @@ class TestHeaderParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint impl
      *     @var string $testDefault 
      * }
      */
-    function __construct(array $headerParameters = array())
+    public function __construct(array $headerParameters = array())
     {
         $this->headerParameters = $headerParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-header';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestPathParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestPathParameters.php
@@ -14,22 +14,22 @@ class TestPathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint implem
      * @param int $testInteger 
      * @param float $testFloat 
      */
-    function __construct(string $testString, int $testInteger, float $testFloat)
+    public function __construct(string $testString, int $testInteger, float $testFloat)
     {
         $this->testString = $testString;
         $this->testInteger = $testInteger;
         $this->testFloat = $testFloat;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{testString}', '{testInteger}', '{testFloat}'), array($this->testString, $this->testInteger, $this->testFloat), '/test-path/{testString}/{testInteger}/{testFloat}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestPostWithPathParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestPostWithPathParameters.php
@@ -15,22 +15,22 @@ class TestPostWithPathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoin
      *     @var string $testHeader 
      * }
      */
-    function __construct(array $testBody, array $queryParameters = array(), array $headerParameters = array())
+    public function __construct(array $testBody, array $queryParameters = array(), array $headerParameters = array())
     {
         $this->body = $testBody;
         $this->queryParameters = $queryParameters;
         $this->headerParameters = $headerParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-path-parameters/{testPath}';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return $this->getSerializedBody($serializer);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
@@ -16,20 +16,20 @@ class TestQueryParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint imple
      *     @var string $testDefault 
      * }
      */
-    function __construct(array $queryParameters = array())
+    public function __construct(array $queryParameters = array())
     {
         $this->queryParameters = $queryParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-query';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestRefArray.php
+++ b/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestRefArray.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestRefArray extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-array-ref';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestReferenceResponse.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-query';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/yaml/expected/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/yaml/expected/Endpoint/TestReferenceResponse.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-query';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/composer.json
+++ b/src/OpenApi/composer.json
@@ -13,7 +13,8 @@
     "autoload": {
         "psr-4": {
             "Jane\\OpenApi\\": ""
-        }
+        },
+        "files": ["helpers.php"]
     },
     "bin": [
         "bin/jane-openapi"
@@ -23,7 +24,7 @@
         "jane-php/json-schema": "^4.0",
         "jane-php/json-schema-runtime": "^4.0",
         "jane-php/open-api-runtime": "^4.0",
-        "nikic/php-parser": "^3.0",
+        "nikic/php-parser": "^3.0 || ^4.0",
         "symfony/serializer": "^3.2|^4.0",
         "symfony/yaml": "^3.1|^4.0"
     },


### PR DESCRIPTION
Will add php-parser 4.x support for branch 4.x and keep php-parser 3.x support for no BC-break

Todo:
- [x] add `public` when needed on class methods