### PR TITLE
v4: get the content type from the header and pass it to the transformResponseBody function

### DIFF
--- a/src/OpenApiRuntime/Client/Psr7HttplugEndpointTrait.php
+++ b/src/OpenApiRuntime/Client/Psr7HttplugEndpointTrait.php
@@ -10,12 +10,14 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 trait Psr7HttplugEndpointTrait
 {
-    abstract protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer);
+    abstract protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer, string $contentType = null);
 
     public function parsePSR7Response(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
         if ($fetchMode === Client::FETCH_OBJECT) {
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer);
+            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+
+            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
         }
 
         if ($fetchMode === Client::FETCH_RESPONSE) {

--- a/src/OpenApiRuntime/Tests/Client/Psr7HttplugClientTest.php
+++ b/src/OpenApiRuntime/Tests/Client/Psr7HttplugClientTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\OpenApiRuntime\Tests\Client;
+
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
+use Http\Message\StreamFactory;
+use Jane\OpenApiRuntime\Client\Psr7HttplugClient;
+use Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class Psr7HttplugClientTest extends TestCase
+{
+    /**
+     * @covers \Jane\OpenApiRuntime\Client\Psr7HttplugClient::__construct
+     * @covers \Jane\OpenApiRuntime\Client\Psr7HttplugClient::executePsr7Endpoint
+     */
+    public function testExecutePsr7Endpoint()
+    {
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $httpClientMock = $this->createMock(HttpClient::class);
+        $httpClientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->willReturn($responseMock);
+
+        $requestMock = $this->createMock(RequestInterface::class);
+        $messageFactoryMock = $this->createMock(MessageFactory::class);
+        $messageFactoryMock
+            ->expects($this->once())
+            ->method('createRequest')
+            ->with('GET', '/foo', [], 'bar')
+            ->willReturn($requestMock);
+
+        $serializerMock = $this->createMock(SerializerInterface::class);
+
+        $streamFactoryMock = $this->createMock(StreamFactory::class);
+
+        $client = new class($httpClientMock, $messageFactoryMock, $serializerMock) extends Psr7HttplugClient {
+        };
+
+        $constructorArgs = [
+            $httpClientMock,
+            $messageFactoryMock,
+            $serializerMock,
+            $streamFactoryMock,
+        ];
+        $endpointMock = $this->getMockBuilder(Psr7HttplugEndpoint::class)->setConstructorArgs($constructorArgs)->getMock();
+        $endpointMock
+            ->expects($this->once())
+            ->method('getBody')
+            ->willReturn([[], 'bar']);
+        $endpointMock
+            ->expects($this->once())
+            ->method('getQueryString')
+            ->willReturn('');
+        $endpointMock
+            ->expects($this->exactly(2))
+            ->method('getUri')
+            ->willReturn('/foo');
+        $endpointMock
+            ->expects($this->once())
+            ->method('getMethod')
+            ->willReturn('GET');
+        $endpointMock
+            ->expects($this->once())
+            ->method('getHeaders')
+            ->with([])
+            ->willReturn([]);
+        $endpointMock
+            ->expects($this->once())
+            ->method('parsePSR7Response')
+            ->willReturn('foo');
+
+        $this->assertSame('foo', $client->executePsr7Endpoint($endpointMock));
+    }
+}

--- a/src/OpenApiRuntime/Tests/Client/Psr7HttplugEndpointTraitTest.php
+++ b/src/OpenApiRuntime/Tests/Client/Psr7HttplugEndpointTraitTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\OpenApiRuntime\Tests\Client;
+
+use Jane\OpenApiRuntime\Client\Client;
+use Jane\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
+use Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class Psr7HttplugEndpointTraitTest extends TestCase
+{
+    /**
+     * @covers \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait::parsePSR7Response
+     */
+    public function testParsePSR7ResponseWithObjectFetchModeShouldTransformResponseBody()
+    {
+        $endpoint = $this->getEndpointInstance();
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock
+            ->expects($this->once())
+            ->method('hasHeader')
+            ->with('Content-Type')
+            ->willReturn(true);
+
+        $responseMock
+            ->expects($this->once())
+            ->method('getHeader')
+            ->willReturn(['application/json']);
+
+        $responseMock
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $serializerMock = $this->createMock(SerializerInterface::class);
+
+        $this->assertSame('foo', $endpoint->parsePSR7Response($responseMock, $serializerMock));
+    }
+
+    /**
+     * @covers \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait::parsePSR7Response
+     */
+    public function testParsePSR7ResponseWithResponseFetchModeShouldReturnResponse()
+    {
+        $endpoint = $this->getEndpointInstance();
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $serializerMock = $this->createMock(SerializerInterface::class);
+
+        $this->assertSame($responseMock, $endpoint->parsePSR7Response($responseMock, $serializerMock, Client::FETCH_RESPONSE));
+    }
+
+    /**
+     * @covers \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait::parsePSR7Response
+     */
+    public function testParsePSR7ResponseWithInvalidFetchModeShouldThrowException()
+    {
+        $endpoint = $this->getEndpointInstance();
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $serializerMock = $this->createMock(SerializerInterface::class);
+
+        $this->expectException(InvalidFetchModeException::class);
+        $this->expectExceptionMessage('Fetch mode foo is not supported');
+        $endpoint->parsePSR7Response($responseMock, $serializerMock, 'foo');
+    }
+
+    private function getEndpointInstance()
+    {
+        static $endpoint = null;
+        if ($endpoint === null) {
+            $endpoint = new class() {
+                use Psr7HttplugEndpointTrait;
+
+                protected function transformResponseBody(
+                    string $body,
+                    int $status,
+                    SerializerInterface $serializer,
+                    string $contentType = null
+                ) {
+                    return 'foo';
+                }
+            };
+        }
+
+        return $endpoint;
+    }
+}


### PR DESCRIPTION
fix for #76 for the `4.x` branch

