### PR TITLE
Adding Proxy generation for readOnly

### DIFF
--- a/src/JsonSchema/Generator/Model/ConstructGenerator.php
+++ b/src/JsonSchema/Generator/Model/ConstructGenerator.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Jane\JsonSchema\Generator\Model;
+
+use Jane\JsonSchema\Generator\Context\Context;
+use Jane\JsonSchema\Generator\Naming;
+use Jane\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\JsonSchema\Guesser\Guess\Property;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Param;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar;
+
+trait ConstructGenerator
+{
+    /**
+     * The naming service.
+     *
+     * @return Naming
+     */
+    abstract protected function getNaming();
+
+    /**
+     * Return a model class.
+     *
+     * @param string $proxyFqdn
+     *
+     * @return Stmt\ClassMethod
+     */
+    protected function createConstruct(string $proxyFqdn, ClassGuess $class, Context $context): Stmt\ClassMethod
+    {
+        $proxyVariable = new Expr\Variable('proxy');
+        $propertiesVariable = new Expr\Variable('properties');
+
+        $methods = [
+            new Stmt\Expression(new Expr\Assign(
+                $propertiesVariable,
+                new Expr\MethodCall($proxyVariable, '__properties')
+            )),
+        ];
+
+        /** @var Property $property */
+        foreach ($class->getProperties() as $property) {
+            $propertyVar = new Expr\ArrayDimFetch(new Expr\Variable('properties'), new Scalar\String_($property->getName()));
+
+            list($normalizationStatements, $outputVar) = $property->getType()->createNormalizationStatement($context, $propertyVar);
+
+            $normalizationStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\PropertyFetch(new Expr\Variable('this'), sprintf("{'%s'}", $property->getPhpName())), $outputVar));
+
+            if ($property->isNullable()) {
+                $methods = array_merge($methods, $normalizationStatements);
+
+                continue;
+            }
+
+            $methods[] = new Stmt\If_(
+                new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $propertyVar),
+                [
+                    'stmts' => $normalizationStatements,
+                ]
+            );
+        }
+
+        return new Stmt\ClassMethod(
+            '__construct',
+            [
+                'type' => Stmt\Class_::MODIFIER_PUBLIC,
+                'params' => [new Param($proxyVariable, new Expr\ConstFetch(new Name('null')), $proxyFqdn)],
+                'stmts' => [
+                    new Stmt\If_(
+                        new Expr\Instanceof_($proxyVariable, new Name($proxyFqdn)),
+                        [
+                            'stmts' => $methods,
+                        ]
+                    ),
+                ],
+            ]
+        );
+    }
+}

--- a/src/JsonSchema/Generator/ModelGenerator.php
+++ b/src/JsonSchema/Generator/ModelGenerator.php
@@ -87,7 +87,9 @@ class ModelGenerator implements GeneratorInterface
     {
         $methods = [];
         $methods[] = $this->createGetter($property, $namespace, $required);
-        $methods[] = $this->createSetter($property, $namespace, $required);
+        if (!$property->isReadOnly()) {
+            $methods[] = $this->createSetter($property, $namespace, $required);
+        }
 
         return $methods;
     }

--- a/src/JsonSchema/Generator/Naming.php
+++ b/src/JsonSchema/Generator/Naming.php
@@ -85,6 +85,11 @@ class Naming
         return $name;
     }
 
