### PR TITLE
fixed undefined offset error

### DIFF
--- a/src/OpenApi/Generator/Psr18ClientGenerator.php
+++ b/src/OpenApi/Generator/Psr18ClientGenerator.php
@@ -109,7 +109,7 @@ class Psr18ClientGenerator extends ClientGenerator
         $plugins = [];
 
         $servers = $openApi->getServers();
-        $server = $servers !== null && $servers[0] !== null ? $servers[0] : null;
+        $server = $servers !== null && !empty($servers[0]) ? $servers[0] : null;
 
         if (null !== $server) {
             $url = parse_url($server->getUrl());


### PR DESCRIPTION
This fixes notice when you run `generate`:
```
PHP Notice:  Undefined offset: 0 in /app/vendor/jane-php/open-api/Generator/Psr18ClientGenerator.php on line 112
PHP Stack trace:
PHP   1. {main}() /app/vendor/jane-php/open-api/bin/jane-openapi:0
PHP   2. Jane\OpenApi\Application->run($input = *uninitialized*, $output = *uninitialized*) /app/vendor/jane-php/open-api/bin/jane-openapi:22
PHP   3. Jane\OpenApi\Application->doRun($input = *uninitialized*, $output = *uninitialized*) /app/vendor/symfony/console/Application.php:149
PHP   4. Jane\OpenApi\Application->doRunCommand($command = *uninitialized*, $input = *uninitialized*, $output = *uninitialized*) /app/vendor/symfony/console/Application.php:273
PHP   5. Jane\OpenApi\Command\GenerateCommand->run($input = *uninitialized*, $output = *uninitialized*) /app/vendor/symfony/console/Application.php:934
PHP   6. Jane\OpenApi\Command\GenerateCommand->execute($input = *uninitialized*, $output = *uninitialized*) /app/vendor/symfony/console/Command/Command.php:255
PHP   7. Jane\OpenApi\JaneOpenApi->generate($registry = *uninitialized*) /app/vendor/jane-php/open-api/Command/GenerateCommand.php:69
PHP   8. Jane\OpenApi\Generator\Psr18ClientGenerator->generate($schema = *uninitialized*, $className = *uninitialized*, $context = *uninitialized*) /app/vendor/jane-php/json-schema/Generator/ChainGenerator.php:28
PHP   9. Jane\OpenApi\Generator\Psr18ClientGenerator->getFactoryMethod($context = *uninitialized*) /app/vendor/jane-php/open-api/Generator/ClientGenerator.php:50
PHP  10. Jane\OpenApi\Generator\Psr18ClientGenerator->getHttpClientCreateExpr($context = *uninitialized*) /app/vendor/jane-php/open-api/Generator/Psr18ClientGenerator.php:48
```