### PR TITLE
Fix reference in endpoint parameter schema

### DIFF
--- a/src/OpenApi/Generator/EndpointGenerator.php
+++ b/src/OpenApi/Generator/EndpointGenerator.php
@@ -140,6 +140,11 @@ abstract class EndpointGenerator
                 $parameter = $this->resolveParameter($parameter);
             }
 
+            if (!$parameter instanceof \stdClass && $parameter->getSchema() instanceof Reference) {
+                [$_, $schema] = $this->resolve($parameter->getSchema(), Schema::class);
+                $parameter->setSchema($schema);
+            }
+
             if ($parameter instanceof ParameterWithSchemaWithExampleInPath || $parameter instanceof ParameterWithSchemaWithExamplesInPath) {
                 $pathParams[] = $this->nonBodyParameterGenerator->generateMethodParameter($parameter, $context, $operation->getReference() . '/parameters/' . $key);
                 $pathParamsDoc[] = $this->nonBodyParameterGenerator->generateMethodDocParameter($parameter, $context, $operation->getReference() . '/parameters/' . $key);

--- a/src/OpenApi/Tests/fixtures/model-type-reference/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/model-type-reference/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/schema.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/model-type-reference/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/model-type-reference/expected/Client.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/model-type-reference/expected/Model/Model.php
+++ b/src/OpenApi/Tests/fixtures/model-type-reference/expected/Model/Model.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Model
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $foo;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $bar;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+    /**
+     * 
+     *
+     * @param string $foo
+     *
+     * @return self
+     */
+    public function setFoo(string $foo) : self
+    {
+        $this->foo = $foo;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getBar() : string
+    {
+        return $this->bar;
+    }
+    /**
+     * 
+     *
+     * @param string $bar
+     *
+     * @return self
+     */
+    public function setBar(string $bar) : self
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/model-type-reference/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-type-reference/expected/Normalizer/ModelNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Model';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Model';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Model();
+        if (property_exists($data, 'foo')) {
+            $object->setFoo($data->{'foo'});
+        }
+        if (property_exists($data, 'bar')) {
+            $object->setBar($data->{'bar'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/model-type-reference/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/model-type-reference/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new ModelNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/model-type-reference/schema.json
+++ b/src/OpenApi/Tests/fixtures/model-type-reference/schema.json
@@ -1,0 +1,26 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "",
+        "title": ""
+    },
+    "paths": {},
+    "components": {
+        "schemas": {
+            "Model": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "$ref": "#/components/schemas/Foo"
+                    },
+                    "bar": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Foo": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/parameter-type-reference/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/parameter-type-reference/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/schema.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/parameter-type-reference/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/parameter-type-reference/expected/Client.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    /**
+     * caca
+     *
+     * @param array $queryParameters {
+     *     @var string $bar 
+     * }
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function foo(array $queryParameters = array(), string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Endpoint\Foo($queryParameters), $fetch);
+    }
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/parameter-type-reference/expected/Endpoint/Foo.php
+++ b/src/OpenApi/Tests/fixtures/parameter-type-reference/expected/Endpoint/Foo.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Endpoint;
+
+class Foo extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    /**
+     * caca
+     *
+     * @param array $queryParameters {
+     *     @var string $bar 
+     * }
+     */
+    public function __construct(array $queryParameters = array())
+    {
+        $this->queryParameters = $queryParameters;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/foo';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(array('bar'));
+        $optionsResolver->setRequired(array('bar'));
+        $optionsResolver->setDefaults(array());
+        $optionsResolver->setAllowedTypes('bar', array('string'));
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        return null;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/parameter-type-reference/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/parameter-type-reference/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/parameter-type-reference/schema.json
+++ b/src/OpenApi/Tests/fixtures/parameter-type-reference/schema.json
@@ -1,0 +1,37 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "",
+        "title": ""
+    },
+    "paths": {
+        "/foo": {
+            "get": {
+                "operationId": "foo",
+                "description": "caca",
+                "parameters": [
+                    {
+                        "name": "bar",
+                        "in": "query",
+                        "schema": {
+                            "$ref": "#/components/schemas/Bar"
+                        },
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": "Default response"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Bar": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/response-type-reference/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/response-type-reference/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/schema.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/response-type-reference/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/response-type-reference/expected/Client.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Jane\OpenApi\Tests\Expected\Model\FooGetResponse200|\Psr\Http\Message\ResponseInterface
+     */
+    public function foo(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Endpoint\Foo(), $fetch);
+    }
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/response-type-reference/expected/Endpoint/Foo.php
+++ b/src/OpenApi/Tests/fixtures/response-type-reference/expected/Endpoint/Foo.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Endpoint;
+
+class Foo extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/foo';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\OpenApi\Tests\Expected\Model\FooGetResponse200
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
+            return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\FooGetResponse200', 'json');
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/response-type-reference/expected/Model/FooGetResponse200.php
+++ b/src/OpenApi/Tests/fixtures/response-type-reference/expected/Model/FooGetResponse200.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class FooGetResponse200
+{
+    /**
+     * 
+     *
+     * @var int
+     */
+    protected $id;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $bar;
+    /**
+     * 
+     *
+     * @return int
+     */
+    public function getId() : int
+    {
+        return $this->id;
+    }
+    /**
+     * 
+     *
+     * @param int $id
+     *
+     * @return self
+     */
+    public function setId(int $id) : self
+    {
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getBar() : string
+    {
+        return $this->bar;
+    }
+    /**
+     * 
+     *
+     * @param string $bar
+     *
+     * @return self
+     */
+    public function setBar(string $bar) : self
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/response-type-reference/expected/Normalizer/FooGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/response-type-reference/expected/Normalizer/FooGetResponse200Normalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FooGetResponse200Normalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\FooGetResponse200';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\FooGetResponse200';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\FooGetResponse200();
+        if (property_exists($data, 'id')) {
+            $object->setId($data->{'id'});
+        }
+        if (property_exists($data, 'bar')) {
+            $object->setBar($data->{'bar'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getId()) {
+            $data->{'id'} = $object->getId();
+        }
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/response-type-reference/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/response-type-reference/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new FooGetResponse200Normalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/response-type-reference/schema.json
+++ b/src/OpenApi/Tests/fixtures/response-type-reference/schema.json
@@ -1,0 +1,41 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "",
+        "title": ""
+    },
+    "paths": {
+        "/foo": {
+            "get": {
+                "operationId": "foo",
+                "responses": {
+                    "200": {
+                        "description": "Default response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer"
+                                        },
+                                        "bar": {
+                                            "$ref": "#/components/schemas/Bar"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Bar": {
+                "type": "string"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #108 

Will resolve reference inside the `schema` field of a parameter.