+    public function getProxyName($name)
+    {
+        return sprintf('Proxy%s', $this->getClassName($name));
+    }
+
     /**
      * @param $name
      *

--- a/src/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/NormalizerGenerator.php
@@ -69,10 +69,10 @@ class NormalizerGenerator implements GeneratorInterface
             $proxyFqdn = sprintf('%s\\Proxy\\%s', $schema->getNamespace(), $this->getNaming()->getProxyName($class->getName()));
 
             $methods = [];
-            $methods[] = $this->createSupportsDenormalizationMethod($modelFqdn);
+            $methods[] = $this->createSupportsDenormalizationMethod($modelFqdn, $proxyFqdn, $hasReadOnlyProperty);
             $methods[] = $this->createSupportsNormalizationMethod($modelFqdn, $proxyFqdn, $hasReadOnlyProperty);
             $methods[] = $this->createDenormalizeMethod($modelFqdn, $context, $class, $hasReadOnlyProperty);
-            $methods[] = $this->createNormalizeMethod($modelFqdn, $context, $class, $hasReadOnlyProperty);
+            $methods[] = $this->createNormalizeMethod($modelFqdn, $proxyFqdn, $context, $class, $hasReadOnlyProperty);
 
             if ($this->useCacheableSupportsMethod) {
                 $methods[] = $this->createHasCacheableSupportsMethod();

--- a/src/JsonSchema/Generator/PropertyCheckTrait.php
+++ b/src/JsonSchema/Generator/PropertyCheckTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Jane\JsonSchema\Generator;
+
+use Jane\JsonSchema\Guesser\Guess\ClassGuess;
+
+trait PropertyCheckTrait
+{
+    public function hasReadOnlyProperty(ClassGuess $class): bool
+    {
+        foreach ($class->getProperties() as $property) {
+            if ($property->isReadOnly()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/JsonSchema/Generator/Proxy/ClassGenerator.php
+++ b/src/JsonSchema/Generator/Proxy/ClassGenerator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\JsonSchema\Generator\Proxy;
+
+use Jane\JsonSchema\Generator\Naming;
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+
+trait ClassGenerator
+{
+    /**
+     * The naming service.
+     *
+     * @return Naming
+     */
+    abstract protected function getNaming();
+
+    /**
+     * Return a model class.
+     *
+     * @param string $name
+     * @param Node[] $methods
+     * @param bool   $hasExtensions
+     *
+     * @return Stmt\Class_
+     */
+    protected function createProxy(string $name, string $namespace, array $methods): Stmt\Class_
+    {
+        return new Stmt\Class_(
+            new Name($this->getNaming()->getProxyName($name)),
+            [
+                'stmts' => $methods,
+                'extends' => new Name(sprintf('\\%s\\Model\\%s', $namespace, $this->getNaming()->getClassName($name))),
+            ]
+        );
+    }
+}

--- a/src/JsonSchema/Generator/Proxy/ConstructGenerator.php
+++ b/src/JsonSchema/Generator/Proxy/ConstructGenerator.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Jane\JsonSchema\Generator\Proxy;
+
+use Jane\JsonSchema\Generator\Context\Context;
+use Jane\JsonSchema\Generator\Naming;
+use Jane\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\JsonSchema\Guesser\Guess\Property;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Param;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar;
+
+trait ConstructGenerator
+{
+    /**
+     * The naming service.
+     *
+     * @return Naming
+     */
+    abstract protected function getNaming();
+
+    /**
+     * Return a model class.
+     *
+     * @param string $proxyFqdn
+     *
+     * @return Stmt\ClassMethod
+     */
+    protected function createConstruct(string $modelFdqn, ClassGuess $class, Context $context): Stmt\ClassMethod
+    {
+        $modelVariable = new Expr\Variable('model');
+        $propertiesVariable = new Expr\Variable('properties');
+
+        $methods = [
+            new Stmt\Expression(new Expr\Assign(
+                $propertiesVariable,
+                new Expr\MethodCall(new Expr\Variable('this'), '__properties')
+            )),
+        ];
+
+        /** @var Property $property */
+        foreach ($class->getProperties() as $property) {
+            $propertyVar = new Expr\MethodCall($modelVariable, $this->getNaming()->getPrefixedMethodName('get', $property->getPhpName()));
+
+            list($normalizationStatements, $outputVar) = $property->getType()->createNormalizationStatement($context, $propertyVar);
+
+            $normalizationStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\ArrayDimFetch(new Expr\Variable('properties'), new Scalar\String_($property->getName())), $outputVar));
+
+            if (!$property->isNullable()) {
+                $methods = array_merge($methods, $normalizationStatements);
+
+                continue;
+            }
+
+            $methods[] = new Stmt\If_(
+                new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $propertyVar),
+                [
+                    'stmts' => $normalizationStatements,
+                ]
+            );
+        }
+
+        return new Stmt\ClassMethod(
+            '__construct',
+            [
+                'type' => Stmt\Class_::MODIFIER_PUBLIC,
+                'params' => [new Param($modelVariable, new Expr\ConstFetch(new Name('null')), $modelFdqn)],
+                'stmts' => [
+                    new Stmt\If_(
+                        new Expr\Instanceof_($modelVariable, new Name($modelFdqn)),
+                        [
+                            'stmts' => $methods,
+                        ]
+                    ),
+                ],
+            ]
+        );
+    }
+}

