### PR TITLE
Quick fix for OpenApi/ExceptionGenerator

### DIFF
--- a/src/OpenApi/Generator/ExceptionGenerator.php
+++ b/src/OpenApi/Generator/ExceptionGenerator.php
@@ -113,10 +113,10 @@ class ExceptionGenerator
                         new Stmt\ClassMethod('__construct', [
                             'type' => Stmt\Class_::MODIFIER_PUBLIC,
                             'stmts' => [
-                                new Expr\StaticCall(new Name('parent'), '__construct', [
+                                parserExpression(new Expr\StaticCall(new Name('parent'), '__construct', [
                                     new Scalar\String_($description),
                                     new Scalar\LNumber($status),
-                                ]),
+                                ])),
                             ],
                         ]),
                     ],


### PR DESCRIPTION
After https://github.com/janephp/janephp/pull/61, there is a missing `parserException()` in `ExceptionGenerator`, thanks to @michaelthieulin to spot this one