### PR TITLE
add null type to PHPDoc for getters/setters

### DIFF
--- a/src/JsonSchema/Model/JsonSchema.php
+++ b/src/JsonSchema/Model/JsonSchema.php
@@ -148,7 +148,7 @@ class JsonSchema
     protected $not;
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getId(): ?string
     {
@@ -156,7 +156,7 @@ class JsonSchema
     }
 
     /**
-     * @param string $id
+     * @param string|null $id
      *
      * @return self
      */
@@ -168,7 +168,7 @@ class JsonSchema
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDollarSchema(): ?string
     {
@@ -176,7 +176,7 @@ class JsonSchema
     }
 
     /**
-     * @param string $dollarSchema
+     * @param string|null $dollarSchema
      *
      * @return self
      */
@@ -188,7 +188,7 @@ class JsonSchema
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getTitle(): ?string
     {
@@ -196,7 +196,7 @@ class JsonSchema
     }
 
     /**
-     * @param string $title
+     * @param string|null $title
      *
      * @return self
      */
@@ -208,7 +208,7 @@ class JsonSchema
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getDescription(): ?string
     {
@@ -216,7 +216,7 @@ class JsonSchema
     }
 
     /**
-     * @param string $description
+     * @param string|null $description
      *
      * @return self
      */
@@ -248,7 +248,7 @@ class JsonSchema
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getMultipleOf(): ?float
     {
@@ -256,7 +256,7 @@ class JsonSchema
     }
 
     /**
-     * @param float $multipleOf
+     * @param float|null $multipleOf
      *
      * @return self
      */
@@ -268,7 +268,7 @@ class JsonSchema
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getMaximum(): ?float
     {
@@ -276,7 +276,7 @@ class JsonSchema
     }
 
     /**
-     * @param float $maximum
+     * @param float|null $maximum
      *
      * @return self
      */
@@ -288,7 +288,7 @@ class JsonSchema
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
     public function getExclusiveMaximum(): ?bool
     {
@@ -296,7 +296,7 @@ class JsonSchema
     }
 
     /**
-     * @param bool $exclusiveMaximum
+     * @param bool|null $exclusiveMaximum
      *
      * @return self
      */
@@ -308,7 +308,7 @@ class JsonSchema
     }
 
     /**
-     * @return float
+     * @return float|null
      */
     public function getMinimum(): ?float
     {
@@ -316,7 +316,7 @@ class JsonSchema
     }
 
     /**
-     * @param float $minimum
+     * @param float|null $minimum
      *
      * @return self
      */
@@ -328,7 +328,7 @@ class JsonSchema
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
     public function getExclusiveMinimum(): ?bool
     {
@@ -336,7 +336,7 @@ class JsonSchema
     }
 
     /**
-     * @param bool $exclusiveMinimum
+     * @param bool|null $exclusiveMinimum
      *
      * @return self
      */
@@ -348,7 +348,7 @@ class JsonSchema
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMaxLength(): ?int
     {
@@ -356,7 +356,7 @@ class JsonSchema
     }
 
     /**
-     * @param int $maxLength
+     * @param int|null $maxLength
      *
      * @return self
      */
@@ -368,7 +368,7 @@ class JsonSchema
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMinLength(): ?int
     {
@@ -376,7 +376,7 @@ class JsonSchema
     }
 
     /**
-     * @param int $minLength
+     * @param int|null $minLength
      *
      * @return self
      */
@@ -388,7 +388,7 @@ class JsonSchema
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPattern(): ?string
     {
@@ -396,7 +396,7 @@ class JsonSchema
     }
 
     /**
-     * @param string $pattern
+     * @param string|null $pattern
      *
      * @return self
      */
@@ -408,7 +408,7 @@ class JsonSchema
     }
 
     /**
-     * @return bool|JsonSchema
+     * @return bool|JsonSchema|null
      */
     public function getAdditionalItems()
     {
@@ -416,7 +416,7 @@ class JsonSchema
     }
 
     /**
-     * @param bool|JsonSchema $additionalItems
+     * @param bool|JsonSchema|null $additionalItems
      *
      * @return self
      */
@@ -428,7 +428,7 @@ class JsonSchema
     }
 
     /**
-     * @return JsonSchema|JsonSchema[]
+     * @return JsonSchema|JsonSchema[]|null
      */
     public function getItems()
     {
@@ -436,7 +436,7 @@ class JsonSchema
     }
 
     /**
-     * @param JsonSchema|JsonSchema[] $items
+     * @param JsonSchema|JsonSchema[]|null $items
      *
      * @return self
      */
@@ -448,7 +448,7 @@ class JsonSchema
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMaxItems(): ?int
     {
@@ -456,7 +456,7 @@ class JsonSchema
     }
 
     /**
-     * @param int $maxItems
+     * @param int|null $maxItems
      *
      * @return self
      */
@@ -468,7 +468,7 @@ class JsonSchema
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMinItems(): ?int
     {
@@ -476,7 +476,7 @@ class JsonSchema
     }
 
     /**
-     * @param int $minItems
+     * @param int|null $minItems
      *
      * @return self
      */
