### PR TITLE
Handling of nullable attribute on query parameters

### DIFF
--- a/src/OpenApi/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/OpenApi/Generator/Parameter/NonBodyParameterGenerator.php
@@ -62,8 +62,8 @@ class NonBodyParameterGenerator extends ParameterGenerator
                     $types[] = new Expr\ArrayItem(new Scalar\String_($typeString));
                 }
 
-                if($schema->getNullable()) {
-                   $types[] = new Expr\ArrayItem(new Scalar\String_('null'));
+                if ($schema->getNullable()) {
+                    $types[] = new Expr\ArrayItem(new Scalar\String_('null'));
                 }
 
                 $allowedTypes[] = new Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'setAllowedTypes', [

--- a/src/OpenApi/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/OpenApi/Generator/Parameter/NonBodyParameterGenerator.php
@@ -62,6 +62,10 @@ class NonBodyParameterGenerator extends ParameterGenerator
                     $types[] = new Expr\ArrayItem(new Scalar\String_($typeString));
                 }
 
+                if($schema->getNullable()) {
+                   $types[] = new Expr\ArrayItem(new Scalar\String_('null'));
+                }
+
                 $allowedTypes[] = new Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'setAllowedTypes', [
                     new Node\Arg(new Scalar\String_($parameter->getName())),
                     new Node\Arg(new Expr\Array_($types)),

--- a/src/OpenApi/Tests/fixtures/test-nullable/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable/expected/Client.php
@@ -4,6 +4,20 @@ namespace Jane\OpenApi\Tests\Expected;
 
 class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
 {
+    /**
+     * 
+     *
+     * @param array $queryParameters {
+     *     @var int $testNullableInteger 
+     * }
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function testNullableQueryParameters(array $queryParameters = array(), string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Endpoint\TestNullableQueryParameters($queryParameters), $fetch);
+    }
     public static function create($httpClient = null)
     {
         if (null === $httpClient) {

--- a/src/OpenApi/Tests/fixtures/test-nullable/expected/Endpoint/TestNullableQueryParameters.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable/expected/Endpoint/TestNullableQueryParameters.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Endpoint;
+
+class TestNullableQueryParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    /**
+     * 
+     *
+     * @param array $queryParameters {
+     *     @var int $testNullableInteger 
+     * }
+     */
+    public function __construct(array $queryParameters = array())
+    {
+        $this->queryParameters = $queryParameters;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/test-nullable-query-parameter';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(array('testNullableInteger'));
+        $optionsResolver->setRequired(array());
+        $optionsResolver->setDefaults(array());
+        $optionsResolver->setAllowedTypes('testNullableInteger', array('int', 'null'));
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status) {
+            return null;
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/test-nullable/schema.json
+++ b/src/OpenApi/Tests/fixtures/test-nullable/schema.json
@@ -4,7 +4,31 @@
         "version": "",
         "title": ""
     },
-    "paths": {},
+    "paths": {
+        "/test-nullable-query-parameter": {
+            "get": {
+                "operationId": "Test Nullable Query Parameters",
+                "parameters": [
+                    {
+                        "name": "testNullableInteger",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer",
+                            "nullable": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                },
+                "tags": [
+                    "Test"
+                ]
+            }
+        }
+    },
     "components": {
         "schemas": {
             "Model": {

--- a/src/OpenApiRuntime/Client/BaseEndpoint.php
+++ b/src/OpenApiRuntime/Client/BaseEndpoint.php
@@ -26,7 +26,10 @@ abstract class BaseEndpoint implements Endpoint
 
     public function getQueryString(): string
     {
-        return http_build_query($this->getQueryOptionsResolver()->resolve($this->queryParameters), null, '&', PHP_QUERY_RFC3986);
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(function($value) { return $value ?: ''; }, $optionsResolved);
+
+        return http_build_query($optionsResolved, null, '&', PHP_QUERY_RFC3986);
     }
 
     public function getHeaders(array $baseHeaders = []): array

--- a/src/OpenApiRuntime/Client/BaseEndpoint.php
+++ b/src/OpenApiRuntime/Client/BaseEndpoint.php
@@ -27,7 +27,7 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(function($value) { return $value ?: ''; }, $optionsResolved);
+        $optionsResolved = array_map(function ($value) { return $value ?: ''; }, $optionsResolved);
 
         return http_build_query($optionsResolved, null, '&', PHP_QUERY_RFC3986);
     }


### PR DESCRIPTION
I am building a REST API according to an Openapi specifications file (V3). 
I have generated SDK with Jane but this one seems to not considering ```nullable: true``` attribute in request query parameters.

**My example openapi specs file:**
```
[...]
paths:
  /tickets:
    get:
      summary: Get tickets according to filters
      operationId: getTickets
      parameters:
        - in: query
          name: status
          required: false
          schema:
            type: string
        - in: query
          name: assigneeId
          required: false
          schema:
            type: integer
            nullable: true
[...]
```

**Source code generated by Jane in Endpoint/GetTickets.php::getQueryOptionsResolver():**

```
protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
{
    $optionsResolver = parent::getQueryOptionsResolver();
    $optionsResolver->setDefined(array('status', 'assigneeId'));
    $optionsResolver->setRequired(array());
    $optionsResolver->setDefaults(array());
    $optionsResolver->setAllowedTypes('status', array('string'));
    $optionsResolver->setAllowedTypes('assigneeId', array('int')); <-- Missing 'null' in this array according to nullable attribute in openapi specs
    return $optionsResolver;
}
```
**Expected call to my API endpoint to get opened and unassigned tickets:**
`GET api.domain.fr/tickets?status=open&assigneeId=`