--- a/src/JsonSchema/Generator/Proxy/PropertiesGenerator.php
+++ b/src/JsonSchema/Generator/Proxy/PropertiesGenerator.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\JsonSchema\Generator\Proxy;
+
+use Jane\JsonSchema\Generator\Naming;
+use Jane\JsonSchema\Guesser\Guess\Property;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar;
+
+trait PropertiesGenerator
+{
+    /**
+     * The naming service.
+     *
+     * @return Naming
+     */
+    abstract protected function getNaming();
+
+    /**
+     * @param array|Property[] $properties
+     */
+    protected function createProperties(array $properties): Stmt\ClassMethod
+    {
+        $arrayItems = [];
+        foreach ($properties as $property) {
+            $arrayItems[] = new Expr\ArrayItem(
+                new Expr\PropertyFetch(new Expr\Variable('this'), $property->getPhpName()),
+                new Scalar\String_($property->getName()),
+                true
+            );
+        }
+
+        return new Stmt\ClassMethod(
+            '__properties',
+            [
+                'type' => Stmt\Class_::MODIFIER_PUBLIC,
+                'stmts' => [
+                    new Stmt\Return_(
+                        new Expr\Array_($arrayItems, ['kind' => Expr\Array_::KIND_SHORT])
+                    ),
+                ],
+                'returnType' => 'array',
+            ]
+        );
+    }
+}

--- a/src/JsonSchema/Generator/ProxyGenerator.php
+++ b/src/JsonSchema/Generator/ProxyGenerator.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Jane\JsonSchema\Generator;
+
+use Jane\JsonSchema\Generator\Context\Context;
+use Jane\JsonSchema\Generator\Proxy\ClassGenerator;
+use Jane\JsonSchema\Generator\Proxy\PropertiesGenerator;
+use Jane\JsonSchema\Schema;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+
+class ProxyGenerator implements GeneratorInterface
+{
+    use ClassGenerator;
+    use PropertiesGenerator;
+
+    const FILE_TYPE_PROXY = 'proxy';
+
+    /**
+     * @var Naming Naming Service
+     */
+    protected $naming;
+
+    /**
+     * @param Naming $naming Naming Service
+     */
+    public function __construct(Naming $naming)
+    {
+        $this->naming = $naming;
+    }
+
+    /**
+     * The naming service.
+     *
+     * @return Naming
+     */
+    protected function getNaming()
+    {
+        return $this->naming;
+    }
+
+    /**
+     * Generate a proxy given a schema.
+     */
+    public function generate(Schema $schema, string $className, Context $context)
+    {
+        foreach ($schema->getClasses() as $class) {
+            $proxy = $this->createProxy($class->getName(), $schema->getNamespace(), [$this->createProperties($class->getProperties())]);
+            $namespace = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Proxy'), [$proxy]);
+
+            $className = $this->getNaming()->getProxyName($class->getName());
+            $schema->addFile(new File(sprintf('%s/Proxy/%s.php', $schema->getDirectory(), $className), $namespace, self::FILE_TYPE_PROXY));
+        }
+    }
+}

--- a/src/JsonSchema/Generator/ProxyGenerator.php
+++ b/src/JsonSchema/Generator/ProxyGenerator.php
@@ -45,11 +45,20 @@ class ProxyGenerator implements GeneratorInterface
     public function generate(Schema $schema, string $className, Context $context)
     {
         foreach ($schema->getClasses() as $class) {
-            $proxy = $this->createProxy($class->getName(), $schema->getNamespace(), [$this->createProperties($class->getProperties())]);
-            $namespace = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Proxy'), [$proxy]);
+            $hasReadOnlyProperty = false;
+            foreach ($class->getProperties() as $property) {
+                if ($property->isReadOnly()) {
+                    $hasReadOnlyProperty = true;
+                }
+            }
 
-            $className = $this->getNaming()->getProxyName($class->getName());
-            $schema->addFile(new File(sprintf('%s/Proxy/%s.php', $schema->getDirectory(), $className), $namespace, self::FILE_TYPE_PROXY));
+            if ($hasReadOnlyProperty) {
+                $proxy = $this->createProxy($class->getName(), $schema->getNamespace(), [$this->createProperties($class->getProperties())]);
+                $namespace = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Proxy'), [$proxy]);
+
+                $className = $this->getNaming()->getProxyName($class->getName());
+                $schema->addFile(new File(sprintf('%s/Proxy/%s.php', $schema->getDirectory(), $className), $namespace, self::FILE_TYPE_PROXY));
+            }
         }
     }
 }

