### PR TITLE
Fix missing nullable fields after normalize

### DIFF
--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -99,12 +99,14 @@ trait NormalizerGenerator
 
             $normalizationStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\PropertyFetch($dataVariable, sprintf("{'%s'}", $property->getName())), $outputVar));
 
-            if ($property->isNullable() || (!$property->isNullable() && $context->isStrict()) || ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) || ($property->getType()->getName() === Type::TYPE_NULL)) {
-                if ($property->getType() instanceof DateTimeType ||
-                    $property->getType() instanceof MapType ||
-                    $property->getType() instanceof MultipleType ||
-                    $property->getType() instanceof ObjectType ||
-                    $property->getType() instanceof PatternMultipleType) {
+            if ($property->isNullable() || ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) || ($property->getType()->getName() === Type::TYPE_NULL)) {
+                if ($property->getType()->getName() !== Type::TYPE_NULL &&
+                    (
+                        $property->getType() instanceof DateTimeType ||
+                        $property->getType() instanceof MapType ||
+                        $property->getType() instanceof ObjectType ||
+                        $property->getType() instanceof PatternMultipleType
+                    )) {
                     $statements[] = new Stmt\If_(
                         new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $propertyVar),
                         [

--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -95,7 +95,7 @@ trait NormalizerGenerator
 
             $normalizationStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\PropertyFetch($dataVariable, sprintf("{'%s'}", $property->getName())), $outputVar));
 
-            if ((!$property->isNullable() && $context->isStrict()) || ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) || ($property->getType()->getName() === Type::TYPE_NULL)) {
+            if ($property->isNullable() || (!$property->isNullable() && $context->isStrict()) || ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) || ($property->getType()->getName() === Type::TYPE_NULL)) {
                 $statements = array_merge($statements, $normalizationStatements);
 
                 continue;

--- a/src/JsonSchema/Tests/fixtures/additional-properties/expected/Normalizer/AdditionalPropertiesNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/additional-properties/expected/Normalizer/AdditionalPropertiesNormalizer.php
@@ -49,7 +49,9 @@ class AdditionalPropertiesNormalizer implements DenormalizerInterface, Normalize
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         foreach ($object as $key => $value) {
             if (preg_match('/.*/', $key)) {
                 $data->{$key} = $value;

--- a/src/JsonSchema/Tests/fixtures/additional-properties/expected/Normalizer/PatternPropertiesNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/additional-properties/expected/Normalizer/PatternPropertiesNormalizer.php
@@ -52,7 +52,9 @@ class PatternPropertiesNormalizer implements DenormalizerInterface, NormalizerIn
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         foreach ($object as $key => $value) {
             if (preg_match('/x-.*/', $key)) {
                 $data->{$key} = $value;

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BarNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BarNormalizer.php
@@ -39,8 +39,12 @@ class BarNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazBazNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazBazNormalizer.php
@@ -36,7 +36,9 @@ class BazBazNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'baz'} = $object->getBaz();
+        if (null !== $object->getBaz()) {
+            $data->{'baz'} = $object->getBaz();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazNormalizer.php
@@ -42,18 +42,14 @@ class BazNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         if (null !== $object->getBar()) {
             $data->{'Bar'} = $this->normalizer->normalize($object->getBar(), 'json', $context);
         }
-        else {
-            $data->{'Bar'} = null;
-        }
         if (null !== $object->getBaz()) {
             $data->{'Baz'} = $this->normalizer->normalize($object->getBaz(), 'json', $context);
-        }
-        else {
-            $data->{'Baz'} = null;
         }
         return $data;
     }

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazNormalizer.php
@@ -43,8 +43,18 @@ class BazNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     {
         $data = new \stdClass();
         $data->{'foo'} = $object->getFoo();
-        $data->{'Bar'} = $this->normalizer->normalize($object->getBar(), 'json', $context);
-        $data->{'Baz'} = $this->normalizer->normalize($object->getBaz(), 'json', $context);
+        if (null !== $object->getBar()) {
+            $data->{'Bar'} = $this->normalizer->normalize($object->getBar(), 'json', $context);
+        }
+        else {
+            $data->{'Bar'} = null;
+        }
+        if (null !== $object->getBaz()) {
+            $data->{'Baz'} = $this->normalizer->normalize($object->getBaz(), 'json', $context);
+        }
+        else {
+            $data->{'Baz'} = null;
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/ChildtypeNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/ChildtypeNormalizer.php
@@ -39,8 +39,12 @@ class ChildtypeNormalizer implements DenormalizerInterface, NormalizerInterface,
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'childProperty'} = $object->getChildProperty();
-        $data->{'inheritedProperty'} = $object->getInheritedProperty();
+        if (null !== $object->getChildProperty()) {
+            $data->{'childProperty'} = $object->getChildProperty();
+        }
+        if (null !== $object->getInheritedProperty()) {
+            $data->{'inheritedProperty'} = $object->getInheritedProperty();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/FooNormalizer.php
@@ -36,7 +36,9 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/OtherchildtypeNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/OtherchildtypeNormalizer.php
@@ -39,8 +39,12 @@ class OtherchildtypeNormalizer implements DenormalizerInterface, NormalizerInter
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'inheritedProperty'} = $object->getInheritedProperty();
-        $data->{'childProperty'} = $object->getChildProperty();
+        if (null !== $object->getInheritedProperty()) {
+            $data->{'inheritedProperty'} = $object->getInheritedProperty();
+        }
+        if (null !== $object->getChildProperty()) {
+            $data->{'childProperty'} = $object->getChildProperty();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/ParenttypeNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/ParenttypeNormalizer.php
@@ -36,7 +36,9 @@ class ParenttypeNormalizer implements DenormalizerInterface, NormalizerInterface
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'inheritedProperty'} = $object->getInheritedProperty();
+        if (null !== $object->getInheritedProperty()) {
+            $data->{'inheritedProperty'} = $object->getInheritedProperty();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/TestNormalizer.php
@@ -39,8 +39,18 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'child'} = $this->normalizer->normalize($object->getChild(), 'json', $context);
-        $data->{'parent'} = $this->normalizer->normalize($object->getParent(), 'json', $context);
+        if (null !== $object->getChild()) {
+            $data->{'child'} = $this->normalizer->normalize($object->getChild(), 'json', $context);
+        }
+        else {
+            $data->{'child'} = null;
+        }
+        if (null !== $object->getParent()) {
+            $data->{'parent'} = $this->normalizer->normalize($object->getParent(), 'json', $context);
+        }
+        else {
+            $data->{'parent'} = null;
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/TestNormalizer.php
@@ -42,14 +42,8 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getChild()) {
             $data->{'child'} = $this->normalizer->normalize($object->getChild(), 'json', $context);
         }
-        else {
-            $data->{'child'} = null;
-        }
         if (null !== $object->getParent()) {
             $data->{'parent'} = $this->normalizer->normalize($object->getParent(), 'json', $context);
-        }
-        else {
-            $data->{'parent'} = null;
         }
         return $data;
     }

--- a/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
@@ -62,23 +62,38 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'date'} = $object->getDate()->format("l, d-M-y H:i:s T");
-        $value = $object->getDateOrNull();
-        if (is_object($object->getDateOrNull())) {
-            $value = $object->getDateOrNull()->format("l, d-M-y H:i:s T");
-        } elseif (is_null($object->getDateOrNull())) {
+        if (null !== $object->getDate()) {
+            $data->{'date'} = $object->getDate()->format("l, d-M-y H:i:s T");
+        }
+        else {
+            $data->{'date'} = null;
+        }
+        if (null !== $object->getDateOrNull()) {
             $value = $object->getDateOrNull();
+            if (is_object($object->getDateOrNull())) {
+                $value = $object->getDateOrNull()->format("l, d-M-y H:i:s T");
+            } elseif (is_null($object->getDateOrNull())) {
+                $value = $object->getDateOrNull();
+            }
+            $data->{'dateOrNull'} = $value;
         }
-        $data->{'dateOrNull'} = $value;
-        $value_1 = $object->getDateOrNullOrInt();
-        if (is_object($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt()->format("l, d-M-y H:i:s T");
-        } elseif (is_null($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt();
-        } elseif (is_int($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt();
+        else {
+            $data->{'dateOrNull'} = null;
         }
-        $data->{'dateOrNullOrInt'} = $value_1;
+        if (null !== $object->getDateOrNullOrInt()) {
+            $value_1 = $object->getDateOrNullOrInt();
+            if (is_object($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt()->format("l, d-M-y H:i:s T");
+            } elseif (is_null($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            } elseif (is_int($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            }
+            $data->{'dateOrNullOrInt'} = $value_1;
+        }
+        else {
+            $data->{'dateOrNullOrInt'} = null;
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
@@ -65,35 +65,22 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getDate()) {
             $data->{'date'} = $object->getDate()->format("l, d-M-y H:i:s T");
         }
-        else {
-            $data->{'date'} = null;
-        }
-        if (null !== $object->getDateOrNull()) {
+        $value = $object->getDateOrNull();
+        if (is_object($object->getDateOrNull())) {
+            $value = $object->getDateOrNull()->format("l, d-M-y H:i:s T");
+        } elseif (is_null($object->getDateOrNull())) {
             $value = $object->getDateOrNull();
-            if (is_object($object->getDateOrNull())) {
-                $value = $object->getDateOrNull()->format("l, d-M-y H:i:s T");
-            } elseif (is_null($object->getDateOrNull())) {
-                $value = $object->getDateOrNull();
-            }
-            $data->{'dateOrNull'} = $value;
         }
-        else {
-            $data->{'dateOrNull'} = null;
-        }
-        if (null !== $object->getDateOrNullOrInt()) {
+        $data->{'dateOrNull'} = $value;
+        $value_1 = $object->getDateOrNullOrInt();
+        if (is_object($object->getDateOrNullOrInt())) {
+            $value_1 = $object->getDateOrNullOrInt()->format("l, d-M-y H:i:s T");
+        } elseif (is_null($object->getDateOrNullOrInt())) {
             $value_1 = $object->getDateOrNullOrInt();
-            if (is_object($object->getDateOrNullOrInt())) {
-                $value_1 = $object->getDateOrNullOrInt()->format("l, d-M-y H:i:s T");
-            } elseif (is_null($object->getDateOrNullOrInt())) {
-                $value_1 = $object->getDateOrNullOrInt();
-            } elseif (is_int($object->getDateOrNullOrInt())) {
-                $value_1 = $object->getDateOrNullOrInt();
-            }
-            $data->{'dateOrNullOrInt'} = $value_1;
+        } elseif (is_int($object->getDateOrNullOrInt())) {
+            $value_1 = $object->getDateOrNullOrInt();
         }
-        else {
-            $data->{'dateOrNullOrInt'} = null;
-        }
+        $data->{'dateOrNullOrInt'} = $value_1;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
@@ -62,23 +62,38 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'date'} = $object->getDate()->format("Y-m-d\TH:i:sP");
-        $value = $object->getDateOrNull();
-        if (is_object($object->getDateOrNull())) {
-            $value = $object->getDateOrNull()->format("Y-m-d\TH:i:sP");
-        } elseif (is_null($object->getDateOrNull())) {
+        if (null !== $object->getDate()) {
+            $data->{'date'} = $object->getDate()->format("Y-m-d\TH:i:sP");
+        }
+        else {
+            $data->{'date'} = null;
+        }
+        if (null !== $object->getDateOrNull()) {
             $value = $object->getDateOrNull();
+            if (is_object($object->getDateOrNull())) {
+                $value = $object->getDateOrNull()->format("Y-m-d\TH:i:sP");
+            } elseif (is_null($object->getDateOrNull())) {
+                $value = $object->getDateOrNull();
+            }
+            $data->{'dateOrNull'} = $value;
         }
-        $data->{'dateOrNull'} = $value;
-        $value_1 = $object->getDateOrNullOrInt();
-        if (is_object($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt()->format("Y-m-d\TH:i:sP");
-        } elseif (is_null($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt();
-        } elseif (is_int($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt();
+        else {
+            $data->{'dateOrNull'} = null;
         }
-        $data->{'dateOrNullOrInt'} = $value_1;
+        if (null !== $object->getDateOrNullOrInt()) {
+            $value_1 = $object->getDateOrNullOrInt();
+            if (is_object($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt()->format("Y-m-d\TH:i:sP");
+            } elseif (is_null($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            } elseif (is_int($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            }
+            $data->{'dateOrNullOrInt'} = $value_1;
+        }
+        else {
+            $data->{'dateOrNullOrInt'} = null;
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
@@ -65,35 +65,22 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getDate()) {
             $data->{'date'} = $object->getDate()->format("Y-m-d\TH:i:sP");
         }
-        else {
-            $data->{'date'} = null;
-        }
-        if (null !== $object->getDateOrNull()) {
+        $value = $object->getDateOrNull();
+        if (is_object($object->getDateOrNull())) {
+            $value = $object->getDateOrNull()->format("Y-m-d\TH:i:sP");
+        } elseif (is_null($object->getDateOrNull())) {
             $value = $object->getDateOrNull();
-            if (is_object($object->getDateOrNull())) {
-                $value = $object->getDateOrNull()->format("Y-m-d\TH:i:sP");
-            } elseif (is_null($object->getDateOrNull())) {
-                $value = $object->getDateOrNull();
-            }
-            $data->{'dateOrNull'} = $value;
         }
-        else {
-            $data->{'dateOrNull'} = null;
-        }
-        if (null !== $object->getDateOrNullOrInt()) {
+        $data->{'dateOrNull'} = $value;
+        $value_1 = $object->getDateOrNullOrInt();
+        if (is_object($object->getDateOrNullOrInt())) {
+            $value_1 = $object->getDateOrNullOrInt()->format("Y-m-d\TH:i:sP");
+        } elseif (is_null($object->getDateOrNullOrInt())) {
             $value_1 = $object->getDateOrNullOrInt();
-            if (is_object($object->getDateOrNullOrInt())) {
-                $value_1 = $object->getDateOrNullOrInt()->format("Y-m-d\TH:i:sP");
-            } elseif (is_null($object->getDateOrNullOrInt())) {
-                $value_1 = $object->getDateOrNullOrInt();
-            } elseif (is_int($object->getDateOrNullOrInt())) {
-                $value_1 = $object->getDateOrNullOrInt();
-            }
-            $data->{'dateOrNullOrInt'} = $value_1;
+        } elseif (is_int($object->getDateOrNullOrInt())) {
+            $value_1 = $object->getDateOrNullOrInt();
         }
-        else {
-            $data->{'dateOrNullOrInt'} = null;
-        }
+        $data->{'dateOrNullOrInt'} = $value_1;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/deep-object/expected/Normalizer/TestFooItemNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/deep-object/expected/Normalizer/TestFooItemNormalizer.php
@@ -42,7 +42,9 @@ class TestFooItemNormalizer implements DenormalizerInterface, NormalizerInterfac
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/deep-object/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/deep-object/expected/Normalizer/TestNormalizer.php
@@ -46,11 +46,13 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $values = array();
-        foreach ($object->getFoo() as $value) {
-            $values[] = $this->normalizer->normalize($value, 'json', $context);
+        if (null !== $object->getFoo()) {
+            $values = array();
+            foreach ($object->getFoo() as $value) {
+                $values[] = $this->normalizer->normalize($value, 'json', $context);
+            }
+            $data->{'foo'} = $values;
         }
-        $data->{'foo'} = $values;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/BarItemNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/BarItemNormalizer.php
@@ -42,7 +42,9 @@ class BarItemNormalizer implements DenormalizerInterface, NormalizerInterface, D
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/FooNormalizer.php
@@ -42,7 +42,9 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/HelloWorldNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/HelloWorldNormalizer.php
@@ -42,7 +42,9 @@ class HelloWorldNormalizer implements DenormalizerInterface, NormalizerInterface
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/deprecated/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/deprecated/expected/Normalizer/FooNormalizer.php
@@ -45,8 +45,12 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'email'} = $object->getEmail();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getEmail()) {
+            $data->{'email'} = $object->getEmail();
+        }
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/multi-files/expected/Normalizer/TestFooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/multi-files/expected/Normalizer/TestFooNormalizer.php
@@ -36,7 +36,9 @@ class TestFooNormalizer implements DenormalizerInterface, NormalizerInterface, D
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/multi-files/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/multi-files/expected/Normalizer/TestNormalizer.php
@@ -36,7 +36,12 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $this->normalizer->normalize($object->getFoo(), 'json', $context);
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $this->normalizer->normalize($object->getFoo(), 'json', $context);
+        }
+        else {
+            $data->{'foo'} = null;
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/multi-files/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/multi-files/expected/Normalizer/TestNormalizer.php
@@ -39,9 +39,6 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getFoo()) {
             $data->{'foo'} = $this->normalizer->normalize($object->getFoo(), 'json', $context);
         }
-        else {
-            $data->{'foo'} = null;
-        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Normalizer/TestNormalizer.php
@@ -36,7 +36,12 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $this->normalizer->normalize($object->getFoo(), 'json', $context);
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $this->normalizer->normalize($object->getFoo(), 'json', $context);
+        }
+        else {
+            $data->{'foo'} = null;
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Normalizer/TestNormalizer.php
@@ -39,9 +39,6 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getFoo()) {
             $data->{'foo'} = $this->normalizer->normalize($object->getFoo(), 'json', $context);
         }
-        else {
-            $data->{'foo'} = null;
-        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema2/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema2/Normalizer/FooNormalizer.php
@@ -36,7 +36,9 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/name-conflict/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/name-conflict/expected/Normalizer/TestNormalizer.php
@@ -45,8 +45,12 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'msgref'} = $object->getMsgref();
-        $data->{'msg_ref'} = $object->getMsgRef2();
+        if (null !== $object->getMsgref()) {
+            $data->{'msgref'} = $object->getMsgref();
+        }
+        if (null !== $object->getMsgRef2()) {
+            $data->{'msg_ref'} = $object->getMsgRef2();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/one-of/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/one-of/expected/Normalizer/FooNormalizer.php
@@ -83,9 +83,6 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
             }
             $data->{'foo'} = $value;
         }
-        else {
-            $data->{'foo'} = null;
-        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/one-of/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/one-of/expected/Normalizer/FooNormalizer.php
@@ -61,26 +61,31 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $value = $object->getFoo();
-        if (is_string($object->getFoo())) {
+        if (null !== $object->getFoo()) {
             $value = $object->getFoo();
-        } elseif (!is_null($object->getFoo())) {
-            $values = new \stdClass();
-            foreach ($object->getFoo() as $key => $value_1) {
-                if (preg_match('/^[a-zA-Z0-9._-]+$/', $key) && !is_null($value_1)) {
-                    $value_2 = $value_1;
-                    if (is_object($value_1)) {
+            if (is_string($object->getFoo())) {
+                $value = $object->getFoo();
+            } elseif (!is_null($object->getFoo())) {
+                $values = new \stdClass();
+                foreach ($object->getFoo() as $key => $value_1) {
+                    if (preg_match('/^[a-zA-Z0-9._-]+$/', $key) && !is_null($value_1)) {
                         $value_2 = $value_1;
-                    } elseif (is_null($value_1)) {
-                        $value_2 = $value_1;
+                        if (is_object($value_1)) {
+                            $value_2 = $value_1;
+                        } elseif (is_null($value_1)) {
+                            $value_2 = $value_1;
+                        }
+                        $values->{$key} = $value_2;
+                        continue;
                     }
-                    $values->{$key} = $value_2;
-                    continue;
                 }
+                $value = $values;
             }
-            $value = $values;
+            $data->{'foo'} = $value;
         }
-        $data->{'foo'} = $value;
+        else {
+            $data->{'foo'} = null;
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/reserved-words/expected/Normalizer/ListNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/reserved-words/expected/Normalizer/ListNormalizer.php
@@ -42,7 +42,9 @@ class ListNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Normalizer/TestNormalizer.php
@@ -39,12 +39,11 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'string'} = $object->getString();
+        if (null !== $object->getString()) {
+            $data->{'string'} = $object->getString();
+        }
         if (null !== $object->getSubObject()) {
             $data->{'subObject'} = $this->normalizer->normalize($object->getSubObject(), 'json', $context);
-        }
-        else {
-            $data->{'subObject'} = null;
         }
         return $data;
     }

--- a/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Normalizer/TestNormalizer.php
@@ -40,7 +40,12 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $data = new \stdClass();
         $data->{'string'} = $object->getString();
-        $data->{'subObject'} = $this->normalizer->normalize($object->getSubObject(), 'json', $context);
+        if (null !== $object->getSubObject()) {
+            $data->{'subObject'} = $this->normalizer->normalize($object->getSubObject(), 'json', $context);
+        }
+        else {
+            $data->{'subObject'} = null;
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Normalizer/TestSubObjectNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Normalizer/TestSubObjectNormalizer.php
@@ -36,7 +36,9 @@ class TestSubObjectNormalizer implements DenormalizerInterface, NormalizerInterf
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
@@ -66,18 +66,13 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $data = new \stdClass();
         $data->{'onlyNull'} = $object->getOnlyNull();
-        if (null !== $object->getNullOrString()) {
+        $value = $object->getNullOrString();
+        if (is_string($object->getNullOrString())) {
             $value = $object->getNullOrString();
-            if (is_string($object->getNullOrString())) {
-                $value = $object->getNullOrString();
-            } elseif (is_null($object->getNullOrString())) {
-                $value = $object->getNullOrString();
-            }
-            $data->{'nullOrString'} = $value;
+        } elseif (is_null($object->getNullOrString())) {
+            $value = $object->getNullOrString();
         }
-        else {
-            $data->{'nullOrString'} = null;
-        }
+        $data->{'nullOrString'} = $value;
         if (null !== $object->getArray()) {
             $values = array();
             foreach ($object->getArray() as $value_1) {

--- a/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
@@ -66,13 +66,18 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $data = new \stdClass();
         $data->{'onlyNull'} = $object->getOnlyNull();
-        $value = $object->getNullOrString();
-        if (is_string($object->getNullOrString())) {
+        if (null !== $object->getNullOrString()) {
             $value = $object->getNullOrString();
-        } elseif (is_null($object->getNullOrString())) {
-            $value = $object->getNullOrString();
+            if (is_string($object->getNullOrString())) {
+                $value = $object->getNullOrString();
+            } elseif (is_null($object->getNullOrString())) {
+                $value = $object->getNullOrString();
+            }
+            $data->{'nullOrString'} = $value;
         }
-        $data->{'nullOrString'} = $value;
+        else {
+            $data->{'nullOrString'} = null;
+        }
         if (null !== $object->getArray()) {
             $values = array();
             foreach ($object->getArray() as $value_1) {

--- a/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
@@ -52,18 +52,13 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $data = new \stdClass();
         $data->{'onlyNull'} = $object->getOnlyNull();
-        if (null !== $object->getNullOrString()) {
+        $value = $object->getNullOrString();
+        if (is_string($object->getNullOrString())) {
             $value = $object->getNullOrString();
-            if (is_string($object->getNullOrString())) {
-                $value = $object->getNullOrString();
-            } elseif (is_null($object->getNullOrString())) {
-                $value = $object->getNullOrString();
-            }
-            $data->{'nullOrString'} = $value;
+        } elseif (is_null($object->getNullOrString())) {
+            $value = $object->getNullOrString();
         }
-        else {
-            $data->{'nullOrString'} = null;
-        }
+        $data->{'nullOrString'} = $value;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
@@ -52,13 +52,18 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $data = new \stdClass();
         $data->{'onlyNull'} = $object->getOnlyNull();
-        $value = $object->getNullOrString();
-        if (is_string($object->getNullOrString())) {
+        if (null !== $object->getNullOrString()) {
             $value = $object->getNullOrString();
-        } elseif (is_null($object->getNullOrString())) {
-            $value = $object->getNullOrString();
+            if (is_string($object->getNullOrString())) {
+                $value = $object->getNullOrString();
+            } elseif (is_null($object->getNullOrString())) {
+                $value = $object->getNullOrString();
+            }
+            $data->{'nullOrString'} = $value;
         }
-        $data->{'nullOrString'} = $value;
+        else {
+            $data->{'nullOrString'} = null;
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/BarNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/BarNormalizer.php
@@ -36,7 +36,9 @@ class BarNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FooNormalizer.php
@@ -39,8 +39,12 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'bar'} = $object->getBar();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FuzNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FuzNormalizer.php
@@ -36,7 +36,9 @@ class FuzNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/array-definition/expected/Normalizer/BarItemNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/array-definition/expected/Normalizer/BarItemNormalizer.php
@@ -36,7 +36,9 @@ class BarItemNormalizer implements DenormalizerInterface, NormalizerInterface, D
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
@@ -66,7 +66,12 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     {
         $data = new \stdClass();
         $data->{'stringProperty'} = $object->getStringProperty();
-        $data->{'dateProperty'} = $object->getDateProperty()->format("Y-m-d\TH:i:sP");
+        if (null !== $object->getDateProperty()) {
+            $data->{'dateProperty'} = $object->getDateProperty()->format("Y-m-d\TH:i:sP");
+        }
+        else {
+            $data->{'dateProperty'} = null;
+        }
         $data->{'integerProperty'} = $object->getIntegerProperty();
         $data->{'floatProperty'} = $object->getFloatProperty();
         $values = array();
@@ -74,13 +79,28 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $values[] = $value;
         }
         $data->{'arrayProperty'} = $values;
-        $values_1 = new \stdClass();
-        foreach ($object->getMapProperty() as $key => $value_1) {
-            $values_1->{$key} = $value_1;
+        if (null !== $object->getMapProperty()) {
+            $values_1 = new \stdClass();
+            foreach ($object->getMapProperty() as $key => $value_1) {
+                $values_1->{$key} = $value_1;
+            }
+            $data->{'mapProperty'} = $values_1;
         }
-        $data->{'mapProperty'} = $values_1;
-        $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
-        $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
+        else {
+            $data->{'mapProperty'} = null;
+        }
+        if (null !== $object->getObjectProperty()) {
+            $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
+        }
+        else {
+            $data->{'objectProperty'} = null;
+        }
+        if (null !== $object->getObjectRefProperty()) {
+            $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
+        }
+        else {
+            $data->{'objectRefProperty'} = null;
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
@@ -65,20 +65,25 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'stringProperty'} = $object->getStringProperty();
+        if (null !== $object->getStringProperty()) {
+            $data->{'stringProperty'} = $object->getStringProperty();
+        }
         if (null !== $object->getDateProperty()) {
             $data->{'dateProperty'} = $object->getDateProperty()->format("Y-m-d\TH:i:sP");
         }
-        else {
-            $data->{'dateProperty'} = null;
+        if (null !== $object->getIntegerProperty()) {
+            $data->{'integerProperty'} = $object->getIntegerProperty();
         }
-        $data->{'integerProperty'} = $object->getIntegerProperty();
-        $data->{'floatProperty'} = $object->getFloatProperty();
-        $values = array();
-        foreach ($object->getArrayProperty() as $value) {
-            $values[] = $value;
+        if (null !== $object->getFloatProperty()) {
+            $data->{'floatProperty'} = $object->getFloatProperty();
         }
-        $data->{'arrayProperty'} = $values;
+        if (null !== $object->getArrayProperty()) {
+            $values = array();
+            foreach ($object->getArrayProperty() as $value) {
+                $values[] = $value;
+            }
+            $data->{'arrayProperty'} = $values;
+        }
         if (null !== $object->getMapProperty()) {
             $values_1 = new \stdClass();
             foreach ($object->getMapProperty() as $key => $value_1) {
@@ -86,20 +91,11 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             }
             $data->{'mapProperty'} = $values_1;
         }
-        else {
-            $data->{'mapProperty'} = null;
-        }
         if (null !== $object->getObjectProperty()) {
             $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
         }
-        else {
-            $data->{'objectProperty'} = null;
-        }
         if (null !== $object->getObjectRefProperty()) {
             $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
-        }
-        else {
-            $data->{'objectRefProperty'} = null;
         }
         return $data;
     }

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -36,7 +36,9 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'stringProperty'} = $object->getStringProperty();
+        if (null !== $object->getStringProperty()) {
+            $data->{'stringProperty'} = $object->getStringProperty();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
@@ -66,7 +66,12 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     {
         $data = new \stdClass();
         $data->{'stringProperty'} = $object->getStringProperty();
-        $data->{'dateProperty'} = $object->getDateProperty()->format("Y-m-d\TH:i:sP");
+        if (null !== $object->getDateProperty()) {
+            $data->{'dateProperty'} = $object->getDateProperty()->format("Y-m-d\TH:i:sP");
+        }
+        else {
+            $data->{'dateProperty'} = null;
+        }
         $data->{'integerProperty'} = $object->getIntegerProperty();
         $data->{'floatProperty'} = $object->getFloatProperty();
         $values = array();
@@ -74,13 +79,28 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $values[] = $value;
         }
         $data->{'arrayProperty'} = $values;
-        $values_1 = new \stdClass();
-        foreach ($object->getMapProperty() as $key => $value_1) {
-            $values_1->{$key} = $value_1;
+        if (null !== $object->getMapProperty()) {
+            $values_1 = new \stdClass();
+            foreach ($object->getMapProperty() as $key => $value_1) {
+                $values_1->{$key} = $value_1;
+            }
+            $data->{'mapProperty'} = $values_1;
         }
-        $data->{'mapProperty'} = $values_1;
-        $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
-        $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
+        else {
+            $data->{'mapProperty'} = null;
+        }
+        if (null !== $object->getObjectProperty()) {
+            $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
+        }
+        else {
+            $data->{'objectProperty'} = null;
+        }
+        if (null !== $object->getObjectRefProperty()) {
+            $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
+        }
+        else {
+            $data->{'objectRefProperty'} = null;
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
@@ -65,20 +65,25 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'stringProperty'} = $object->getStringProperty();
+        if (null !== $object->getStringProperty()) {
+            $data->{'stringProperty'} = $object->getStringProperty();
+        }
         if (null !== $object->getDateProperty()) {
             $data->{'dateProperty'} = $object->getDateProperty()->format("Y-m-d\TH:i:sP");
         }
-        else {
-            $data->{'dateProperty'} = null;
+        if (null !== $object->getIntegerProperty()) {
+            $data->{'integerProperty'} = $object->getIntegerProperty();
         }
-        $data->{'integerProperty'} = $object->getIntegerProperty();
-        $data->{'floatProperty'} = $object->getFloatProperty();
-        $values = array();
-        foreach ($object->getArrayProperty() as $value) {
-            $values[] = $value;
+        if (null !== $object->getFloatProperty()) {
+            $data->{'floatProperty'} = $object->getFloatProperty();
         }
-        $data->{'arrayProperty'} = $values;
+        if (null !== $object->getArrayProperty()) {
+            $values = array();
+            foreach ($object->getArrayProperty() as $value) {
+                $values[] = $value;
+            }
+            $data->{'arrayProperty'} = $values;
+        }
         if (null !== $object->getMapProperty()) {
             $values_1 = new \stdClass();
             foreach ($object->getMapProperty() as $key => $value_1) {
@@ -86,20 +91,11 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             }
             $data->{'mapProperty'} = $values_1;
         }
-        else {
-            $data->{'mapProperty'} = null;
-        }
         if (null !== $object->getObjectProperty()) {
             $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
         }
-        else {
-            $data->{'objectProperty'} = null;
-        }
         if (null !== $object->getObjectRefProperty()) {
             $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
-        }
-        else {
-            $data->{'objectRefProperty'} = null;
         }
         return $data;
     }

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -36,7 +36,9 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'stringProperty'} = $object->getStringProperty();
+        if (null !== $object->getStringProperty()) {
+            $data->{'stringProperty'} = $object->getStringProperty();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/deprecated/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/deprecated/expected/Normalizer/FooNormalizer.php
@@ -39,8 +39,12 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'email'} = $object->getEmail();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getEmail()) {
+            $data->{'email'} = $object->getEmail();
+        }
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/CatInSnakeCaseNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/CatInSnakeCaseNormalizer.php
@@ -42,9 +42,15 @@ class CatInSnakeCaseNormalizer implements DenormalizerInterface, NormalizerInter
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'name'} = $object->getName();
-        $data->{'petType'} = $object->getPetType();
-        $data->{'huntingSkill'} = $object->getHuntingSkill();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
+        if (null !== $object->getHuntingSkill()) {
+            $data->{'huntingSkill'} = $object->getHuntingSkill();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/DogInSnakeCaseNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/DogInSnakeCaseNormalizer.php
@@ -42,9 +42,15 @@ class DogInSnakeCaseNormalizer implements DenormalizerInterface, NormalizerInter
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'name'} = $object->getName();
-        $data->{'petType'} = $object->getPetType();
-        $data->{'packSize'} = $object->getPackSize();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
+        if (null !== $object->getPackSize()) {
+            $data->{'packSize'} = $object->getPackSize();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/PetNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/PetNormalizer.php
@@ -51,8 +51,12 @@ class PetNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
         if (null !== $object->getPetType() and 'dog_in_snake_case' === $object->getPetType()) {
             return $this->normalizer->normalize($object, $format, $context);
         }
-        $data->{'name'} = $object->getName();
-        $data->{'petType'} = $object->getPetType();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/CatNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/CatNormalizer.php
@@ -42,9 +42,15 @@ class CatNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'name'} = $object->getName();
-        $data->{'petType'} = $object->getPetType();
-        $data->{'huntingSkill'} = $object->getHuntingSkill();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
+        if (null !== $object->getHuntingSkill()) {
+            $data->{'huntingSkill'} = $object->getHuntingSkill();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/DogNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/DogNormalizer.php
@@ -42,9 +42,15 @@ class DogNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'name'} = $object->getName();
-        $data->{'petType'} = $object->getPetType();
-        $data->{'packSize'} = $object->getPackSize();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
+        if (null !== $object->getPackSize()) {
+            $data->{'packSize'} = $object->getPackSize();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/PetNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/PetNormalizer.php
@@ -51,8 +51,12 @@ class PetNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
         if (null !== $object->getPetType() and 'Dog' === $object->getPetType()) {
             return $this->normalizer->normalize($object, $format, $context);
         }
-        $data->{'name'} = $object->getName();
-        $data->{'petType'} = $object->getPetType();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getPetType()) {
+            $data->{'petType'} = $object->getPetType();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Normalizer/ErrorNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Normalizer/ErrorNormalizer.php
@@ -36,7 +36,9 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'message'} = $object->getMessage();
+        if (null !== $object->getMessage()) {
+            $data->{'message'} = $object->getMessage();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/ErrorNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/ErrorNormalizer.php
@@ -39,8 +39,12 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'code'} = $object->getCode();
-        $data->{'message'} = $object->getMessage();
+        if (null !== $object->getCode()) {
+            $data->{'code'} = $object->getCode();
+        }
+        if (null !== $object->getMessage()) {
+            $data->{'message'} = $object->getMessage();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/PetNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/PetNormalizer.php
@@ -42,9 +42,15 @@ class PetNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'id'} = $object->getId();
-        $data->{'name'} = $object->getName();
-        $data->{'tag'} = $object->getTag();
+        if (null !== $object->getId()) {
+            $data->{'id'} = $object->getId();
+        }
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        if (null !== $object->getTag()) {
+            $data->{'tag'} = $object->getTag();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/EmptySpaceNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/EmptySpaceNormalizer.php
@@ -36,7 +36,9 @@ class EmptySpaceNormalizer implements DenormalizerInterface, NormalizerInterface
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'stringProperty'} = $object->getStringProperty();
+        if (null !== $object->getStringProperty()) {
+            $data->{'stringProperty'} = $object->getStringProperty();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/ErrorNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/ErrorNormalizer.php
@@ -36,7 +36,9 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'message'} = $object->getMessage();
+        if (null !== $object->getMessage()) {
+            $data->{'message'} = $object->getMessage();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
@@ -70,13 +70,28 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $values[] = $value;
         }
         $data->{'arrayProperty'} = $values;
-        $values_1 = new \stdClass();
-        foreach ($object->getMapProperty() as $key => $value_1) {
-            $values_1->{$key} = $value_1;
+        if (null !== $object->getMapProperty()) {
+            $values_1 = new \stdClass();
+            foreach ($object->getMapProperty() as $key => $value_1) {
+                $values_1->{$key} = $value_1;
+            }
+            $data->{'mapProperty'} = $values_1;
         }
-        $data->{'mapProperty'} = $values_1;
-        $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
-        $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
+        else {
+            $data->{'mapProperty'} = null;
+        }
+        if (null !== $object->getObjectProperty()) {
+            $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
+        }
+        else {
+            $data->{'objectProperty'} = null;
+        }
+        if (null !== $object->getObjectRefProperty()) {
+            $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
+        }
+        else {
+            $data->{'objectRefProperty'} = null;
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
@@ -62,14 +62,22 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'stringProperty'} = $object->getStringProperty();
-        $data->{'integerProperty'} = $object->getIntegerProperty();
-        $data->{'floatProperty'} = $object->getFloatProperty();
-        $values = array();
-        foreach ($object->getArrayProperty() as $value) {
-            $values[] = $value;
+        if (null !== $object->getStringProperty()) {
+            $data->{'stringProperty'} = $object->getStringProperty();
         }
-        $data->{'arrayProperty'} = $values;
+        if (null !== $object->getIntegerProperty()) {
+            $data->{'integerProperty'} = $object->getIntegerProperty();
+        }
+        if (null !== $object->getFloatProperty()) {
+            $data->{'floatProperty'} = $object->getFloatProperty();
+        }
+        if (null !== $object->getArrayProperty()) {
+            $values = array();
+            foreach ($object->getArrayProperty() as $value) {
+                $values[] = $value;
+            }
+            $data->{'arrayProperty'} = $values;
+        }
         if (null !== $object->getMapProperty()) {
             $values_1 = new \stdClass();
             foreach ($object->getMapProperty() as $key => $value_1) {
@@ -77,20 +85,11 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             }
             $data->{'mapProperty'} = $values_1;
         }
-        else {
-            $data->{'mapProperty'} = null;
-        }
         if (null !== $object->getObjectProperty()) {
             $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
         }
-        else {
-            $data->{'objectProperty'} = null;
-        }
         if (null !== $object->getObjectRefProperty()) {
             $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
-        }
-        else {
-            $data->{'objectRefProperty'} = null;
         }
         return $data;
     }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -36,7 +36,9 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'stringProperty'} = $object->getStringProperty();
+        if (null !== $object->getStringProperty()) {
+            $data->{'stringProperty'} = $object->getStringProperty();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/TestIdGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/TestIdGetResponse200Normalizer.php
@@ -36,7 +36,9 @@ class TestIdGetResponse200Normalizer implements DenormalizerInterface, Normalize
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'id'} = $object->getId();
+        if (null !== $object->getId()) {
+            $data->{'id'} = $object->getId();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/model-type-reference/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-type-reference/expected/Normalizer/ModelNormalizer.php
@@ -39,8 +39,12 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Normalizer/BodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Normalizer/BodyNormalizer.php
@@ -36,7 +36,9 @@ class BodyNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/BarNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/BarNormalizer.php
@@ -39,8 +39,12 @@ class BarNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/FooNormalizer.php
@@ -36,7 +36,9 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyBazNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyBazNormalizer.php
@@ -36,7 +36,9 @@ class TestGetBodyBazNormalizer implements DenormalizerInterface, NormalizerInter
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'baz'} = $object->getBaz();
+        if (null !== $object->getBaz()) {
+            $data->{'baz'} = $object->getBaz();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyNormalizer.php
@@ -42,18 +42,14 @@ class TestGetBodyNormalizer implements DenormalizerInterface, NormalizerInterfac
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         if (null !== $object->getBar()) {
             $data->{'Bar'} = $this->normalizer->normalize($object->getBar(), 'json', $context);
         }
-        else {
-            $data->{'Bar'} = null;
-        }
         if (null !== $object->getBaz()) {
             $data->{'Baz'} = $this->normalizer->normalize($object->getBaz(), 'json', $context);
-        }
-        else {
-            $data->{'Baz'} = null;
         }
         return $data;
     }

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyNormalizer.php
@@ -43,8 +43,18 @@ class TestGetBodyNormalizer implements DenormalizerInterface, NormalizerInterfac
     {
         $data = new \stdClass();
         $data->{'foo'} = $object->getFoo();
-        $data->{'Bar'} = $this->normalizer->normalize($object->getBar(), 'json', $context);
-        $data->{'Baz'} = $this->normalizer->normalize($object->getBaz(), 'json', $context);
+        if (null !== $object->getBar()) {
+            $data->{'Bar'} = $this->normalizer->normalize($object->getBar(), 'json', $context);
+        }
+        else {
+            $data->{'Bar'} = null;
+        }
+        if (null !== $object->getBaz()) {
+            $data->{'Baz'} = $this->normalizer->normalize($object->getBaz(), 'json', $context);
+        }
+        else {
+            $data->{'Baz'} = null;
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestPostBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestPostBodyNormalizer.php
@@ -36,7 +36,9 @@ class TestPostBodyNormalizer implements DenormalizerInterface, NormalizerInterfa
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/no-reference-response/expected/Normalizer/TestPostResponse201Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-response/expected/Normalizer/TestPostResponse201Normalizer.php
@@ -36,7 +36,9 @@ class TestPostResponse201Normalizer implements DenormalizerInterface, Normalizer
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/operations/expected/Normalizer/ThingNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Normalizer/ThingNormalizer.php
@@ -36,7 +36,9 @@ class ThingNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'name'} = $object->getName();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Normalizer/TestFormFilePostBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Normalizer/TestFormFilePostBodyNormalizer.php
@@ -36,7 +36,9 @@ class TestFormFilePostBodyNormalizer implements DenormalizerInterface, Normalize
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'testFile'} = $object->getTestFile();
+        if (null !== $object->getTestFile()) {
+            $data->{'testFile'} = $object->getTestFile();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Normalizer/TestFormPostBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Normalizer/TestFormPostBodyNormalizer.php
@@ -55,16 +55,28 @@ class TestFormPostBodyNormalizer implements DenormalizerInterface, NormalizerInt
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'testString'} = $object->getTestString();
-        $data->{'testInteger'} = $object->getTestInteger();
-        $data->{'testFloat'} = $object->getTestFloat();
-        $values = array();
-        foreach ($object->getTestArray() as $value) {
-            $values[] = $value;
+        if (null !== $object->getTestString()) {
+            $data->{'testString'} = $object->getTestString();
         }
-        $data->{'testArray'} = $values;
-        $data->{'testRequired'} = $object->getTestRequired();
-        $data->{'testDefault'} = $object->getTestDefault();
+        if (null !== $object->getTestInteger()) {
+            $data->{'testInteger'} = $object->getTestInteger();
+        }
+        if (null !== $object->getTestFloat()) {
+            $data->{'testFloat'} = $object->getTestFloat();
+        }
+        if (null !== $object->getTestArray()) {
+            $values = array();
+            foreach ($object->getTestArray() as $value) {
+                $values[] = $value;
+            }
+            $data->{'testArray'} = $values;
+        }
+        if (null !== $object->getTestRequired()) {
+            $data->{'testRequired'} = $object->getTestRequired();
+        }
+        if (null !== $object->getTestDefault()) {
+            $data->{'testDefault'} = $object->getTestDefault();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/response-reference/expected/Normalizer/ResponseCommonNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/response-reference/expected/Normalizer/ResponseCommonNormalizer.php
@@ -36,7 +36,9 @@ class ResponseCommonNormalizer implements DenormalizerInterface, NormalizerInter
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/response-type-reference/expected/Normalizer/FooGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/response-type-reference/expected/Normalizer/FooGetResponse200Normalizer.php
@@ -39,8 +39,12 @@ class FooGetResponse200Normalizer implements DenormalizerInterface, NormalizerIn
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'id'} = $object->getId();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getId()) {
+            $data->{'id'} = $object->getId();
+        }
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/test-nullable/expected/Model/Model.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable/expected/Model/Model.php
@@ -19,6 +19,12 @@ class Model
     /**
      * 
      *
+     * @var \DateTime|null
+     */
+    protected $date;
+    /**
+     * 
+     *
      * @return string|null
      */
     public function getFoo() : ?string
@@ -56,6 +62,27 @@ class Model
     public function setBar(string $bar) : self
     {
         $this->bar = $bar;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return \DateTime|null
+     */
+    public function getDate() : ?\DateTime
+    {
+        return $this->date;
+    }
+    /**
+     * 
+     *
+     * @param \DateTime|null $date
+     *
+     * @return self
+     */
+    public function setDate(?\DateTime $date) : self
+    {
+        $this->date = $date;
         return $this;
     }
 }

--- a/src/OpenApi/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
@@ -39,9 +39,7 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        if (null !== $object->getFoo()) {
-            $data->{'foo'} = $object->getFoo();
-        }
+        $data->{'foo'} = $object->getFoo();
         $data->{'bar'} = $object->getBar();
         return $data;
     }

--- a/src/OpenApi/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
@@ -34,6 +34,9 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
         if (property_exists($data, 'bar')) {
             $object->setBar($data->{'bar'});
         }
+        if (property_exists($data, 'date')) {
+            $object->setDate(\DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'date'}));
+        }
         return $object;
     }
     public function normalize($object, $format = null, array $context = array())
@@ -41,6 +44,12 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
         $data = new \stdClass();
         $data->{'foo'} = $object->getFoo();
         $data->{'bar'} = $object->getBar();
+        if (null !== $object->getDate()) {
+            $data->{'date'} = $object->getDate()->format("Y-m-d\TH:i:sP");
+        }
+        else {
+            $data->{'date'} = null;
+        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
@@ -43,7 +43,9 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     {
         $data = new \stdClass();
         $data->{'foo'} = $object->getFoo();
-        $data->{'bar'} = $object->getBar();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
         if (null !== $object->getDate()) {
             $data->{'date'} = $object->getDate()->format("Y-m-d\TH:i:sP");
         }

--- a/src/OpenApi/Tests/fixtures/test-nullable/schema.json
+++ b/src/OpenApi/Tests/fixtures/test-nullable/schema.json
@@ -16,6 +16,11 @@
                     },
                     "bar": {
                         "type": "string"
+                    },
+                    "date": {
+                        "nullable": true,
+                        "type": "string",
+                        "format": "date-time"
                     }
                 }
             }

--- a/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
@@ -79,37 +79,37 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function normalize($object, $format = null, array $context = [])
     {
         $data = new \stdClass();
-        $data->{'stringProperty'} = $object->getStringProperty();
+        if (null !== $object->getStringProperty()) {
+            $data->{'stringProperty'} = $object->getStringProperty();
+        }
         if (null !== $object->getDateProperty()) {
             $data->{'dateProperty'} = $object->getDateProperty()->format("Y-m-d\TH:i:sP");
-        } else {
-            $data->{'dateProperty'} = null;
         }
-        $data->{'integerProperty'} = $object->getIntegerProperty();
-        $data->{'floatProperty'} = $object->getFloatProperty();
-        $values = [];
-        foreach ($object->getArrayProperty() as $value) {
-            $values[] = $value;
+        if (null !== $object->getIntegerProperty()) {
+            $data->{'integerProperty'} = $object->getIntegerProperty();
         }
-        $data->{'arrayProperty'} = $values;
+        if (null !== $object->getFloatProperty()) {
+            $data->{'floatProperty'} = $object->getFloatProperty();
+        }
+        if (null !== $object->getArrayProperty()) {
+            $values = [];
+            foreach ($object->getArrayProperty() as $value) {
+                $values[] = $value;
+            }
+            $data->{'arrayProperty'} = $values;
+        }
         if (null !== $object->getMapProperty()) {
             $values_1 = new \stdClass();
             foreach ($object->getMapProperty() as $key => $value_1) {
                 $values_1->{$key} = $value_1;
             }
             $data->{'mapProperty'} = $values_1;
-        } else {
-            $data->{'mapProperty'} = null;
         }
         if (null !== $object->getObjectProperty()) {
             $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
-        } else {
-            $data->{'objectProperty'} = null;
         }
         if (null !== $object->getObjectRefProperty()) {
             $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
-        } else {
-            $data->{'objectRefProperty'} = null;
         }
 
         return $data;

--- a/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
@@ -80,7 +80,11 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     {
         $data = new \stdClass();
         $data->{'stringProperty'} = $object->getStringProperty();
-        $data->{'dateProperty'} = $object->getDateProperty()->format("Y-m-d\TH:i:sP");
+        if (null !== $object->getDateProperty()) {
+            $data->{'dateProperty'} = $object->getDateProperty()->format("Y-m-d\TH:i:sP");
+        } else {
+            $data->{'dateProperty'} = null;
+        }
         $data->{'integerProperty'} = $object->getIntegerProperty();
         $data->{'floatProperty'} = $object->getFloatProperty();
         $values = [];
@@ -88,13 +92,25 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $values[] = $value;
         }
         $data->{'arrayProperty'} = $values;
-        $values_1 = new \stdClass();
-        foreach ($object->getMapProperty() as $key => $value_1) {
-            $values_1->{$key} = $value_1;
+        if (null !== $object->getMapProperty()) {
+            $values_1 = new \stdClass();
+            foreach ($object->getMapProperty() as $key => $value_1) {
+                $values_1->{$key} = $value_1;
+            }
+            $data->{'mapProperty'} = $values_1;
+        } else {
+            $data->{'mapProperty'} = null;
         }
-        $data->{'mapProperty'} = $values_1;
-        $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
-        $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
+        if (null !== $object->getObjectProperty()) {
+            $data->{'objectProperty'} = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
+        } else {
+            $data->{'objectProperty'} = null;
+        }
+        if (null !== $object->getObjectRefProperty()) {
+            $data->{'objectRefProperty'} = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
+        } else {
+            $data->{'objectRefProperty'} = null;
+        }
 
         return $data;
     }

--- a/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -50,7 +50,9 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     public function normalize($object, $format = null, array $context = [])
     {
         $data = new \stdClass();
-        $data->{'stringProperty'} = $object->getStringProperty();
+        if (null !== $object->getStringProperty()) {
+            $data->{'stringProperty'} = $object->getStringProperty();
+        }
 
         return $data;
     }


### PR DESCRIPTION
In normalize context, we do want to have any nullable field created,
even if they are null.

To try to understand what I do here:
- If our property definition has a nullable marker (see https://github.com/janephp/janephp/issues/100#issuecomment-534900242 for more details on how nullable works) OR one of his type is null
  - If our property definition is not a null type AND we do not have custom normalize value (such as DateTime or objects) we will check if not null before our custom normalization and if null we will just set the value to null
  - Else we simply do our normalization with no null value check
- Else we add a check to avoid to set this field value is null