### PR TITLE
Missing helper file for OpenApi library

### DIFF
--- a/src/OpenApi/helpers.php
+++ b/src/OpenApi/helpers.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Jane;
+
+use PhpParser\Node;
+
+function parserExpression(Node\Expr $expr): Node
+{
+    if (isPhpParser4()) {
+        return new Node\Stmt\Expression($expr);
+    }
+
+    return $expr;
+}
+
+function parserVariable(string $name)
+{
+    if (isPhpParser4()) {
+        return new Node\Expr\Variable($name);
+    }
+
+    return $name;
+}
+
+function isPhpParser4(): bool
+{
+    return class_exists('PhpParser\\Node\\Stmt\\Expression');
+}


### PR DESCRIPTION
When added `nikic/php-parser` 4.x compatibility, I forgot to also add the `helper.php` file in OpenApi folder ~

cf. https://github.com/janephp/janephp/pull/61