### PR TITLE
Correct discriminator classname snake_case into camelCase for denormalization

### DIFF
--- a/src/OpenApi/Generator/Normalizer/DenormalizerGenerator.php
+++ b/src/OpenApi/Generator/Normalizer/DenormalizerGenerator.php
@@ -45,7 +45,7 @@ trait DenormalizerGenerator
                                 'denormalize',
                                 [
                                     new Expr\Variable('data'),
-                                    new Scalar\String_(sprintf('%s\\Model\\%s', $context->getCurrentSchema()->getNamespace(), $name)),
+                                    new Scalar\String_(sprintf('%s\\Model\\%s', $context->getCurrentSchema()->getNamespace(), $this->getNaming()->getClassName($name))),
                                     new Expr\Variable('format'),
                                     new Expr\Variable('context'),
                                 ]

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Client.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Model/CatInSnakeCase.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Model/CatInSnakeCase.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class CatInSnakeCase extends Pet
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $petType;
+    /**
+     * The measured skill for hunting
+     *
+     * @var string
+     */
+    protected $huntingSkill = 'lazy';
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getName() : string
+    {
+        return $this->name;
+    }
+    /**
+     * 
+     *
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name) : self
+    {
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getPetType() : string
+    {
+        return $this->petType;
+    }
+    /**
+     * 
+     *
+     * @param string $petType
+     *
+     * @return self
+     */
+    public function setPetType(string $petType) : self
+    {
+        $this->petType = $petType;
+        return $this;
+    }
+    /**
+     * The measured skill for hunting
+     *
+     * @return string
+     */
+    public function getHuntingSkill() : string
+    {
+        return $this->huntingSkill;
+    }
+    /**
+     * The measured skill for hunting
+     *
+     * @param string $huntingSkill
+     *
+     * @return self
+     */
+    public function setHuntingSkill(string $huntingSkill) : self
+    {
+        $this->huntingSkill = $huntingSkill;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Model/DogInSnakeCase.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Model/DogInSnakeCase.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class DogInSnakeCase extends Pet
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $petType;
+    /**
+     * the size of the pack the dog is from
+     *
+     * @var int
+     */
+    protected $packSize = 0;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getName() : string
+    {
+        return $this->name;
+    }
+    /**
+     * 
+     *
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name) : self
+    {
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getPetType() : string
+    {
+        return $this->petType;
+    }
+    /**
+     * 
+     *
+     * @param string $petType
+     *
+     * @return self
+     */
+    public function setPetType(string $petType) : self
+    {
+        $this->petType = $petType;
+        return $this;
+    }
+    /**
+     * the size of the pack the dog is from
+     *
+     * @return int
+     */
+    public function getPackSize() : int
+    {
+        return $this->packSize;
+    }
+    /**
+     * the size of the pack the dog is from
+     *
+     * @param int $packSize
+     *
+     * @return self
+     */
+    public function setPackSize(int $packSize) : self
+    {
+        $this->packSize = $packSize;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Model/Pet.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Model/Pet.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Pet
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $petType;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getName() : string
+    {
+        return $this->name;
+    }
+    /**
+     * 
+     *
+     * @param string $name
+     */
+    public function setName(string $name)
+    {
+        $this->name = $name;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getPetType() : string
+    {
+        return $this->petType;
+    }
+    /**
+     * 
+     *
+     * @param string $petType
+     */
+    public function setPetType(string $petType)
+    {
+        $this->petType = $petType;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/CatInSnakeCaseNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/CatInSnakeCaseNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class CatInSnakeCaseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\CatInSnakeCase';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\CatInSnakeCase';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\CatInSnakeCase();
+        if (property_exists($data, 'name')) {
+            $object->setName($data->{'name'});
+        }
+        if (property_exists($data, 'petType')) {
+            $object->setPetType($data->{'petType'});
+        }
+        if (property_exists($data, 'huntingSkill')) {
+            $object->setHuntingSkill($data->{'huntingSkill'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
+        if (null !== $object->getHuntingSkill()) {
+            $data->{'huntingSkill'} = $object->getHuntingSkill();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/DogInSnakeCaseNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/DogInSnakeCaseNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class DogInSnakeCaseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\DogInSnakeCase';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\DogInSnakeCase';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\DogInSnakeCase();
+        if (property_exists($data, 'name')) {
+            $object->setName($data->{'name'});
+        }
+        if (property_exists($data, 'petType')) {
+            $object->setPetType($data->{'petType'});
+        }
+        if (property_exists($data, 'packSize')) {
+            $object->setPackSize($data->{'packSize'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
+        if (null !== $object->getPackSize()) {
+            $data->{'packSize'} = $object->getPackSize();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new PetNormalizer();
+        $normalizers[] = new CatInSnakeCaseNormalizer();
+        $normalizers[] = new DogInSnakeCaseNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/PetNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/PetNormalizer.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class PetNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Pet';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Pet';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        if (property_exists($data, 'petType') and 'cat_in_snake_case' === $data->{'petType'}) {
+            return $this->denormalizer->denormalize($data, 'Jane\\OpenApi\\Tests\\Expected\\Model\\CatInSnakeCase', $format, $context);
+        }
+        if (property_exists($data, 'petType') and 'dog_in_snake_case' === $data->{'petType'}) {
+            return $this->denormalizer->denormalize($data, 'Jane\\OpenApi\\Tests\\Expected\\Model\\DogInSnakeCase', $format, $context);
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Pet();
+        if (property_exists($data, 'name')) {
+            $object->setName($data->{'name'});
+        }
+        if (property_exists($data, 'petType')) {
+            $object->setPetType($data->{'petType'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getPetType() and 'cat_in_snake_case' === $object->getPetType()) {
+            return $this->normalizer->normalize($object, $format, $context);
+        }
+        if (null !== $object->getPetType() and 'dog_in_snake_case' === $object->getPetType()) {
+            return $this->normalizer->normalize($object, $format, $context);
+        }
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/swagger.json
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/swagger.json
@@ -1,0 +1,81 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Pets",
+        "version": "1.0.0"
+    },
+    "paths": {},
+    "components": {
+        "schemas": {
+            "Pet": {
+                "type": "object",
+                "discriminator": {
+                    "propertyName": "petType"
+                },
+                "enum": ["cat_in_snake_case", "dog_in_snake_case"],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "petType": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "petType"
+                ]
+            },
+            "cat_in_snake_case": {
+                "description": "A representation of a cat",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pet"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "huntingSkill": {
+                                "type": "string",
+                                "description": "The measured skill for hunting",
+                                "default": "lazy",
+                                "enum": [
+                                    "clueless",
+                                    "lazy",
+                                    "adventurous",
+                                    "aggressive"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "huntingSkill"
+                        ]
+                    }
+                ]
+            },
+            "dog_in_snake_case": {
+                "description": "A representation of a dog",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pet"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "packSize": {
+                                "type": "integer",
+                                "format": "int32",
+                                "description": "the size of the pack the dog is from",
+                                "default": 0,
+                                "minimum": 0
+                            }
+                        },
+                        "required": [
+                            "packSize"
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to https://github.com/janephp/janephp/issues/113

When a discriminator written in snake_case has been generated, the classname remains in snake_case instead camelCase.

I would like to write the tests, do you have any recommendations ? 