--- a/src/JsonSchema/Generator/ProxyGenerator.php
+++ b/src/JsonSchema/Generator/ProxyGenerator.php
@@ -13,6 +13,7 @@ class ProxyGenerator implements GeneratorInterface
 {
     use ClassGenerator;
     use PropertiesGenerator;
+    use PropertyCheckTrait;
 
     const FILE_TYPE_PROXY = 'proxy';
 
@@ -45,14 +46,7 @@ class ProxyGenerator implements GeneratorInterface
     public function generate(Schema $schema, string $className, Context $context)
     {
         foreach ($schema->getClasses() as $class) {
-            $hasReadOnlyProperty = false;
-            foreach ($class->getProperties() as $property) {
-                if ($property->isReadOnly()) {
-                    $hasReadOnlyProperty = true;
-                }
-            }
-
-            if ($hasReadOnlyProperty) {
+            if ($this->hasReadOnlyProperty($class)) {
                 $proxy = $this->createProxy($class->getName(), $schema->getNamespace(), [$this->createProperties($class->getProperties())]);
                 $namespace = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Proxy'), [$proxy]);
 

--- a/src/JsonSchema/Guesser/Guess/Property.php
+++ b/src/JsonSchema/Guesser/Guess/Property.php
@@ -44,7 +44,10 @@ class Property
      */
     private $phpName;
 
-    public function __construct($object, string $name, string $reference, bool $nullable = false, Type $type = null, string $description = null, $default = null)
+    /** @var bool */
+    private $readOnly;
+
+    public function __construct($object, string $name, string $reference, bool $nullable = false, Type $type = null, string $description = null, $default = null, bool $readOnly = false)
     {
         $this->name = $name;
         $this->object = $object;
@@ -53,6 +56,7 @@ class Property
         $this->type = $type;
         $this->description = $description;
         $this->default = $default;
+        $this->readOnly = $readOnly;
     }
 
     public function setPhpName(string $name)
@@ -103,5 +107,10 @@ class Property
     public function getDefault()
     {
         return $this->default;
+    }
+
+    public function isReadOnly(): bool
+    {
+        return $this->readOnly;
     }
 }

--- a/src/JsonSchema/Guesser/JsonSchema/ObjectGuesser.php
+++ b/src/JsonSchema/Guesser/JsonSchema/ObjectGuesser.php
@@ -97,7 +97,7 @@ class ObjectGuesser implements GuesserInterface, PropertiesGuesserInterface, Typ
 
             $nullable = $this->isPropertyNullable($propertyObj);
 
-            $properties[$key] = new Property($property, $key, $reference . '/properties/' . $key, $nullable, null, $propertyObj->getDescription(), $propertyObj->getDefault());
+            $properties[$key] = new Property($property, $key, $reference . '/properties/' . $key, $nullable, null, $propertyObj->getDescription(), $propertyObj->getDefault(), $propertyObj->getReadOnly());
         }
 
         return $properties;

--- a/src/JsonSchema/Jane.php
+++ b/src/JsonSchema/Jane.php
@@ -7,6 +7,7 @@ use Jane\JsonSchema\Generator\Context\Context;
 use Jane\JsonSchema\Generator\ModelGenerator;
 use Jane\JsonSchema\Generator\Naming;
 use Jane\JsonSchema\Generator\NormalizerGenerator;
+use Jane\JsonSchema\Generator\ProxyGenerator;
 use Jane\JsonSchema\Guesser\ChainGuesser;
 use Jane\JsonSchema\Guesser\JsonSchema\JsonSchemaGuesserFactory;
 use Jane\JsonSchema\Normalizer\NormalizerFactory;
@@ -98,10 +99,12 @@ class Jane extends ChainGenerator
         $naming = new Naming();
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
         $modelGenerator = new ModelGenerator($naming, $parser);
+        $proxyGenerator = new ProxyGenerator($naming);
         $normGenerator = new NormalizerGenerator($naming, $options['reference'], $options['use-cacheable-supports-method'] ?? false);
 
         $self = new self($serializer, $chainGuesser, $naming, $options['strict']);
         $self->addGenerator($modelGenerator);
+        $self->addGenerator($proxyGenerator);
         $self->addGenerator($normGenerator);
 
         return $self;

--- a/src/JsonSchema/Tests/fixtures/read-only/.jane
+++ b/src/JsonSchema/Tests/fixtures/read-only/.jane
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'json-schema-file' => __DIR__ . '/schema.json',
+    'root-class' => 'Test',
+    'namespace' => 'Jane\JsonSchema\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Model/Test.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Model;
+
+class Test
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $token;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $email;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getToken() : string
+    {
+        return $this->token;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getEmail() : string
+    {
+        return $this->email;
+    }
+    /**
+     * 
+     *
+     * @param string $email
+     *
+     * @return self
+     */
+    public function setEmail(string $email) : self
+    {
+        $this->email = $email;
+        return $this;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Model/Test.php
@@ -16,6 +16,18 @@ class Test
      * @var string
      */
     protected $email;
+    public function __construct(\Jane\JsonSchema\Tests\Expected\Proxy\ProxyTest $proxy = null)
+    {
+        if ($proxy instanceof \Jane\JsonSchema\Tests\Expected\Proxy\ProxyTest) {
+            $properties = $proxy->__properties();
+            if (null !== $properties['__token']) {
+                $this->{'token'} = $properties['__token'];
+            }
+            if (null !== $properties['email']) {
+                $this->{'email'} = $properties['email'];
+            }
+        }
+    }
     /**
      * 
      *

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/NormalizerFactory.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new \Jane\JsonSchemaRuntime\Normalizer\ReferenceNormalizer();
+        $normalizers[] = new TestNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/TestNormalizer.php
@@ -17,11 +17,11 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     use NormalizerAwareTrait;
     public function supportsDenormalization($data, $type, $format = null)
     {
-        return $type === 'Jane\\JsonSchema\\Tests\\Expected\\Model\\Test';
+        return $type === 'Jane\\JsonSchema\\Tests\\Expected\\Model\\Test' || $type === 'Jane\\JsonSchema\\Tests\\Expected\\Proxy\\ProxyTest';
     }
     public function supportsNormalization($data, $format = null)
     {
-        return $data instanceof \Jane\JsonSchema\Tests\Expected\Proxy\ProxyTest;
+        return $data instanceof \Jane\JsonSchema\Tests\Expected\Model\Test || $data instanceof \Jane\JsonSchema\Tests\Expected\Proxy\ProxyTest;
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {
@@ -42,10 +42,13 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (property_exists($data, 'email')) {
             $properties['email'] = $data->{'email'};
         }
-        return $object;
+        return new \Jane\JsonSchema\Tests\Expected\Model\Test($object);
     }
     public function normalize($object, $format = null, array $context = array())
     {
+        if ($object instanceof \Jane\JsonSchema\Tests\Expected\Model\Test) {
+            $object = new \Jane\JsonSchema\Tests\Expected\Proxy\ProxyTest($object);
+        }
         $data = new \stdClass();
         $properties = $object->__properties();
         if (null !== $properties['__token']) {

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/TestNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Jane\JsonSchema\Tests\Expected\Proxy\ProxyTest;
+class TestNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\JsonSchema\\Tests\\Expected\\Model\\Test';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\JsonSchema\Tests\Expected\Proxy\ProxyTest;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        if (isset($data->{'$ref'})) {
+            return new Reference($data->{'$ref'}, $context['document-origin']);
+        }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
+        $object = new ProxyTest();
+        $properties = $object->__properties();
+        if (property_exists($data, '__token')) {
+            $properties['__token'] = $data->{'__token'};
+        }
+        if (property_exists($data, 'email')) {
+            $properties['email'] = $data->{'email'};
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        $properties = $object->__properties();
+        if (null !== $properties['__token']) {
+            $data->{'__token'} = $properties['__token'];
+        }
+        if (null !== $properties['email']) {
+            $data->{'email'} = $properties['email'];
+        }
+        return $data;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Proxy/ProxyTest.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Proxy/ProxyTest.php
@@ -4,6 +4,14 @@ namespace Jane\JsonSchema\Tests\Expected\Proxy;
 
 class ProxyTest extends \Jane\JsonSchema\Tests\Expected\Model\Test
 {
+    public function __construct(\Jane\JsonSchema\Tests\Expected\Model\Test $model = null)
+    {
+        if ($model instanceof \Jane\JsonSchema\Tests\Expected\Model\Test) {
+            $properties = $this->__properties();
+            $properties['__token'] = $model->getToken();
+            $properties['email'] = $model->getEmail();
+        }
+    }
     public function __properties() : array
     {
         return ['__token' => &$this->token, 'email' => &$this->email];

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Proxy/ProxyTest.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Proxy/ProxyTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Proxy;
+
+class ProxyTest extends \Jane\JsonSchema\Tests\Expected\Model\Test
+{
+    public function __properties() : array
+    {
+        return ['__token' => &$this->token, 'email' => &$this->email];
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/read-only/schema.json
+++ b/src/JsonSchema/Tests/fixtures/read-only/schema.json
@@ -1,0 +1,12 @@
+{
+    "type": "object",
+    "properties": {
+        "token": {
+            "type": "string",
+            "readOnly": true
+        },
+        "email": {
+            "type": "string"
+        }
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/read-only/schema.json
+++ b/src/JsonSchema/Tests/fixtures/read-only/schema.json
@@ -1,7 +1,7 @@
 {
     "type": "object",
     "properties": {
-        "token": {
+        "__token": {
             "type": "string",
             "readOnly": true
         },

--- a/src/OpenApi/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/OpenApi/Generator/Normalizer/NormalizerGenerator.php
@@ -59,20 +59,29 @@ trait NormalizerGenerator
      * We want stricly same class for OpenApi Normalizers since we can have inheritance and this could avoid
      * normalization to use child classes.
      */
-    protected function createSupportsNormalizationMethod($modelFqdn)
+    protected function createSupportsNormalizationMethod(string $modelFqdn, string $proxyFqdn, bool $useProxy)
     {
+        $statements = [];
+
+        if ($useProxy) {
+            $statements[] = new Stmt\Return_(new Expr\BinaryOp\Identical(
+                new Expr\FuncCall(new Name('get_class'), [new Expr\Variable('data')]),
+                new Scalar\String_($proxyFqdn)
+            ));
+        } else {
+            $statements[] = new Stmt\Return_(new Expr\BinaryOp\Identical(
+                new Expr\FuncCall(new Name('get_class'), [new Expr\Variable('data')]),
+                new Scalar\String_($modelFqdn)
+            ));
+        }
+
         return new Stmt\ClassMethod('supportsNormalization', [
             'type' => Stmt\Class_::MODIFIER_PUBLIC,
             'params' => [
                 new Param(new Expr\Variable('data')),
                 new Param(new Expr\Variable('format'), new Expr\ConstFetch(new Name('null'))),
             ],
-            'stmts' => [
-                new Stmt\Return_(new Expr\BinaryOp\Identical(
-                    new Expr\FuncCall(new Name('get_class'), [new Expr\Variable('data')]),
-                    new Scalar\String_($modelFqdn)
-                )),
-            ],
+            'stmts' => $statements,
         ]);
     }
 }

--- a/src/OpenApi/JaneOpenApi.php
+++ b/src/OpenApi/JaneOpenApi.php
@@ -4,6 +4,7 @@ namespace Jane\OpenApi;
 
 use Jane\JsonSchema\Generator\ChainGenerator;
 use Jane\JsonSchema\Generator\Context\Context;
+use Jane\JsonSchema\Generator\ProxyGenerator;
 use Jane\OpenApi\Generator\ModelGenerator;
 use Jane\JsonSchema\Generator\Naming;
 use Jane\OpenApi\Generator\NormalizerGenerator;
@@ -141,6 +142,7 @@ class JaneOpenApi extends ChainGenerator
         $naming = new Naming();
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
         $modelGenerator = new ModelGenerator($naming, $parser);
+        $proxyGenerator = new ProxyGenerator($naming);
         $normGenerator = new NormalizerGenerator($naming, $options['reference'] ?? false, $options['use-cacheable-supports-method'] ?? false);
 
         $self = new self(
@@ -151,6 +153,7 @@ class JaneOpenApi extends ChainGenerator
         );
 
         $self->addGenerator($modelGenerator);
+        $self->addGenerator($proxyGenerator);
         $self->addGenerator($normGenerator);
 
         foreach ($generators as $generator) {


### PR DESCRIPTION
Related to #133 
Adding Proxy to models that are readOnly.

From specs:
> Relevant only for Schema "properties" definitions. Declares the property as "read only". This means that it MAY be sent as part of a response but SHOULD NOT be sent as part of the request. If the property is marked as readOnly being true and is in the required list, the required will take effect on the response only. A property MUST NOT be marked as both readOnly and writeOnly being true. Default value is false.

### Todo
- [x] Proxy generation
- [x] Normalizer using Proxy
- [x] Use proxy only when readOnly one of Model properties has `readOnly: true`
