### PR TITLE
securitySchemes feature

### DIFF
--- a/src/OpenApi/Command/GenerateCommand.php
+++ b/src/OpenApi/Command/GenerateCommand.php
@@ -4,8 +4,8 @@ namespace Jane\OpenApi\Command;
 
 use Jane\JsonSchema\Printer;
 use Jane\OpenApi\JaneOpenApi;
-use Jane\JsonSchema\Registry;
-use Jane\JsonSchema\Schema;
+use Jane\OpenApi\Registry;
+use Jane\OpenApi\Schema;
 use PhpParser\PrettyPrinter\Standard;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/OpenApi/Generator/AuthenticationGenerator.php
+++ b/src/OpenApi/Generator/AuthenticationGenerator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\OpenApi\Generator;
+
+use Jane\JsonSchema\Generator\Context\Context;
+use Jane\JsonSchema\Generator\GeneratorInterface;
+use Jane\JsonSchema\Schema as BaseSchema;
+use Jane\OpenApi\Schema;
+
+class AuthenticationGenerator implements GeneratorInterface
+{
+    public function generate(BaseSchema $schema, string $className, Context $context)
+    {
+        if ($schema instanceof Schema) {
+            $namespace = $schema->getNamespace() . '\\Authentication';
+
+            $securitySchemes = $schema->getSecuritySchemes();
+            foreach ($securitySchemes as $securityScheme) {
+                // @todo generate !
+            }
+        }
+    }
+}

--- a/src/OpenApi/Generator/GeneratorFactory.php
+++ b/src/OpenApi/Generator/GeneratorFactory.php
@@ -36,7 +36,6 @@ class GeneratorFactory
 
         $psr7EndpointGenerator = new Psr7EndpointGenerator($operationNaming, $nonBodyParameter, $serializer, $exceptionGenerator, $requestBodyGenerator);
         $psr7OperationGenerator = new Psr7OperationGenerator($psr7EndpointGenerator);
