### PR TITLE
Fix Content-Type comparison in generated endpoints

### DIFF
--- a/src/OpenApi/Generator/EndpointGenerator.php
+++ b/src/OpenApi/Generator/EndpointGenerator.php
@@ -596,9 +596,12 @@ EOD
                 }
 
                 $statements[] = new Stmt\If_(
-                    new Expr\BinaryOp\Identical(
-                        new Scalar\String_($contentType),
-                        new Expr\Variable('contentType')
+                    new Expr\BinaryOp\NotIdentical(
+                        new Expr\FuncCall(new Name('mb_strpos'), [
+                            new Arg(new Expr\Variable('contentType')),
+                            new Arg(new Scalar\String_($contentType)),
+                        ]),
+                        new Expr\ConstFetch(new Name('false'))
                     ),
                     [
                         'stmts' => [$returnStatement],

--- a/src/OpenApi/Tests/fixtures/array-definition/expected/Endpoint/TestSimple.php
+++ b/src/OpenApi/Tests/fixtures/array-definition/expected/Endpoint/TestSimple.php
@@ -29,7 +29,7 @@ class TestSimple extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Ja
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\BarItem[]', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Endpoint/TestNoTag.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Endpoint/TestNoTag.php
@@ -32,7 +32,7 @@ class TestNoTag extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jan
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (400 === $status && 'application/json' === $contentType) {
+        if (400 === $status && mb_strpos($contentType, 'application/json') !== false) {
             throw new \Jane\OpenApi\Tests\Expected\Exception\TestNoTagBadRequestException($serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error', 'json'));
         }
         if (404 === $status) {

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/CreatePets.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/CreatePets.php
@@ -32,7 +32,7 @@ class CreatePets extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Ja
         if (201 === $status) {
             return null;
         }
-        if ('application/json' === $contentType) {
+        if (mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
@@ -49,10 +49,10 @@ class ListPets extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Pet[]', 'json');
         }
-        if ('application/json' === $contentType) {
+        if (mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ShowPetById.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Endpoint/ShowPetById.php
@@ -39,10 +39,10 @@ class ShowPetById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Pet', 'json');
         }
-        if ('application/json' === $contentType) {
+        if (mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetEmptyTest.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetEmptyTest.php
@@ -29,7 +29,7 @@ class GetEmptyTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\EmptySpace', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTest.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTest.php
@@ -31,13 +31,13 @@ class GetTest extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Schema', 'json');
         }
-        if (400 === $status && 'application/json' === $contentType) {
+        if (400 === $status && mb_strpos($contentType, 'application/json') !== false) {
             throw new \Jane\OpenApi\Tests\Expected\Exception\GetTestBadRequestException($serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error', 'json'));
         }
-        if (404 === $status && 'application/json' === $contentType) {
+        if (404 === $status && mb_strpos($contentType, 'application/json') !== false) {
             throw new \Jane\OpenApi\Tests\Expected\Exception\GetTestNotFoundException($serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error', 'json'));
         }
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestById.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestById.php
@@ -41,13 +41,13 @@ class GetTestById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\TestIdGetResponse200', 'json');
         }
-        if (400 === $status && 'application/json' === $contentType) {
+        if (400 === $status && mb_strpos($contentType, 'application/json') !== false) {
             throw new \Jane\OpenApi\Tests\Expected\Exception\GetTestByIdBadRequestException($serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error', 'json'));
         }
-        if (404 === $status && 'application/json' === $contentType) {
+        if (404 === $status && mb_strpos($contentType, 'application/json') !== false) {
             throw new \Jane\OpenApi\Tests\Expected\Exception\GetTestByIdNotFoundException($serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Error', 'json'));
         }
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestList.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Endpoint/GetTestList.php
@@ -29,7 +29,7 @@ class GetTestList extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \J
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Schema[]', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Endpoint/TestReferenceResponse.php
@@ -29,7 +29,7 @@ class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint imp
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Api1\\Model\\Body', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/multi-specs/expected/Api2/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/multi-specs/expected/Api2/Endpoint/TestReferenceResponse.php
@@ -29,7 +29,7 @@ class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint imp
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Api1\\Model\\Body', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/no-reference-response/expected/Endpoint/Test.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-response/expected/Endpoint/Test.php
@@ -29,7 +29,7 @@ class Test extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\Ope
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (201 === $status && 'application/json' === $contentType) {
+        if (201 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\TestPostResponse201', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThing.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThing.php
@@ -29,7 +29,7 @@ class GetAnotherThing extends \Jane\OpenApiRuntime\Client\BaseEndpoint implement
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Thing', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThingById.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetAnotherThingById.php
@@ -29,7 +29,7 @@ class GetAnotherThingById extends \Jane\OpenApiRuntime\Client\BaseEndpoint imple
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Thing', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThings.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThings.php
@@ -29,7 +29,7 @@ class GetThings extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jan
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Thing[]', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThingsById.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Endpoint/GetThingsById.php
@@ -29,7 +29,7 @@ class GetThingsById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements 
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Thing[]', 'json');
         }
     }

--- a/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestRefArray.php
+++ b/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestRefArray.php
@@ -29,7 +29,7 @@ class TestRefArray extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return json_decode($body);
         }
     }

--- a/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi/Tests/fixtures/response-reference/expected/Endpoint/TestReferenceResponse.php
@@ -29,7 +29,7 @@ class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint imp
      */
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
-        if (200 === $status && 'application/json' === $contentType) {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
             return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\ResponseCommon', 'json');
         }
     }


### PR DESCRIPTION
When having Content-Type such as `application/json; charset=utf-8` we should extract first part and compare only first part.