### PR TITLE
do not type hint mixed parameter types for request bodies in endpoint constructor and clients operations method

### DIFF
--- a/src/OpenApi/Generator/RequestBodyContent/AbstractBodyContentGenerator.php
+++ b/src/OpenApi/Generator/RequestBodyContent/AbstractBodyContentGenerator.php
@@ -16,6 +16,8 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 abstract class AbstractBodyContentGenerator implements RequestBodyContentGeneratorInterface
 {
+    public const PHP_TYPE_MIXED = 'mixed';
+
     private $denormalizer;
 
     public function __construct(DenormalizerInterface $denormalizer)
@@ -184,7 +186,7 @@ abstract class AbstractBodyContentGenerator implements RequestBodyContentGenerat
         ];
 
         if (!isset($convertArray[$type]) || !isset($convertArray[$type][$format])) {
-            return ['mixed'];
+            return [self::PHP_TYPE_MIXED];
         }
 
         return $convertArray[$type][$format];

--- a/src/OpenApi/Generator/RequestBodyGenerator.php
+++ b/src/OpenApi/Generator/RequestBodyGenerator.php
@@ -45,7 +45,7 @@ class RequestBodyGenerator
         $paramType = null;
         if (\count($types) === 1 && $types[0] !== AbstractBodyContentGenerator::PHP_TYPE_MIXED) {
             $paramType = $types[0];
-        };
+        }
 
         if ($onlyArray) {
             $paramType = 'array';

--- a/src/OpenApi/Generator/RequestBodyGenerator.php
+++ b/src/OpenApi/Generator/RequestBodyGenerator.php
@@ -3,6 +3,7 @@
 namespace Jane\OpenApi\Generator;
 
 use Jane\JsonSchema\Generator\Context\Context;
+use Jane\OpenApi\Generator\RequestBodyContent\AbstractBodyContentGenerator;
 use Jane\OpenApi\JsonSchema\Model\Reference;
 use Jane\OpenApi\JsonSchema\Model\RequestBody;
 use PhpParser\Node\Expr;
@@ -41,7 +42,10 @@ class RequestBodyGenerator
 
         $name = 'requestBody';
         [$types, $onlyArray] = $this->getTypes($requestBody, $reference, $context);
-        $paramType = \count($types) === 1 ? $types[0] : null;
+        $paramType = null;
+        if (\count($types) === 1 && $types[0] !== AbstractBodyContentGenerator::PHP_TYPE_MIXED) {
+            $paramType = $types[0];
+        };
 
         if ($onlyArray) {
             $paramType = 'array';

--- a/src/OpenApi/Tests/fixtures/any-of-mixed-request-body-parameter-type/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/any-of-mixed-request-body-parameter-type/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Client.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    /**
+     * 
+     *
+     * @param mixed $requestBody 
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function testMixedRequestBody($requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Endpoint\TestMixedRequestBody($requestBody), $fetch);
+    }
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Endpoint/TestMixedRequestBody.php
+++ b/src/OpenApi/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Endpoint/TestMixedRequestBody.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Endpoint;
+
+class TestMixedRequestBody extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    /**
+     * 
+     *
+     * @param mixed $requestBody 
+     */
+    public function __construct($requestBody)
+    {
+        $this->body = $requestBody;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'POST';
+    }
+    public function getUri() : string
+    {
+        return '/test-simple';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        if (isset($this->body)) {
+            return array(array('Content-Type' => array('application/json')), json_encode($this->body));
+        }
+        return array(array(), null);
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status) {
+            return null;
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/any-of-mixed-request-body-parameter-type/openapi.json
+++ b/src/OpenApi/Tests/fixtures/any-of-mixed-request-body-parameter-type/openapi.json
@@ -1,0 +1,58 @@
+{
+    "openapi": "3.0.0",
+    "paths": {
+        "/test-simple": {
+            "post": {
+                "operationId": "Test Mixed Request Body",
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                },
+                "tags": [
+                    "Test."
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FooBar"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        }
+    },
+    "info": {
+        "version": "",
+        "title": ""
+    },
+    "components": {
+        "schemas": {
+            "FooBar": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "title": "Foo",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "title": "Bar",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
see #157 

Resolved parameter types for response bodies of type `mixed` are used as type hints in endpoint constructor and related client operation method signatures.

This PR fixes this by using the default parameter type `null` for these cases.