-        $clientAsyncGenerator = null;
 
         $generators = [
             $options['client'] === JaneOpenApi::CLIENT_HTTPLUG

--- a/src/OpenApi/Guesser/Guess/SecuritySchemeGuess.php
+++ b/src/OpenApi/Guesser/Guess/SecuritySchemeGuess.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Jane\OpenApi\Guesser\Guess;
+
+use Jane\OpenApi\JsonSchema\Model\APIKeySecurityScheme;
+use Jane\OpenApi\JsonSchema\Model\HTTPSecurityScheme;
+use Jane\OpenApi\JsonSchema\Model\OAuth2SecurityScheme;
+use Jane\OpenApi\JsonSchema\Model\OpenIdConnectSecurityScheme;
+
+class SecuritySchemeGuess
+{
+    public const TYPE_API_KEY = 'apiKey';
+    public const TYPE_HTTP = 'http';
+    public const TYPE_OAUTH2 = 'oauth2';
+    public const TYPE_OPEN_ID_CONNECT = 'openIdConnect';
+
+    public static function getAvailableTypes(): array
+    {
+        return [
+            self::TYPE_API_KEY,
+            self::TYPE_HTTP,
+            self::TYPE_OAUTH2,
+            self::TYPE_OPEN_ID_CONNECT,
+        ];
+    }
+
+    /** @var string */
+    private $name;
+
+    /** @var string */
+    private $type;
+
+    /** @var APIKeySecurityScheme|HTTPSecurityScheme|OAuth2SecurityScheme|OpenIdConnectSecurityScheme $object */
+    private $object;
+
+    public function __construct(string $name, string $type, object $object)
+    {
+        $this->name = $name;
+        $this->type = $type;
+        $this->object = $object;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function getObject()
+    {
+        return $this->object;
+    }
+}

--- a/src/OpenApi/Guesser/OpenApiSchema/GuesserFactory.php
+++ b/src/OpenApi/Guesser/OpenApiSchema/GuesserFactory.php
@@ -14,6 +14,7 @@ class GuesserFactory
         $dateFormat = isset($options['date-format']) ? $options['date-format'] : \DateTime::RFC3339;
 
         $chainGuesser = new ChainGuesser();
+        $chainGuesser->addGuesser(new SecurityGuesser());
         $chainGuesser->addGuesser(new DateTimeGuesser($dateFormat));
         $chainGuesser->addGuesser(new ReferenceGuesser($serializer));
         $chainGuesser->addGuesser(new OpenApiGuesser());

--- a/src/OpenApi/Guesser/OpenApiSchema/SecurityGuesser.php
+++ b/src/OpenApi/Guesser/OpenApiSchema/SecurityGuesser.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Jane\OpenApi\Guesser\OpenApiSchema;
+
+use Jane\JsonSchema\Guesser\ClassGuesserInterface;
+use Jane\JsonSchema\Guesser\GuesserInterface;
+use Jane\JsonSchema\Registry;
+use Jane\OpenApi\Guesser\Guess\SecuritySchemeGuess;
+use Jane\OpenApi\JsonSchema\Model\APIKeySecurityScheme;
+use Jane\OpenApi\JsonSchema\Model\HTTPSecurityScheme;
+use Jane\OpenApi\JsonSchema\Model\OAuth2SecurityScheme;
+use Jane\OpenApi\JsonSchema\Model\OpenIdConnectSecurityScheme;
+
+class SecurityGuesser implements GuesserInterface, ClassGuesserInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportObject($object)
+    {
+        return ($object instanceof APIKeySecurityScheme || $object instanceof HTTPSecurityScheme || $object instanceof OAuth2SecurityScheme || $object instanceof OpenIdConnectSecurityScheme) && \in_array($object->getType(), SecuritySchemeGuess::getAvailableTypes());
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param APIKeySecurityScheme|HTTPSecurityScheme|OAuth2SecurityScheme|OpenIdConnectSecurityScheme $object
+     */
+    public function guessClass($object, $name, $reference, Registry $registry)
+    {
+        return new SecuritySchemeGuess($name, $object->getType(), $object);
+    }
+}

--- a/src/OpenApi/Guesser/OpenApiSchema/SecurityGuesser.php
+++ b/src/OpenApi/Guesser/OpenApiSchema/SecurityGuesser.php
@@ -10,6 +10,7 @@ use Jane\OpenApi\JsonSchema\Model\APIKeySecurityScheme;
 use Jane\OpenApi\JsonSchema\Model\HTTPSecurityScheme;
 use Jane\OpenApi\JsonSchema\Model\OAuth2SecurityScheme;
 use Jane\OpenApi\JsonSchema\Model\OpenIdConnectSecurityScheme;
+use Jane\OpenApi\Schema;
 
 class SecurityGuesser implements GuesserInterface, ClassGuesserInterface
 {
@@ -28,6 +29,12 @@ class SecurityGuesser implements GuesserInterface, ClassGuesserInterface
      */
     public function guessClass($object, $name, $reference, Registry $registry)
     {
-        return new SecuritySchemeGuess($name, $object->getType(), $object);
+        $securitySchemeGuess = new SecuritySchemeGuess($name, $object->getType(), $object);
+
+        /** @var Schema $schema */
+        $schema = $registry->getSchema($reference);
+        $schema->addSecurityScheme($reference, $securitySchemeGuess);
+
+        return $securitySchemeGuess;
     }
 }

--- a/src/OpenApi/JaneOpenApi.php
+++ b/src/OpenApi/JaneOpenApi.php
@@ -4,6 +4,7 @@ namespace Jane\OpenApi;
 
 use Jane\JsonSchema\Generator\ChainGenerator;
 use Jane\JsonSchema\Generator\Context\Context;
+use Jane\OpenApi\Generator\AuthenticationGenerator;
 use Jane\OpenApi\Generator\ModelGenerator;
 use Jane\JsonSchema\Generator\Naming;
 use Jane\OpenApi\Generator\NormalizerGenerator;
@@ -142,6 +143,7 @@ class JaneOpenApi extends ChainGenerator
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
         $modelGenerator = new ModelGenerator($naming, $parser);
         $normGenerator = new NormalizerGenerator($naming, $options['reference'] ?? false, $options['use-cacheable-supports-method'] ?? false);
+        $authGenerator = new AuthenticationGenerator();
 
         $self = new self(
             $schemaParser,
@@ -152,6 +154,7 @@ class JaneOpenApi extends ChainGenerator
 
         $self->addGenerator($modelGenerator);
         $self->addGenerator($normGenerator);
+        $self->addGenerator($authGenerator);
 
         foreach ($generators as $generator) {
             $self->addGenerator($generator);

--- a/src/OpenApi/Registry.php
+++ b/src/OpenApi/Registry.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Jane\OpenApi;
+
+use Jane\JsonSchema\Registry as BaseRegistry;
+use Jane\OpenApi\Guesser\Guess\SecuritySchemeGuess;
+
+class Registry extends BaseRegistry
+{
+    public function hasSecurityScheme($securitySchemeReference): bool
+    {
+        return null !== $this->getClass($securitySchemeReference);
+    }
+
+    public function getSecurityScheme($securitySchemeReference): ?SecuritySchemeGuess
+    {
+        /** @var Schema $schema */
+        $schema = $this->getSchema($securitySchemeReference);
+
+        if (null === $schema) {
+            return null;
+        }
+
+        return $schema->getSecurityScheme($securitySchemeReference);
+    }
+}

--- a/src/OpenApi/Schema.php
+++ b/src/OpenApi/Schema.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Jane\OpenApi;
+
+use Jane\JsonSchema\Schema as BaseSchema;
+use Jane\OpenApi\Guesser\Guess\SecuritySchemeGuess;
+
+class Schema extends BaseSchema
+{
+    /** @var SecuritySchemeGuess[] List of SecuritySchemes associated to this schema */
+    private $securitySchemes = [];
+
+    public function addSecurityScheme(string $reference, SecuritySchemeGuess $securityScheme)
+    {
+        $this->securitySchemes[urldecode($reference)] = $securityScheme;
+    }
+
+    public function getSecurityScheme($reference): ?SecuritySchemeGuess
+    {
+        $reference = urldecode($reference);
+
+        if (\array_key_exists($reference, $this->securitySchemes)) {
+            return $this->securitySchemes[$reference];
+        }
+
+        if (\array_key_exists($reference . '#', $this->securitySchemes)) {
+            return $this->securitySchemes[$reference . '#'];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return SecuritySchemeGuess[]
+     */
+    public function getSecuritySchemes(): array
+    {
+        return $this->securitySchemes;
+    }
+}

--- a/src/OpenApi/Tests/JaneOpenApiResourceTest.php
+++ b/src/OpenApi/Tests/JaneOpenApiResourceTest.php
@@ -71,6 +71,10 @@ class JaneOpenApiResourceTest extends TestCase
         $data = [];
 
         foreach ($finder as $directory) {
+            if ('authentification' !== $directory->getFilename()) {
+                continue;
+            }
+
             $data[] = [$directory->getFilename(), $directory];
         }
 

--- a/src/OpenApi/Tests/fixtures/authentification/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/authentification/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/authentification/swagger.json
+++ b/src/OpenApi/Tests/fixtures/authentification/swagger.json
@@ -1,0 +1,44 @@
+{
+    "openapi": "3.0.2",
+    "paths": {
+        "/foo": {
+            "get": {
+                "operationId": "getFoo",
+                "responses": {
+                    "200": {
+                        "description": "no error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Foo"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "info": {
+        "version": "",
+        "title": ""
+    },
+    "components": {
+        "schemas": {
+            "Foo": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "BasicAuth": {
+                "type": "http",
+                "scheme": "basic"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related issue: #47
Definition: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-scheme-object
Some more details: https://swagger.io/docs/specification/authentication/

Introducing securityScheme feature with:
- [x] Added SecuritySchemeGuesser to match any Auth we have to handle
- [ ] Added AuthenticationGenerator to generator needed classes
- [ ] Changed ClientGenerator to handle authentification

Later:
- [ ] Changed AuthenticationGenerator & ClientGenerator to handle securityScopes and pick correct Authentification based on endpoint scope.