### PR TITLE
Readonly property support

### DIFF
--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -13,7 +13,6 @@ use Jane\JsonSchema\Guesser\Guess\ObjectType;
 use Jane\JsonSchema\Guesser\Guess\PatternMultipleType;
 use Jane\JsonSchema\Guesser\Guess\Property;
 use Jane\JsonSchema\Guesser\Guess\Type;
-use Jane\JsonSchemaRuntime\Reference;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;

--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -13,7 +13,7 @@ use Jane\JsonSchema\Guesser\Guess\ObjectType;
 use Jane\JsonSchema\Guesser\Guess\PatternMultipleType;
 use Jane\JsonSchema\Guesser\Guess\Property;
 use Jane\JsonSchema\Guesser\Guess\Type;
-use Jane\OpenApi\JsonSchema\Model\Schema;
+use Jane\JsonSchemaRuntime\Reference;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Name;
 use PhpParser\Node\Param;
@@ -95,7 +95,7 @@ trait NormalizerGenerator
 
         /** @var Property $property */
         foreach ($classGuess->getProperties() as $property) {
-            if ($property->getObject() instanceof Schema && !$property->getObject()->getReadOnly()) {
+            if (!$this->isReadOnlyProperty($property)) {
                 $propertyVar = new Expr\MethodCall($objectVariable, $this->getNaming()->getPrefixedMethodName('get', $property->getPhpName()));
 
                 list($normalizationStatements, $outputVar) = $property->getType()->createNormalizationStatement($context, $propertyVar);
@@ -197,5 +197,12 @@ trait NormalizerGenerator
         return [
             new Stmt\Expression(new Expr\Assign($dataVariable, new Expr\New_(new Name('\\stdClass')))),
         ];
+    }
+
+    protected function isReadOnlyProperty(Property $property): bool
+    {
+        $isNotAReference = !$property->getObject() instanceof Reference;
+
+        return $isNotAReference && $property->getObject()->getReadOnly();
     }
 }

--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -95,7 +95,7 @@ trait NormalizerGenerator
 
         /** @var Property $property */
         foreach ($classGuess->getProperties() as $property) {
-            if (!$this->isReadOnlyProperty($property)) {
+            if (!$property->isReadOnly()) {
                 $propertyVar = new Expr\MethodCall($objectVariable, $this->getNaming()->getPrefixedMethodName('get', $property->getPhpName()));
 
                 list($normalizationStatements, $outputVar) = $property->getType()->createNormalizationStatement($context, $propertyVar);
@@ -197,12 +197,5 @@ trait NormalizerGenerator
         return [
             new Stmt\Expression(new Expr\Assign($dataVariable, new Expr\New_(new Name('\\stdClass')))),
         ];
-    }
-
-    protected function isReadOnlyProperty(Property $property): bool
-    {
-        $isNotAReference = !$property->getObject() instanceof Reference;
-
-        return $isNotAReference && $property->getObject()->getReadOnly();
     }
 }

--- a/src/JsonSchema/Tests/fixtures/read-only/.jane
+++ b/src/JsonSchema/Tests/fixtures/read-only/.jane
@@ -5,5 +5,4 @@ return [
     'root-class' => 'Test',
     'namespace' => 'Jane\JsonSchema\Tests\Expected',
     'directory' => __DIR__ . '/generated',
-    'use-fixer' => false,
 ];

--- a/src/JsonSchema/Tests/fixtures/read-only/.jane
+++ b/src/JsonSchema/Tests/fixtures/read-only/.jane
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'json-schema-file' => __DIR__ . '/schema.json',
+    'root-class' => 'Test',
+    'namespace' => 'Jane\JsonSchema\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Model/Foo.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Model/Foo.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Model;
+
+class Foo
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $foo;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $bar;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $fooBar;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+    /**
+     * 
+     *
+     * @param string $foo
+     *
+     * @return self
+     */
+    public function setFoo(string $foo) : self
+    {
+        $this->foo = $foo;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getBar() : string
+    {
+        return $this->bar;
+    }
+    /**
+     * 
+     *
+     * @param string $bar
+     *
+     * @return self
+     */
+    public function setBar(string $bar) : self
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getFooBar() : string
+    {
+        return $this->fooBar;
+    }
+    /**
+     * 
+     *
+     * @param string $fooBar
+     *
+     * @return self
+     */
+    public function setFooBar(string $fooBar) : self
+    {
+        $this->fooBar = $fooBar;
+        return $this;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/FooNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FooNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\JsonSchema\\Tests\\Expected\\Model\\Foo';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\JsonSchema\Tests\Expected\Model\Foo;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        if (isset($data->{'$ref'})) {
+            return new Reference($data->{'$ref'}, $context['document-origin']);
+        }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
+        $object = new \Jane\JsonSchema\Tests\Expected\Model\Foo();
+        if (property_exists($data, 'foo')) {
+            $object->setFoo($data->{'foo'});
+        }
+        if (property_exists($data, 'bar')) {
+            $object->setBar($data->{'bar'});
+        }
+        if (property_exists($data, 'fooBar')) {
+            $object->setFooBar($data->{'fooBar'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
+        if (null !== $object->getFooBar()) {
+            $data->{'fooBar'} = $object->getFooBar();
+        }
+        return $data;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/NormalizerFactory.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new \Jane\JsonSchemaRuntime\Normalizer\ReferenceNormalizer();
+        $normalizers[] = new FooNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/read-only/schema.json
+++ b/src/JsonSchema/Tests/fixtures/read-only/schema.json
@@ -1,0 +1,23 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Schema with definitions",
+    "definitions": {
+        "Foo": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "string",
+                    "readOnly": true
+                },
+                "bar": {
+                    "type": "string",
+                    "readOnly": false
+                },
+                "fooBar": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentNormalizer.php
@@ -48,9 +48,6 @@ class ParchmentNormalizer implements DenormalizerInterface, NormalizerInterface,
         if (null !== $object->getDescription()) {
             $data->{'description'} = $object->getDescription();
         }
-        if (null !== $object->getId()) {
-            $data->{'id'} = $object->getId();
-        }
         return $data;
     }
 }

--- a/src/OpenApi/Tests/fixtures/read-only-properties/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/read-only-properties/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/schema.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi/Tests/fixtures/read-only-properties/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/read-only-properties/.jane-openapi
@@ -4,5 +4,4 @@ return [
     'openapi-file' => __DIR__ . '/schema.json',
     'namespace' => 'Jane\OpenApi\Tests\Expected',
     'directory' => __DIR__ . '/generated',
-    'use-fixer' => false,
 ];

--- a/src/OpenApi/Tests/fixtures/read-only-properties/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/read-only-properties/expected/Client.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(\Jane\OpenApi\Tests\Expected\Normalizer\NormalizerFactory::create(), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/read-only-properties/expected/Model/Model.php
+++ b/src/OpenApi/Tests/fixtures/read-only-properties/expected/Model/Model.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Model
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $foo;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $bar;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+    /**
+     * 
+     *
+     * @param string $foo
+     *
+     * @return self
+     */
+    public function setFoo(string $foo) : self
+    {
+        $this->foo = $foo;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getBar() : string
+    {
+        return $this->bar;
+    }
+    /**
+     * 
+     *
+     * @param string $bar
+     *
+     * @return self
+     */
+    public function setBar(string $bar) : self
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/read-only-properties/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/read-only-properties/expected/Normalizer/ModelNormalizer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Model';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Model';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException();
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Model();
+        if (property_exists($data, 'foo')) {
+            $object->setFoo($data->{'foo'});
+        }
+        if (property_exists($data, 'bar')) {
+            $object->setBar($data->{'bar'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/read-only-properties/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/read-only-properties/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new ModelNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/read-only-properties/schema.json
+++ b/src/OpenApi/Tests/fixtures/read-only-properties/schema.json
@@ -1,0 +1,23 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "",
+        "title": ""
+    },
+    "components": {
+        "schemas": {
+            "Model": {
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "bar": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR provides a simplified solution (compared to the v6 proxy approach) to add support for `readOnly` properties by normalizing only properties for the request payload model which are not marked with `readOnly: true`.

provides a solution for #133 

