### PR TITLE
[Psr18ClientGenerator] Check if path exists before using it

### DIFF
--- a/src/OpenApi/Generator/Psr18ClientGenerator.php
+++ b/src/OpenApi/Generator/Psr18ClientGenerator.php
@@ -115,13 +115,13 @@ class Psr18ClientGenerator extends ClientGenerator
             $url = parse_url($server->getUrl());
             $baseUri = '';
 
-            if (isset($url['host'])) {
+            if (\array_key_exists('host', $url)) {
                 $scheme = $url['scheme'] ?? 'https';
                 $baseUri = $scheme . '://' . trim($url['host'], '/');
                 $plugins[] = AddHostPlugin::class;
             }
 
-            if (null !== $url['path']) {
+            if (\array_key_exists('path', $url) && null !== $url['path']) {
                 $baseUri .= '/' . trim($url['path'], '/');
                 $plugins[] = AddPathPlugin::class;
             }


### PR DESCRIPTION
We are using [`parse_url`](https://www.php.net/manual/en/function.parse-url.php) function in `Psr18ClientGenerator` class. This function returns an array with "potential keys" (quoted from documentation). So we have to check if key exists before using it.