@@ -488,7 +488,7 @@ class JsonSchema
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
     public function getUniqueItems(): ?bool
     {
@@ -496,7 +496,7 @@ class JsonSchema
     }
 
     /**
-     * @param bool $uniqueItems
+     * @param bool|null $uniqueItems
      *
      * @return self
      */
@@ -508,7 +508,7 @@ class JsonSchema
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMaxProperties(): ?int
     {
@@ -516,7 +516,7 @@ class JsonSchema
     }
 
     /**
-     * @param int $maxProperties
+     * @param int|null $maxProperties
      *
      * @return self
      */
@@ -528,7 +528,7 @@ class JsonSchema
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getMinProperties(): ?int
     {
@@ -536,7 +536,7 @@ class JsonSchema
     }
 
     /**
-     * @param int $minProperties
+     * @param int|null $minProperties
      *
      * @return self
      */
@@ -548,7 +548,7 @@ class JsonSchema
     }
 
     /**
-     * @return string[]
+     * @return string[]|null
      */
     public function getRequired(): ?array
     {
@@ -556,7 +556,7 @@ class JsonSchema
     }
 
     /**
-     * @param string[] $required
+     * @param string[]|null $required
      *
      * @return self
      */
@@ -568,7 +568,7 @@ class JsonSchema
     }
 
     /**
-     * @return bool|JsonSchema
+     * @return bool|JsonSchema|null
      */
     public function getAdditionalProperties()
     {
@@ -576,7 +576,7 @@ class JsonSchema
     }
 
     /**
-     * @param bool|JsonSchema $additionalProperties
+     * @param bool|JsonSchema|null $additionalProperties
      *
      * @return self
      */
@@ -588,7 +588,7 @@ class JsonSchema
     }
 
     /**
-     * @return JsonSchema[]
+     * @return JsonSchema[]|null
      */
     public function getDefinitions(): ?\ArrayObject
     {
@@ -596,7 +596,7 @@ class JsonSchema
     }
 
     /**
-     * @param JsonSchema[] $definitions
+     * @param JsonSchema[]|null $definitions
      *
      * @return self
      */
@@ -608,7 +608,7 @@ class JsonSchema
     }
 
     /**
-     * @return JsonSchema[]
+     * @return JsonSchema[]|null
      */
     public function getProperties(): ?\ArrayObject
     {
@@ -616,7 +616,7 @@ class JsonSchema
     }
 
     /**
-     * @param JsonSchema[] $properties
+     * @param JsonSchema[]|null $properties
      *
      * @return self
      */
@@ -628,7 +628,7 @@ class JsonSchema
     }
 
     /**
-     * @return JsonSchema[]
+     * @return JsonSchema[]|null
      */
     public function getPatternProperties(): ?\ArrayObject
     {
@@ -636,7 +636,7 @@ class JsonSchema
     }
 
     /**
-     * @param JsonSchema[] $patternProperties
+     * @param JsonSchema[]|null $patternProperties
      *
      * @return self
      */
@@ -648,7 +648,7 @@ class JsonSchema
     }
 
     /**
-     * @return JsonSchema[]|string[][]
+     * @return JsonSchema[]|string[][]|null
      */
     public function getDependencies(): ?\ArrayObject
     {
@@ -656,7 +656,7 @@ class JsonSchema
     }
 
     /**
-     * @param JsonSchema[]|string[][] $dependencies
+     * @param JsonSchema[]|string[][]|null $dependencies
      *
      * @return self
      */
@@ -668,7 +668,7 @@ class JsonSchema
     }
 
     /**
-     * @return mixed[]
+     * @return mixed[]|null
      */
     public function getEnum(): ?array
     {
@@ -676,7 +676,7 @@ class JsonSchema
     }
 
     /**
-     * @param mixed[] $enum
+     * @param mixed[]|null $enum
      *
      * @return self
      */
@@ -708,7 +708,7 @@ class JsonSchema
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFormat(): ?string
     {
@@ -716,7 +716,7 @@ class JsonSchema
     }
 
     /**
-     * @param string $format
+     * @param string|null $format
      *
      * @return self
      */
@@ -728,7 +728,7 @@ class JsonSchema
     }
 
     /**
-     * @return JsonSchema[]
+     * @return JsonSchema[]|null
      */
     public function getAllOf(): ?array
     {
@@ -736,7 +736,7 @@ class JsonSchema
     }
 
     /**
-     * @param JsonSchema[] $allOf
+     * @param JsonSchema[]|null $allOf
      *
      * @return self
      */
@@ -748,7 +748,7 @@ class JsonSchema
     }
 
     /**
-     * @return JsonSchema[]
+     * @return JsonSchema[]|null
      */
     public function getAnyOf(): ?array
     {
@@ -756,7 +756,7 @@ class JsonSchema
     }
 
     /**
-     * @param JsonSchema[] $anyOf
+     * @param JsonSchema[]|null $anyOf
      *
      * @return self
      */
