### PR TITLE
Fix generated endpoint in case of uppercase in path parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [OpenAPI] Fix generated endpoint in case of uppercase first letter in path parameter  #79
+
 ## 4.4.0 - 2019-06-17
  
 ### Added

--- a/src/OpenApi/Generator/EndpointGenerator.php
+++ b/src/OpenApi/Generator/EndpointGenerator.php
@@ -148,7 +148,7 @@ abstract class EndpointGenerator
             if ($parameter instanceof PathParameterSubSchema) {
                 $pathParams[] = $this->nonBodyParameterGenerator->generateMethodParameter($parameter, $context, $operation->getReference() . '/parameters/' . $key);
                 $pathParamsDoc[] = $this->nonBodyParameterGenerator->generateMethodDocParameter($parameter, $context, $operation->getReference() . '/parameters/' . $key);
-                $methodStatements[] = parserExpression(new Expr\Assign(new Expr\PropertyFetch(new Expr\Variable('this'), Inflector::camelize($parameter->getName())), new Expr\Variable(Inflector::camelize($parameter->getName()))));
+                $methodStatements[] = parserExpression(new Expr\Assign(new Expr\PropertyFetch(new Expr\Variable('this'), $parameter->getName()), new Expr\Variable(Inflector::camelize($parameter->getName()))));
                 $pathProperties[] = new Stmt\Property(Stmt\Class_::MODIFIER_PROTECTED, [
                     new Stmt\PropertyProperty(new Name($parameter->getName())),
                 ]);

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/GetByTestInteger.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Endpoint/GetByTestInteger.php
@@ -12,7 +12,7 @@ class GetByTestInteger extends \Jane\OpenApiRuntime\Client\BaseEndpoint implemen
      */
     public function __construct(int $testInteger)
     {
-        $this->testInteger = $testInteger;
+        $this->test_integer = $testInteger;
     }
     use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
     public function getMethod() : string

--- a/src/OpenApi/Tests/fixtures/uppercase-parameter/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/uppercase-parameter/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ .  '/swagger.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/uppercase-parameter/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/uppercase-parameter/expected/Client.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    /**
+     * 
+     *
+     * @param string $testParameter 
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function testGetWithUppercasePathParameters(string $testParameter, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Endpoint\TestGetWithUppercasePathParameters($testParameter), $fetch);
+    }
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/uppercase-parameter/expected/Endpoint/TestGetWithUppercasePathParameters.php
+++ b/src/OpenApi/Tests/fixtures/uppercase-parameter/expected/Endpoint/TestGetWithUppercasePathParameters.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Endpoint;
+
+class TestGetWithUppercasePathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7HttplugEndpoint
+{
+    protected $TestParameter;
+    /**
+     * 
+     *
+     * @param string $testParameter 
+     */
+    public function __construct(string $testParameter)
+    {
+        $this->TestParameter = $testParameter;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7HttplugEndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return str_replace(array('{TestParameter}'), array($this->TestParameter), '/test-uppercase-path-parameters/{TestParameter}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, \Http\Message\StreamFactory $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer)
+    {
+    }
+}

--- a/src/OpenApi/Tests/fixtures/uppercase-parameter/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/uppercase-parameter/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/uppercase-parameter/swagger.json
+++ b/src/OpenApi/Tests/fixtures/uppercase-parameter/swagger.json
@@ -1,0 +1,25 @@
+{
+    "swagger": "2.0",
+    "paths": {
+        "/test-uppercase-path-parameters/{TestParameter}": {
+            "get": {
+                "operationId": "testGetWithUppercasePathParameters",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Test"
+                ],
+                "parameters": [
+                    {
+                        "name": "TestParameter",
+                        "in": "path",
+                        "type": "string",
+                        "required": true,
+                        "x-nullable": false
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fix address issue #79 by removing `Inflector::camelize()` in EndpointGenerator class for property name in the constructor