### PR TITLE
Fixing missing exception interfaces

### DIFF
--- a/src/OpenApi/Generator/ExceptionGenerator.php
+++ b/src/OpenApi/Generator/ExceptionGenerator.php
@@ -35,8 +35,9 @@ class ExceptionGenerator
         $schema = $context->getCurrentSchema();
         $schema->getRootName();
 
-        if (!isset($this->intialized[$schema->getRootName()])) {
-            $this->intialized[$schema->getRootName()] = true;
+        $unique = $schema->getRootName() . $schema->getDirectory();
+        if (!isset($this->intialized[$unique])) {
+            $this->intialized[$unique] = true;
             $this->createBaseExceptions($schema);
         }
 

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/.jane-openapi
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'mapping' => [
+        __DIR__ . '/swagger_one.yaml' => [
+            'namespace' => 'Jane\OpenApi\Tests\Expected\One',
+            'directory' => __DIR__ . '/generated/One',
+        ],
+        __DIR__ . '/swagger_two.yaml' => [
+            'namespace' => 'Jane\OpenApi\Tests\Expected\Two',
+            'directory' => __DIR__ . '/generated/Two',
+        ],
+    ],
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\One;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\OpenApi\Tests\Expected\One\Exception\TestOneNotFoundException
+     *
+     * @return null|\Jane\OpenApi\Tests\Expected\One\Model\TestOneGetResponse200|\Psr\Http\Message\ResponseInterface
+     */
+    public function testOne(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\One\Endpoint\TestOne(), $fetch);
+    }
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\One\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Endpoint/TestOne.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Endpoint/TestOne.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\One\Endpoint;
+
+class TestOne extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
+{
+    use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/test-one';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\OpenApi\Tests\Expected\One\Exception\TestOneNotFoundException
+     *
+     * @return null|\Jane\OpenApi\Tests\Expected\One\Model\TestOneGetResponse200
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer)
+    {
+        if (200 === $status) {
+            return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\One\\Model\\TestOneGetResponse200', 'json');
+        }
+        if (404 === $status) {
+            throw new \Jane\OpenApi\Tests\Expected\One\Exception\TestOneNotFoundException();
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Exception/ApiException.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\One\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Exception/ClientException.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\One\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Exception/ServerException.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\One\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Exception/TestOneNotFoundException.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Exception/TestOneNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\One\Exception;
+
+class TestOneNotFoundException extends \RuntimeException implements ClientException
+{
+    public function __construct()
+    {
+        parent::__construct('Not found', 404);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Model/TestOneGetResponse200.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Model/TestOneGetResponse200.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\One\Model;
+
+class TestOneGetResponse200
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $message;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getMessage() : ?string
+    {
+        return $this->message;
+    }
+    /**
+     * 
+     *
+     * @param string $message
+     *
+     * @return self
+     */
+    public function setMessage(?string $message) : self
+    {
+        $this->message = $message;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Normalizer/NormalizerFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\One\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new TestOneGetResponse200Normalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Normalizer/TestOneGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/One/Normalizer/TestOneGetResponse200Normalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\One\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class TestOneGetResponse200Normalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\One\\Model\\TestOneGetResponse200';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\OpenApi\Tests\Expected\One\Model\TestOneGetResponse200;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\One\Model\TestOneGetResponse200();
+        if (property_exists($data, 'message')) {
+            $object->setMessage($data->{'message'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getMessage()) {
+            $data->{'message'} = $object->getMessage();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Two;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\OpenApi\Tests\Expected\Two\Exception\TestTwoNotFoundException
+     *
+     * @return null|\Jane\OpenApi\Tests\Expected\Two\Model\TestTwoGetResponse200|\Psr\Http\Message\ResponseInterface
+     */
+    public function testTwo(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Two\Endpoint\TestTwo(), $fetch);
+    }
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\Two\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Endpoint/TestTwo.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Endpoint/TestTwo.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Two\Endpoint;
+
+class TestTwo extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
+{
+    use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/test-two';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\OpenApi\Tests\Expected\Two\Exception\TestTwoNotFoundException
+     *
+     * @return null|\Jane\OpenApi\Tests\Expected\Two\Model\TestTwoGetResponse200
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer)
+    {
+        if (200 === $status) {
+            return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Two\\Model\\TestTwoGetResponse200', 'json');
+        }
+        if (404 === $status) {
+            throw new \Jane\OpenApi\Tests\Expected\Two\Exception\TestTwoNotFoundException();
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/ApiException.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Two\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/ClientException.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Two\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/ServerException.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Two\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/TestTwoNotFoundException.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/TestTwoNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Two\Exception;
+
+class TestTwoNotFoundException extends \RuntimeException implements ClientException
+{
+    public function __construct()
+    {
+        parent::__construct('Not found', 404);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Model/TestTwoGetResponse200.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Model/TestTwoGetResponse200.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Two\Model;
+
+class TestTwoGetResponse200
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $message;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getMessage() : ?string
+    {
+        return $this->message;
+    }
+    /**
+     * 
+     *
+     * @param string $message
+     *
+     * @return self
+     */
+    public function setMessage(?string $message) : self
+    {
+        $this->message = $message;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Normalizer/NormalizerFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Two\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new TestTwoGetResponse200Normalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Normalizer/TestTwoGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/expected/Two/Normalizer/TestTwoGetResponse200Normalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Two\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class TestTwoGetResponse200Normalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Two\\Model\\TestTwoGetResponse200';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\OpenApi\Tests\Expected\Two\Model\TestTwoGetResponse200;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Two\Model\TestTwoGetResponse200();
+        if (property_exists($data, 'message')) {
+            $object->setMessage($data->{'message'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getMessage()) {
+            $data->{'message'} = $object->getMessage();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/swagger_one.yaml
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/swagger_one.yaml
@@ -1,0 +1,22 @@
+swagger: '2.0'
+info:
+    title: Swagger
+    version: 1.0.0
+schemes:
+    - https
+produces:
+    - application/json
+paths:
+    '/test-one':
+        get:
+            operationId: testOne
+            responses:
+                '200':
+                    description: Success
+                    schema:
+                        type: object
+                        properties:
+                            message:
+                                type: string
+                '404':
+                    description: Not found

--- a/src/OpenApi/Tests/fixtures/exception-with-no-schema/swagger_two.yaml
+++ b/src/OpenApi/Tests/fixtures/exception-with-no-schema/swagger_two.yaml
@@ -1,0 +1,22 @@
+swagger: '2.0'
+info:
+    title: Swagger
+    version: 1.0.0
+schemes:
+    - https
+produces:
+    - application/json
+paths:
+    '/test-two':
+        get:
+            operationId: testTwo
+            responses:
+                '200':
+                    description: Success
+                    schema:
+                        type: object
+                        properties:
+                            message:
+                                type: string
+                '404':
+                    description: Not found


### PR DESCRIPTION
When using `mapping` configuration with several schemas and atleast two of them having exceptions (status codes different than 200). Jane will generate base exception interfaces only for the first schema and ignore after that one.

This PR bring a fix to that and related test.