@@ -768,7 +768,7 @@ class JsonSchema
     }
 
     /**
-     * @return JsonSchema[]
+     * @return JsonSchema[]|null
      */
     public function getOneOf(): ?array
     {
@@ -776,7 +776,7 @@ class JsonSchema
     }
 
     /**
-     * @param JsonSchema[] $oneOf
+     * @param JsonSchema[]|null $oneOf
      *
      * @return self
      */
@@ -790,7 +790,7 @@ class JsonSchema
     /**
      * Core schema meta-schema.
      *
-     * @return JsonSchema
+     * @return JsonSchema|null
      */
     public function getNot(): ?self
     {
@@ -800,7 +800,7 @@ class JsonSchema
     /**
      * Core schema meta-schema.
      *
-     * @param JsonSchema $not
+     * @param JsonSchema|null $not
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/additional-properties/expected/Model/AdditionalProperties.php
+++ b/src/JsonSchema/Tests/fixtures/additional-properties/expected/Model/AdditionalProperties.php
@@ -13,7 +13,7 @@ class AdditionalProperties extends \ArrayObject
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class AdditionalProperties extends \ArrayObject
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/additional-properties/expected/Model/PatternProperties.php
+++ b/src/JsonSchema/Tests/fixtures/additional-properties/expected/Model/PatternProperties.php
@@ -13,7 +13,7 @@ class PatternProperties extends \ArrayObject
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class PatternProperties extends \ArrayObject
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Bar.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Bar.php
@@ -19,7 +19,7 @@ class Bar
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -28,7 +28,7 @@ class Bar
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */
@@ -40,7 +40,7 @@ class Bar
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getBar() : ?string
     {
@@ -49,7 +49,7 @@ class Bar
     /**
      * 
      *
-     * @param string $bar
+     * @param string|null $bar
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Baz.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Baz.php
@@ -25,7 +25,7 @@ class Baz
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -34,7 +34,7 @@ class Baz
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */
@@ -46,7 +46,7 @@ class Baz
     /**
      * 
      *
-     * @return Bar
+     * @return Bar|null
      */
     public function getBar() : ?Bar
     {
@@ -55,7 +55,7 @@ class Baz
     /**
      * 
      *
-     * @param Bar $bar
+     * @param Bar|null $bar
      *
      * @return self
      */
@@ -67,7 +67,7 @@ class Baz
     /**
      * 
      *
-     * @return BazBaz
+     * @return BazBaz|null
      */
     public function getBaz() : ?BazBaz
     {
@@ -76,7 +76,7 @@ class Baz
     /**
      * 
      *
-     * @param BazBaz $baz
+     * @param BazBaz|null $baz
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Model/BazBaz.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Model/BazBaz.php
@@ -13,7 +13,7 @@ class BazBaz
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getBaz() : ?string
     {
@@ -22,7 +22,7 @@ class BazBaz
     /**
      * 
      *
-     * @param string $baz
+     * @param string|null $baz
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Childtype.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Childtype.php
@@ -19,7 +19,7 @@ class Childtype
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getChildProperty() : ?string
     {
@@ -28,7 +28,7 @@ class Childtype
     /**
      * 
      *
-     * @param string $childProperty
+     * @param string|null $childProperty
      *
      * @return self
      */
@@ -40,7 +40,7 @@ class Childtype
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getInheritedProperty() : ?string
     {
@@ -49,7 +49,7 @@ class Childtype
     /**
      * 
      *
-     * @param string $inheritedProperty
+     * @param string|null $inheritedProperty
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Foo.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Foo.php
@@ -13,7 +13,7 @@ class Foo
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class Foo
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Otherchildtype.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Otherchildtype.php
@@ -19,7 +19,7 @@ class Otherchildtype
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getInheritedProperty() : ?string
     {
@@ -28,7 +28,7 @@ class Otherchildtype
     /**
      * 
      *
-     * @param string $inheritedProperty
+     * @param string|null $inheritedProperty
      *
      * @return self
      */
@@ -40,7 +40,7 @@ class Otherchildtype
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getChildProperty() : ?string
     {
@@ -49,7 +49,7 @@ class Otherchildtype
     /**
      * 
      *
-     * @param string $childProperty
+     * @param string|null $childProperty
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Parenttype.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Parenttype.php
@@ -13,7 +13,7 @@ class Parenttype
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getInheritedProperty() : ?string
     {
@@ -22,7 +22,7 @@ class Parenttype
     /**
      * 
      *
-     * @param string $inheritedProperty
+     * @param string|null $inheritedProperty
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Model/Test.php
@@ -19,7 +19,7 @@ class Test
     /**
      * 
      *
-     * @return Childtype
+     * @return Childtype|null
      */
     public function getChild() : ?Childtype
     {
@@ -28,7 +28,7 @@ class Test
     /**
      * 
      *
-     * @param Childtype $child
+     * @param Childtype|null $child
      *
      * @return self
      */
@@ -40,7 +40,7 @@ class Test
     /**
      * 
      *
-     * @return Parenttype
+     * @return Parenttype|null
      */
     public function getParent() : ?Parenttype
     {
@@ -49,7 +49,7 @@ class Test
     /**
      * 
      *
-     * @param Parenttype $parent
+     * @param Parenttype|null $parent
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/datetime-format/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/datetime-format/expected/Model/Test.php
@@ -25,7 +25,7 @@ class Test
     /**
      * 
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getDate() : ?\DateTime
     {
@@ -34,7 +34,7 @@ class Test
     /**
      * 
      *
-     * @param \DateTime $date
+     * @param \DateTime|null $date
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/datetime/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/datetime/expected/Model/Test.php
@@ -25,7 +25,7 @@ class Test
     /**
      * 
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getDate() : ?\DateTime
     {
@@ -34,7 +34,7 @@ class Test
     /**
      * 
      *
-     * @param \DateTime $date
+     * @param \DateTime|null $date
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/deep-object/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/deep-object/expected/Model/Test.php
@@ -13,7 +13,7 @@ class Test
     /**
      * 
      *
-     * @return TestFooItem[]
+     * @return TestFooItem[]|null
      */
     public function getFoo() : ?array
     {
@@ -22,7 +22,7 @@ class Test
     /**
      * 
      *
-     * @param TestFooItem[] $foo
+     * @param TestFooItem[]|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/deep-object/expected/Model/TestFooItem.php
+++ b/src/JsonSchema/Tests/fixtures/deep-object/expected/Model/TestFooItem.php
@@ -13,7 +13,7 @@ class TestFooItem
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getBar() : ?string
     {
@@ -22,7 +22,7 @@ class TestFooItem
     /**
      * 
      *
-     * @param string $bar
+     * @param string|null $bar
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/definitions/expected/Model/BarItem.php
+++ b/src/JsonSchema/Tests/fixtures/definitions/expected/Model/BarItem.php
@@ -13,7 +13,7 @@ class BarItem
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getBar() : ?string
     {
@@ -22,7 +22,7 @@ class BarItem
     /**
      * 
      *
-     * @param string $bar
+     * @param string|null $bar
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/definitions/expected/Model/Foo.php
+++ b/src/JsonSchema/Tests/fixtures/definitions/expected/Model/Foo.php
@@ -13,7 +13,7 @@ class Foo
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class Foo
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/definitions/expected/Model/HelloWorld.php
+++ b/src/JsonSchema/Tests/fixtures/definitions/expected/Model/HelloWorld.php
@@ -13,7 +13,7 @@ class HelloWorld
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class HelloWorld
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/multi-files/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/multi-files/expected/Model/Test.php
@@ -13,7 +13,7 @@ class Test
     /**
      * 
      *
-     * @return TestFoo
+     * @return TestFoo|null
      */
     public function getFoo() : ?TestFoo
     {
@@ -22,7 +22,7 @@ class Test
     /**
      * 
      *
-     * @param TestFoo $foo
+     * @param TestFoo|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/multi-files/expected/Model/TestFoo.php
+++ b/src/JsonSchema/Tests/fixtures/multi-files/expected/Model/TestFoo.php
@@ -13,7 +13,7 @@ class TestFoo
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class TestFoo
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Model/Test.php
@@ -13,7 +13,7 @@ class Test
     /**
      * 
      *
-     * @return \Jane\JsonSchema\Tests\Expected\Schema2\Model\Foo
+     * @return \Jane\JsonSchema\Tests\Expected\Schema2\Model\Foo|null
      */
     public function getFoo() : ?\Jane\JsonSchema\Tests\Expected\Schema2\Model\Foo
     {
@@ -22,7 +22,7 @@ class Test
     /**
      * 
      *
-     * @param \Jane\JsonSchema\Tests\Expected\Schema2\Model\Foo $foo
+     * @param \Jane\JsonSchema\Tests\Expected\Schema2\Model\Foo|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema2/Model/Foo.php
+++ b/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema2/Model/Foo.php
@@ -13,7 +13,7 @@ class Foo
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class Foo
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/name-conflict/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/name-conflict/expected/Model/Test.php
@@ -19,7 +19,7 @@ class Test
     /**
      * Indicates the ID of the referenced original mail.
      *
-     * @return string
+     * @return string|null
      */
     public function getMsgref() : ?string
     {
@@ -28,7 +28,7 @@ class Test
     /**
      * Indicates the ID of the referenced original mail.
      *
-     * @param string $msgref
+     * @param string|null $msgref
      *
      * @return self
      */
@@ -40,7 +40,7 @@ class Test
     /**
      * Message reference on reply/forward.
      *
-     * @return string
+     * @return string|null
      */
     public function getMsgRef2() : ?string
     {
@@ -49,7 +49,7 @@ class Test
     /**
      * Message reference on reply/forward.
      *
-     * @param string $msgRef2
+     * @param string|null $msgRef2
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/reserved-words/expected/Model/_List.php
+++ b/src/JsonSchema/Tests/fixtures/reserved-words/expected/Model/_List.php
@@ -13,7 +13,7 @@ class _List
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class _List
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Model/Test.php
@@ -19,7 +19,7 @@ class Test
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getString() : ?string
     {
@@ -28,7 +28,7 @@ class Test
     /**
      * 
      *
-     * @param string $string
+     * @param string|null $string
      *
      * @return self
      */
@@ -40,7 +40,7 @@ class Test
     /**
      * 
      *
-     * @return TestSubObject
+     * @return TestSubObject|null
      */
     public function getSubObject() : ?TestSubObject
     {
@@ -49,7 +49,7 @@ class Test
     /**
      * 
      *
-     * @param TestSubObject $subObject
+     * @param TestSubObject|null $subObject
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Model/TestSubObject.php
+++ b/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Model/TestSubObject.php
@@ -13,7 +13,7 @@ class TestSubObject
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class TestSubObject
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Model/Test.php
@@ -73,7 +73,7 @@ class Test
     /**
      * 
      *
-     * @return string[]
+     * @return string[]|null
      */
     public function getArray() : ?array
     {
@@ -82,7 +82,7 @@ class Test
     /**
      * 
      *
-     * @param string[] $array
+     * @param string[]|null $array
      *
      * @return self
      */
@@ -94,7 +94,7 @@ class Test
     /**
      * 
      *
-     * @return string[]
+     * @return string[]|null
      */
     public function getObject() : ?\ArrayObject
     {
@@ -103,7 +103,7 @@ class Test
     /**
      * 
      *
-     * @param string[] $object
+     * @param string[]|null $object
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Model/Bar.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Model/Bar.php
@@ -13,7 +13,7 @@ class Bar
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getBar() : ?string
     {
@@ -22,7 +22,7 @@ class Bar
     /**
      * 
      *
-     * @param string $bar
+     * @param string|null $bar
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Model/Foo.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Model/Foo.php
@@ -19,7 +19,7 @@ class Foo
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getBar() : ?string
     {
@@ -28,7 +28,7 @@ class Foo
     /**
      * 
      *
-     * @param string $bar
+     * @param string|null $bar
      *
      * @return self
      */
@@ -40,7 +40,7 @@ class Foo
     /**
      * A description
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -49,7 +49,7 @@ class Foo
     /**
      * A description
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Model/Fuz.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Model/Fuz.php
@@ -13,7 +13,7 @@ class Fuz
     /**
      * A description
      *
-     * @return string
+     * @return string|null
      */
     public function getBar() : ?string
     {
@@ -22,7 +22,7 @@ class Fuz
     /**
      * A description
      *
-     * @param string $bar
+     * @param string|null $bar
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/array-definition/expected/Model/BarItem.php
+++ b/src/OpenApi/Tests/fixtures/array-definition/expected/Model/BarItem.php
@@ -13,7 +13,7 @@ class BarItem
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getBar() : ?string
     {
@@ -22,7 +22,7 @@ class BarItem
     /**
      * 
      *
-     * @param string $bar
+     * @param string|null $bar
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Model/Schema.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Model/Schema.php
@@ -55,7 +55,7 @@ class Schema
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getStringProperty() : ?string
     {
@@ -64,7 +64,7 @@ class Schema
     /**
      * 
      *
-     * @param string $stringProperty
+     * @param string|null $stringProperty
      *
      * @return self
      */
@@ -76,7 +76,7 @@ class Schema
     /**
      * 
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getDateProperty() : ?\DateTime
     {
@@ -85,7 +85,7 @@ class Schema
     /**
      * 
      *
-     * @param \DateTime $dateProperty
+     * @param \DateTime|null $dateProperty
      *
      * @return self
      */
@@ -97,7 +97,7 @@ class Schema
     /**
      * 
      *
-     * @return int
+     * @return int|null
      */
     public function getIntegerProperty() : ?int
     {
@@ -106,7 +106,7 @@ class Schema
     /**
      * 
      *
-     * @param int $integerProperty
+     * @param int|null $integerProperty
      *
      * @return self
      */
@@ -118,7 +118,7 @@ class Schema
     /**
      * 
      *
-     * @return float
+     * @return float|null
      */
     public function getFloatProperty() : ?float
     {
@@ -127,7 +127,7 @@ class Schema
     /**
      * 
      *
-     * @param float $floatProperty
+     * @param float|null $floatProperty
      *
      * @return self
      */
@@ -139,7 +139,7 @@ class Schema
     /**
      * 
      *
-     * @return mixed[]
+     * @return mixed[]|null
      */
     public function getArrayProperty() : ?array
     {
@@ -148,7 +148,7 @@ class Schema
     /**
      * 
      *
-     * @param mixed[] $arrayProperty
+     * @param mixed[]|null $arrayProperty
      *
      * @return self
      */
@@ -160,7 +160,7 @@ class Schema
     /**
      * 
      *
-     * @return string[]
+     * @return string[]|null
      */
     public function getMapProperty() : ?\ArrayObject
     {
@@ -169,7 +169,7 @@ class Schema
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param string[]|null $mapProperty
      *
      * @return self
      */
@@ -181,7 +181,7 @@ class Schema
     /**
      * 
      *
-     * @return SchemaObjectProperty
+     * @return SchemaObjectProperty|null
      */
     public function getObjectProperty() : ?SchemaObjectProperty
     {
@@ -190,7 +190,7 @@ class Schema
     /**
      * 
      *
-     * @param SchemaObjectProperty $objectProperty
+     * @param SchemaObjectProperty|null $objectProperty
      *
      * @return self
      */
@@ -202,7 +202,7 @@ class Schema
     /**
      * 
      *
-     * @return Schema
+     * @return Schema|null
      */
     public function getObjectRefProperty() : ?Schema
     {
@@ -211,7 +211,7 @@ class Schema
     /**
      * 
      *
-     * @param Schema $objectRefProperty
+     * @param Schema|null $objectRefProperty
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Model/SchemaObjectProperty.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Model/SchemaObjectProperty.php
@@ -13,7 +13,7 @@ class SchemaObjectProperty
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getStringProperty() : ?string
     {
@@ -22,7 +22,7 @@ class SchemaObjectProperty
     /**
      * 
      *
-     * @param string $stringProperty
+     * @param string|null $stringProperty
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Model/Schema.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Model/Schema.php
@@ -55,7 +55,7 @@ class Schema
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getStringProperty() : ?string
     {
@@ -64,7 +64,7 @@ class Schema
     /**
      * 
      *
-     * @param string $stringProperty
+     * @param string|null $stringProperty
      *
      * @return self
      */
@@ -76,7 +76,7 @@ class Schema
     /**
      * 
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getDateProperty() : ?\DateTime
     {
@@ -85,7 +85,7 @@ class Schema
     /**
      * 
      *
-     * @param \DateTime $dateProperty
+     * @param \DateTime|null $dateProperty
      *
      * @return self
      */
@@ -97,7 +97,7 @@ class Schema
     /**
      * 
      *
-     * @return int
+     * @return int|null
      */
     public function getIntegerProperty() : ?int
     {
@@ -106,7 +106,7 @@ class Schema
     /**
      * 
      *
-     * @param int $integerProperty
+     * @param int|null $integerProperty
      *
      * @return self
      */
@@ -118,7 +118,7 @@ class Schema
     /**
      * 
      *
-     * @return float
+     * @return float|null
      */
     public function getFloatProperty() : ?float
     {
@@ -127,7 +127,7 @@ class Schema
     /**
      * 
      *
-     * @param float $floatProperty
+     * @param float|null $floatProperty
      *
      * @return self
      */
@@ -139,7 +139,7 @@ class Schema
     /**
      * 
      *
-     * @return mixed[]
+     * @return mixed[]|null
      */
     public function getArrayProperty() : ?array
     {
@@ -148,7 +148,7 @@ class Schema
     /**
      * 
      *
-     * @param mixed[] $arrayProperty
+     * @param mixed[]|null $arrayProperty
      *
      * @return self
      */
@@ -160,7 +160,7 @@ class Schema
     /**
      * 
      *
-     * @return string[]
+     * @return string[]|null
      */
     public function getMapProperty() : ?\ArrayObject
     {
@@ -169,7 +169,7 @@ class Schema
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param string[]|null $mapProperty
      *
      * @return self
      */
@@ -181,7 +181,7 @@ class Schema
     /**
      * 
      *
-     * @return SchemaObjectProperty
+     * @return SchemaObjectProperty|null
      */
     public function getObjectProperty() : ?SchemaObjectProperty
     {
@@ -190,7 +190,7 @@ class Schema
     /**
      * 
      *
-     * @param SchemaObjectProperty $objectProperty
+     * @param SchemaObjectProperty|null $objectProperty
      *
      * @return self
      */
@@ -202,7 +202,7 @@ class Schema
     /**
      * 
      *
-     * @return Schema
+     * @return Schema|null
      */
     public function getObjectRefProperty() : ?Schema
     {
@@ -211,7 +211,7 @@ class Schema
     /**
      * 
      *
-     * @param Schema $objectRefProperty
+     * @param Schema|null $objectRefProperty
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Model/SchemaObjectProperty.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Model/SchemaObjectProperty.php
@@ -13,7 +13,7 @@ class SchemaObjectProperty
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getStringProperty() : ?string
     {
@@ -22,7 +22,7 @@ class SchemaObjectProperty
     /**
      * 
      *
-     * @param string $stringProperty
+     * @param string|null $stringProperty
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Model/Error.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Model/Error.php
@@ -13,7 +13,7 @@ class Error
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getMessage() : ?string
     {
@@ -22,7 +22,7 @@ class Error
     /**
      * 
      *
-     * @param string $message
+     * @param string|null $message
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Model/Error.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Model/Error.php
@@ -19,7 +19,7 @@ class Error
     /**
      * 
      *
-     * @return int
+     * @return int|null
      */
     public function getCode() : ?int
     {
@@ -28,7 +28,7 @@ class Error
     /**
      * 
      *
-     * @param int $code
+     * @param int|null $code
      *
      * @return self
      */
@@ -40,7 +40,7 @@ class Error
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getMessage() : ?string
     {
@@ -49,7 +49,7 @@ class Error
     /**
      * 
      *
-     * @param string $message
+     * @param string|null $message
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Model/Pet.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Model/Pet.php
@@ -25,7 +25,7 @@ class Pet
     /**
      * 
      *
-     * @return int
+     * @return int|null
      */
     public function getId() : ?int
     {
@@ -34,7 +34,7 @@ class Pet
     /**
      * 
      *
-     * @param int $id
+     * @param int|null $id
      *
      * @return self
      */
@@ -46,7 +46,7 @@ class Pet
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getName() : ?string
     {
@@ -55,7 +55,7 @@ class Pet
     /**
      * 
      *
-     * @param string $name
+     * @param string|null $name
      *
      * @return self
      */
@@ -67,7 +67,7 @@ class Pet
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getTag() : ?string
     {
@@ -76,7 +76,7 @@ class Pet
     /**
      * 
      *
-     * @param string $tag
+     * @param string|null $tag
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Model/EmptySpace.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Model/EmptySpace.php
@@ -13,7 +13,7 @@ class EmptySpace
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getStringProperty() : ?string
     {
@@ -22,7 +22,7 @@ class EmptySpace
     /**
      * 
      *
-     * @param string $stringProperty
+     * @param string|null $stringProperty
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Model/Error.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Model/Error.php
@@ -13,7 +13,7 @@ class Error
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getMessage() : ?string
     {
@@ -22,7 +22,7 @@ class Error
     /**
      * 
      *
-     * @param string $message
+     * @param string|null $message
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Model/Schema.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Model/Schema.php
@@ -49,7 +49,7 @@ class Schema
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getStringProperty() : ?string
     {
@@ -58,7 +58,7 @@ class Schema
     /**
      * 
      *
-     * @param string $stringProperty
+     * @param string|null $stringProperty
      *
      * @return self
      */
@@ -70,7 +70,7 @@ class Schema
     /**
      * 
      *
-     * @return int
+     * @return int|null
      */
     public function getIntegerProperty() : ?int
     {
@@ -79,7 +79,7 @@ class Schema
     /**
      * 
      *
-     * @param int $integerProperty
+     * @param int|null $integerProperty
      *
      * @return self
      */
@@ -91,7 +91,7 @@ class Schema
     /**
      * 
      *
-     * @return float
+     * @return float|null
      */
     public function getFloatProperty() : ?float
     {
@@ -100,7 +100,7 @@ class Schema
     /**
      * 
      *
-     * @param float $floatProperty
+     * @param float|null $floatProperty
      *
      * @return self
      */
@@ -112,7 +112,7 @@ class Schema
     /**
      * 
      *
-     * @return mixed[]
+     * @return mixed[]|null
      */
     public function getArrayProperty() : ?array
     {
@@ -121,7 +121,7 @@ class Schema
     /**
      * 
      *
-     * @param mixed[] $arrayProperty
+     * @param mixed[]|null $arrayProperty
      *
      * @return self
      */
@@ -133,7 +133,7 @@ class Schema
     /**
      * 
      *
-     * @return string[]
+     * @return string[]|null
      */
     public function getMapProperty() : ?\ArrayObject
     {
@@ -142,7 +142,7 @@ class Schema
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param string[]|null $mapProperty
      *
      * @return self
      */
@@ -154,7 +154,7 @@ class Schema
     /**
      * 
      *
-     * @return SchemaObjectProperty
+     * @return SchemaObjectProperty|null
      */
     public function getObjectProperty() : ?SchemaObjectProperty
     {
@@ -163,7 +163,7 @@ class Schema
     /**
      * 
      *
-     * @param SchemaObjectProperty $objectProperty
+     * @param SchemaObjectProperty|null $objectProperty
      *
      * @return self
      */
@@ -175,7 +175,7 @@ class Schema
     /**
      * 
      *
-     * @return Schema
+     * @return Schema|null
      */
     public function getObjectRefProperty() : ?Schema
     {
@@ -184,7 +184,7 @@ class Schema
     /**
      * 
      *
-     * @param Schema $objectRefProperty
+     * @param Schema|null $objectRefProperty
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Model/SchemaObjectProperty.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Model/SchemaObjectProperty.php
@@ -13,7 +13,7 @@ class SchemaObjectProperty
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getStringProperty() : ?string
     {
@@ -22,7 +22,7 @@ class SchemaObjectProperty
     /**
      * 
      *
-     * @param string $stringProperty
+     * @param string|null $stringProperty
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Model/TestIdGetResponse200.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Model/TestIdGetResponse200.php
@@ -13,7 +13,7 @@ class TestIdGetResponse200
     /**
      * 
      *
-     * @return int
+     * @return int|null
      */
     public function getId() : ?int
     {
@@ -22,7 +22,7 @@ class TestIdGetResponse200
     /**
      * 
      *
-     * @param int $id
+     * @param int|null $id
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Model/Body.php
+++ b/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Model/Body.php
@@ -13,7 +13,7 @@ class Body
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class Body
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Model/Bar.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Model/Bar.php
@@ -19,7 +19,7 @@ class Bar
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -28,7 +28,7 @@ class Bar
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */
@@ -40,7 +40,7 @@ class Bar
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getBar() : ?string
     {
@@ -49,7 +49,7 @@ class Bar
     /**
      * 
      *
-     * @param string $bar
+     * @param string|null $bar
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Model/Foo.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Model/Foo.php
@@ -13,7 +13,7 @@ class Foo
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class Foo
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Model/TestGetBody.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Model/TestGetBody.php
@@ -25,7 +25,7 @@ class TestGetBody
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -34,7 +34,7 @@ class TestGetBody
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */
@@ -46,7 +46,7 @@ class TestGetBody
     /**
      * 
      *
-     * @return Bar
+     * @return Bar|null
      */
     public function getBar() : ?Bar
     {
@@ -55,7 +55,7 @@ class TestGetBody
     /**
      * 
      *
-     * @param Bar $bar
+     * @param Bar|null $bar
      *
      * @return self
      */
@@ -67,7 +67,7 @@ class TestGetBody
     /**
      * 
      *
-     * @return TestGetBodyBaz
+     * @return TestGetBodyBaz|null
      */
     public function getBaz() : ?TestGetBodyBaz
     {
@@ -76,7 +76,7 @@ class TestGetBody
     /**
      * 
      *
-     * @param TestGetBodyBaz $baz
+     * @param TestGetBodyBaz|null $baz
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Model/TestGetBodyBaz.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Model/TestGetBodyBaz.php
@@ -13,7 +13,7 @@ class TestGetBodyBaz
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getBaz() : ?string
     {
@@ -22,7 +22,7 @@ class TestGetBodyBaz
     /**
      * 
      *
-     * @param string $baz
+     * @param string|null $baz
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Model/TestPostBody.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Model/TestPostBody.php
@@ -13,7 +13,7 @@ class TestPostBody
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class TestPostBody
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/no-reference-response/expected/Model/TestPostResponse201.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-response/expected/Model/TestPostResponse201.php
@@ -13,7 +13,7 @@ class TestPostResponse201
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class TestPostResponse201
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/operations/expected/Model/Thing.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Model/Thing.php
@@ -13,7 +13,7 @@ class Thing
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getName() : ?string
     {
@@ -22,7 +22,7 @@ class Thing
     /**
      * 
      *
-     * @param string $name
+     * @param string|null $name
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Model/TestFormFilePostBody.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Model/TestFormFilePostBody.php
@@ -13,7 +13,7 @@ class TestFormFilePostBody
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getTestFile() : ?string
     {
@@ -22,7 +22,7 @@ class TestFormFilePostBody
     /**
      * 
      *
-     * @param string $testFile
+     * @param string|null $testFile
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Model/TestFormPostBody.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Model/TestFormPostBody.php
@@ -43,7 +43,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getTestString() : ?string
     {
@@ -52,7 +52,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @param string $testString
+     * @param string|null $testString
      *
      * @return self
      */
@@ -64,7 +64,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @return int
+     * @return int|null
      */
     public function getTestInteger() : ?int
     {
@@ -73,7 +73,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @param int $testInteger
+     * @param int|null $testInteger
      *
      * @return self
      */
@@ -85,7 +85,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @return float
+     * @return float|null
      */
     public function getTestFloat() : ?float
     {
@@ -94,7 +94,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @param float $testFloat
+     * @param float|null $testFloat
      *
      * @return self
      */
@@ -106,7 +106,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @return mixed[]
+     * @return mixed[]|null
      */
     public function getTestArray() : ?array
     {
@@ -115,7 +115,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @param mixed[] $testArray
+     * @param mixed[]|null $testArray
      *
      * @return self
      */
@@ -127,7 +127,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getTestRequired() : ?string
     {
@@ -136,7 +136,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @param string $testRequired
+     * @param string|null $testRequired
      *
      * @return self
      */
@@ -148,7 +148,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getTestDefault() : ?string
     {
@@ -157,7 +157,7 @@ class TestFormPostBody
     /**
      * 
      *
-     * @param string $testDefault
+     * @param string|null $testDefault
      *
      * @return self
      */

--- a/src/OpenApi/Tests/fixtures/response-reference/expected/Model/ResponseCommon.php
+++ b/src/OpenApi/Tests/fixtures/response-reference/expected/Model/ResponseCommon.php
@@ -13,7 +13,7 @@ class ResponseCommon
     /**
      * 
      *
-     * @return string
+     * @return string|null
      */
     public function getFoo() : ?string
     {
@@ -22,7 +22,7 @@ class ResponseCommon
     /**
      * 
      *
-     * @param string $foo
+     * @param string|null $foo
      *
      * @return self
      */


### PR DESCRIPTION
Hello,
I noticed that when the PHP7 types are nullable, the PHPDoc does not reflect the change.
So for example, if the type is `?string`, in my opinion the PHPDoc should say `string|null`.

This PR implements this, taking into account the cases where `null` or `mixed` are already part of the recipe.

Thanks!