### PR TITLE
Fix nullable array types

### DIFF
--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -4,6 +4,7 @@ namespace Jane\JsonSchema\Generator\Normalizer;
 
 use Jane\JsonSchema\Generator\Context\Context;
 use Jane\JsonSchema\Generator\Naming;
+use Jane\JsonSchema\Guesser\Guess\ArrayType;
 use Jane\JsonSchema\Guesser\Guess\ClassGuess;
 use Jane\JsonSchema\Guesser\Guess\DateTimeType;
 use Jane\JsonSchema\Guesser\Guess\MapType;
@@ -105,7 +106,8 @@ trait NormalizerGenerator
                         $property->getType() instanceof DateTimeType ||
                         $property->getType() instanceof MapType ||
                         $property->getType() instanceof ObjectType ||
-                        $property->getType() instanceof PatternMultipleType
+                        $property->getType() instanceof PatternMultipleType ||
+                        $property->getType() instanceof ArrayType
                     )) {
                     $statements[] = new Stmt\If_(
                         new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $propertyVar),

--- a/src/OpenApi/Tests/fixtures/test-nullable-array/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/test-nullable-array/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/schema.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Client.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function testNullableArray(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Endpoint\TestNullableArray(), $fetch);
+    }
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Endpoint/TestNullableArray.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Endpoint/TestNullableArray.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Endpoint;
+
+class TestNullableArray extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/test-nullable-array';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status) {
+            return null;
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Model/Model.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Model/Model.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Model
+{
+    /**
+     * 
+     *
+     * @var string|null
+     */
+    protected $foo;
+    /**
+     * 
+     *
+     * @var mixed[]|null
+     */
+    protected $bar;
+    /**
+     * 
+     *
+     * @return string|null
+     */
+    public function getFoo() : ?string
+    {
+        return $this->foo;
+    }
+    /**
+     * 
+     *
+     * @param string|null $foo
+     *
+     * @return self
+     */
+    public function setFoo(?string $foo) : self
+    {
+        $this->foo = $foo;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return mixed[]|null
+     */
+    public function getBar() : ?array
+    {
+        return $this->bar;
+    }
+    /**
+     * 
+     *
+     * @param mixed[]|null $bar
+     *
+     * @return self
+     */
+    public function setBar(?array $bar) : self
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Normalizer/ModelNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Model';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Model';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Model();
+        if (property_exists($data, 'foo')) {
+            $object->setFoo($data->{'foo'});
+        }
+        if (property_exists($data, 'bar')) {
+            $values = array();
+            foreach ($data->{'bar'} as $value) {
+                $values[] = $value;
+            }
+            $object->setBar($values);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getBar()) {
+            $values = array();
+            foreach ($object->getBar() as $value) {
+                $values[] = $value;
+            }
+            $data->{'bar'} = $values;
+        }
+        else {
+            $data->{'bar'} = null;
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new ModelNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/test-nullable-array/schema.json
+++ b/src/OpenApi/Tests/fixtures/test-nullable-array/schema.json
@@ -1,0 +1,39 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "",
+        "title": ""
+    },
+    "paths": {
+        "/test-nullable-array": {
+            "get": {
+                "operationId": "Test Nullable Array",
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                },
+                "tags": [
+                    "Test"
+                ]
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Model": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "nullable": true,
+                        "type": "string"
+                    },
+                    "bar": {
+                        "nullable": true,
+                        "type": "array"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #201 by extending the condition checking if the property is of type `ArrayType`

