### PR TITLE
No cs-fix in tests

### DIFF
--- a/src/OpenApi/Tests/fixtures/array-definition/expected/Endpoint/TestSimple.php
+++ b/src/OpenApi/Tests/fixtures/array-definition/expected/Endpoint/TestSimple.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestSimple extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-simple';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestObjectBodyParameter.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestObjectBodyParameter.php
@@ -9,20 +9,20 @@ class TestObjectBodyParameter extends \Jane\OpenApiRuntime\Client\BaseEndpoint i
      *
      * @param \Jane\OpenApi\Tests\Expected\Model\Schema $requestBody 
      */
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Schema $requestBody)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Schema $requestBody)
     {
         $this->body = $requestBody;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-object';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         if ($this->body instanceof \Jane\OpenApi\Tests\Expected\Model\Schema) {
             return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestObjectListBodyParameter.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestObjectListBodyParameter.php
@@ -9,20 +9,20 @@ class TestObjectListBodyParameter extends \Jane\OpenApiRuntime\Client\BaseEndpoi
      *
      * @param \Jane\OpenApi\Tests\Expected\Model\Schema[] $requestBody 
      */
-    function __construct(array $requestBody)
+    public function __construct(array $requestBody)
     {
         $this->body = $requestBody;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-object-list';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         if (is_array($this->body) and isset($this->body[0]) and $this->body[0] instanceof \Jane\OpenApi\Tests\Expected\Model\Schema) {
             return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestSimpleBodyParameter.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Endpoint/TestSimpleBodyParameter.php
@@ -9,20 +9,20 @@ class TestSimpleBodyParameter extends \Jane\OpenApiRuntime\Client\BaseEndpoint i
      *
      * @param string|resource|\Psr\Http\Message\StreamInterface $requestBody 
      */
-    function __construct($requestBody)
+    public function __construct($requestBody)
     {
         $this->body = $requestBody;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-simple';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         if (is_string($this->body) or is_resource($this->body) or $this->body instanceof \Psr\Http\Message\StreamInterface) {
             return array(array('Content-Type' => array('text/plain')), $this->body);

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
@@ -9,20 +9,20 @@ class BodyParameterTriggersContentTypeBeingSet extends \Jane\OpenApiRuntime\Clie
      *
      * @param string $requestBody 
      */
-    function __construct(string $requestBody)
+    public function __construct(string $requestBody)
     {
         $this->body = $requestBody;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-simple';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         if (is_string($this->body)) {
             return array(array('Content-Type' => array('application/json')), json_encode($this->body));

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Endpoint/ProducesTriggersAcceptBeingSet.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Endpoint/ProducesTriggersAcceptBeingSet.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class ProducesTriggersAcceptBeingSet extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-object';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Endpoint/TestNoTag.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Endpoint/TestNoTag.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestNoTag extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-exception';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagBadRequestException.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagBadRequestException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class TestNoTagBadRequestException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('Bad request on test exception', 400);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagInternalServerErrorException.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagInternalServerErrorException.php
@@ -4,7 +4,7 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 
 class TestNoTagInternalServerErrorException extends \RuntimeException implements ServerException
 {
-    function __construct()
+    public function __construct()
     {
         parent::__construct('Internal server error on test exception', 500);
     }

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagNotFoundException.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Exception/TestNoTagNotFoundException.php
@@ -4,7 +4,7 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 
 class TestNoTagNotFoundException extends \RuntimeException implements ClientException
 {
-    function __construct()
+    public function __construct()
     {
         parent::__construct('Not found get', 404);
     }

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/CreatePets.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/CreatePets.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class CreatePets extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/pets';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
@@ -11,24 +11,24 @@ class ListPets extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane
      *     @var int $limit How many items to return at one time (max 100)
      * }
      */
-    function __construct(array $queryParameters = array())
+    public function __construct(array $queryParameters = array())
     {
         $this->queryParameters = $queryParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/pets';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ShowPetById.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ShowPetById.php
@@ -10,24 +10,24 @@ class ShowPetById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
      *
      * @param string $petId The id of the pet to retrieve
      */
-    function __construct(string $petId)
+    public function __construct(string $petId)
     {
         $this->petId = $petId;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{petId}'), array($this->petId), '/pets/{petId}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/host/expected/Endpoint/TestHost.php
+++ b/src/OpenApi/Tests/fixtures/host/expected/Endpoint/TestHost.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestHost extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-exception';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetEmptyTest.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetEmptyTest.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetEmptyTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-empty';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTest.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTest.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestById.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestById.php
@@ -10,24 +10,24 @@ class GetTestById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
      *
      * @param int $id id
      */
-    function __construct(int $id)
+    public function __construct(int $id)
     {
         $this->id = $id;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{id}'), array($this->id), '/test/{id}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestList.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestList.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTestList extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-list';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestBadRequestException.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestBadRequestException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestBadRequestException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('bad request', 400);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestByIdBadRequestException.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestByIdBadRequestException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestByIdBadRequestException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('bad request', 400);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestByIdNotFoundException.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestByIdNotFoundException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestByIdNotFoundException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('not found', 404);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestNotFoundException.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Exception/GetTestNotFoundException.php
@@ -5,12 +5,12 @@ namespace Jane\OpenApi\Tests\Expected\Exception;
 class GetTestNotFoundException extends \RuntimeException implements ClientException
 {
     private $error;
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\Error $error)
     {
         parent::__construct('not found', 404);
         $this->error = $error;
     }
-    function getError()
+    public function getError()
     {
         return $this->error;
     }

--- a/src/OpenApi/Tests/fixtures/multi-resources/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
+++ b/src/OpenApi/Tests/fixtures/multi-resources/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class BodyParameterTriggersContentTypeBeingSet extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-simple';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/multi-resources/expected/Endpoint/ProducesTriggersAcceptBeingSet.php
+++ b/src/OpenApi/Tests/fixtures/multi-resources/expected/Endpoint/ProducesTriggersAcceptBeingSet.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class ProducesTriggersAcceptBeingSet extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-object';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Endpoint/TestReferenceResponse.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Api1\Endpoint;
 class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-query';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/multi-specs/expected/Api2/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/multi-specs/expected/Api2/Endpoint/TestReferenceResponse.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Api2\Endpoint;
 class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-query';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Endpoint/GetTest.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Endpoint/GetTest.php
@@ -9,20 +9,20 @@ class GetTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\
      *
      * @param \Jane\OpenApi\Tests\Expected\Model\TestGetBody $requestBody 
      */
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\TestGetBody $requestBody)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\TestGetBody $requestBody)
     {
         $this->body = $requestBody;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         if ($this->body instanceof \Jane\OpenApi\Tests\Expected\Model\TestGetBody) {
             return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Endpoint/Test.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Endpoint/Test.php
@@ -9,20 +9,20 @@ class Test extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\Ope
      *
      * @param \Jane\OpenApi\Tests\Expected\Model\TestPostBody $requestBody 
      */
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\TestPostBody $requestBody)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\TestPostBody $requestBody)
     {
         $this->body = $requestBody;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         if ($this->body instanceof \Jane\OpenApi\Tests\Expected\Model\TestPostBody) {
             return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));

--- a/src/OpenApi/Tests/fixtures/no-reference-response/expected/Endpoint/Test.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-response/expected/Endpoint/Test.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class Test extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/DeleteTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/DeleteTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class DeleteTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'DELETE';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThing.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThing.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetAnotherThing extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/another-things';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThingById.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThingById.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetAnotherThingById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/another-things/{id}';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrl.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrl.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTestOperationUrl extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-operation-url';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrlById.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrlById.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTestOperationUrlById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-operation-url/{id}';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrlWithExtension.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetTestOperationUrlWithExtension.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetTestOperationUrlWithExtension extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-operation-url-with-extension.php';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThings.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThings.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetThings extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/things';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThingsById.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThingsById.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class GetThingsById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/things/{id}';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/HeadTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/HeadTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class HeadTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'HEAD';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/OptionsTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/OptionsTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class OptionsTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'OPTIONS';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PatchTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PatchTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class PatchTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'PATCH';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PostNo200Thing.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PostNo200Thing.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class PostNo200Thing extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/no-200-things';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PostTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PostTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class PostTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PutTest.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/PutTest.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class PutTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'PUT';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-get';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/TestNoTag.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/TestNoTag.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestNoTag extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-no-tag';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/GetByTestInteger.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/GetByTestInteger.php
@@ -10,20 +10,20 @@ class GetByTestInteger extends \Jane\OpenApiRuntime\Client\BaseEndpoint implemen
      *
      * @param int $testInteger 
      */
-    function __construct(int $testInteger)
+    public function __construct(int $testInteger)
     {
         $this->testInteger = $testInteger;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{test_integer}'), array($this->test_integer), '/{test_integer}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestBinaryBody.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestBinaryBody.php
@@ -9,20 +9,20 @@ class TestBinaryBody extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements
      *
      * @param string|resource|\Psr\Http\Message\StreamInterface $requestBody 
      */
-    function __construct($requestBody)
+    public function __construct($requestBody)
     {
         $this->body = $requestBody;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-binary-body';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         if (is_string($this->body) or is_resource($this->body) or $this->body instanceof \Psr\Http\Message\StreamInterface) {
             return array(array('Content-Type' => array('test/plain')), $this->body);

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestFormFileParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestFormFileParameters.php
@@ -9,20 +9,20 @@ class TestFormFileParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint im
      *
      * @param \Jane\OpenApi\Tests\Expected\Model\TestFormFilePostBody $requestBody 
      */
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\TestFormFilePostBody $requestBody)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\TestFormFilePostBody $requestBody)
     {
         $this->body = $requestBody;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-form-file';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         if ($this->body instanceof \Jane\OpenApi\Tests\Expected\Model\TestFormFilePostBody) {
             $bodyBuilder = new \Http\Message\MultipartStream\MultipartStreamBuilder($streamFactory);

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestFormParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestFormParameters.php
@@ -9,20 +9,20 @@ class TestFormParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint implem
      *
      * @param \Jane\OpenApi\Tests\Expected\Model\TestFormPostBody $requestBody 
      */
-    function __construct(\Jane\OpenApi\Tests\Expected\Model\TestFormPostBody $requestBody)
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\TestFormPostBody $requestBody)
     {
         $this->body = $requestBody;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-form';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         if ($this->body instanceof \Jane\OpenApi\Tests\Expected\Model\TestFormPostBody) {
             return array(array('Content-Type' => array('application/x-www-form-urlencoded')), http_build_query($serializer->normalize($this->body, 'json')));

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestGetWithPathParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestGetWithPathParameters.php
@@ -16,22 +16,22 @@ class TestGetWithPathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint
      *     @var string $testHeader 
      * }
      */
-    function __construct(string $testPath, array $queryParameters = array(), array $headerParameters = array())
+    public function __construct(string $testPath, array $queryParameters = array(), array $headerParameters = array())
     {
         $this->testPath = $testPath;
         $this->queryParameters = $queryParameters;
         $this->headerParameters = $headerParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{testPath}'), array($this->testPath), '/test-path-parameters/{testPath}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
@@ -16,20 +16,20 @@ class TestHeaderParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint impl
      *     @var string $testDefault 
      * }
      */
-    function __construct(array $headerParameters = array())
+    public function __construct(array $headerParameters = array())
     {
         $this->headerParameters = $headerParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-header';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestPathParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestPathParameters.php
@@ -14,22 +14,22 @@ class TestPathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint implem
      * @param int $testInteger 
      * @param float $testFloat 
      */
-    function __construct(string $testString, int $testInteger, float $testFloat)
+    public function __construct(string $testString, int $testInteger, float $testFloat)
     {
         $this->testString = $testString;
         $this->testInteger = $testInteger;
         $this->testFloat = $testFloat;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{testString}', '{testInteger}', '{testFloat}'), array($this->testString, $this->testInteger, $this->testFloat), '/test-path/{testString}/{testInteger}/{testFloat}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestPostWithPathParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestPostWithPathParameters.php
@@ -16,22 +16,22 @@ class TestPostWithPathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoin
      *     @var string $testHeader 
      * }
      */
-    function __construct(string $testPath, array $queryParameters = array(), array $headerParameters = array())
+    public function __construct(string $testPath, array $queryParameters = array(), array $headerParameters = array())
     {
         $this->testPath = $testPath;
         $this->queryParameters = $queryParameters;
         $this->headerParameters = $headerParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'POST';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return str_replace(array('{testPath}'), array($this->testPath), '/test-path-parameters/{testPath}');
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
@@ -16,20 +16,20 @@ class TestQueryParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint imple
      *     @var string $testDefault 
      * }
      */
-    function __construct(array $queryParameters = array())
+    public function __construct(array $queryParameters = array())
     {
         $this->queryParameters = $queryParameters;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-query';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }

--- a/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestRefArray.php
+++ b/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestRefArray.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestRefArray extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-array-ref';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestReferenceResponse.php
@@ -5,19 +5,19 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-query';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }
-    function getExtraHeaders() : array
+    public function getExtraHeaders() : array
     {
         return array('Accept' => array('application/json'));
     }

--- a/src/OpenApi/Tests/fixtures/yaml/expected/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/yaml/expected/Endpoint/TestReferenceResponse.php
@@ -5,15 +5,15 @@ namespace Jane\OpenApi\Tests\Expected\Endpoint;
 class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
 {
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
-    function getMethod() : string
+    public function getMethod() : string
     {
         return 'GET';
     }
-    function getUri() : string
+    public function getUri() : string
     {
         return '/test-query';
     }
-    function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
     {
         return array(array(), null);
     }


### PR DESCRIPTION
Fixed tests in `master` branch:

- No more `php-cs-fixer` after running fixtures (same as `4.x` branch: https://github.com/janephp/janephp/pull/56)