### PR TITLE
Conflict with jane < 4.5 for OpenApi runtime

### DIFF
--- a/src/OpenApi/composer.json
+++ b/src/OpenApi/composer.json
@@ -36,7 +36,8 @@
         "friendsofphp/php-cs-fixer": "To have a nice formatting of the generated files"
     },
     "conflict": {
-        "friendsofphp/php-cs-fixer": "<2.7.3|>=3.0"
+        "friendsofphp/php-cs-fixer": "<2.7.3|>=3.0",
+        "jane-php/open-api-runtime": "< 4.5"
     },
     "config": {
         "process-timeout": 1800,


### PR DESCRIPTION
We conflict for versions lower than 4.5 since it introduce PSR-18 Client Generation with some breaking changes.