### PR TITLE
Improve sorting in multiType guesser

### DIFF
--- a/src/JsonSchema/Guesser/Guess/MultipleType.php
+++ b/src/JsonSchema/Guesser/Guess/MultipleType.php
@@ -60,7 +60,11 @@ class MultipleType extends Type
         usort($types, function ($first, $second) {
             /* @var Type $first */
             /* @var Type $second */
-            return $first->name == 'mixed' ? 1 : 0;
+            if (($second instanceof ObjectType && 'Reference' === $second->getClassName()) || 'mixed' === $first->getName()) {
+                return 1;
+            }
+
+            return 0;
         });
 
         return $types;

--- a/src/JsonSchema/Guesser/Guess/ObjectType.php
+++ b/src/JsonSchema/Guesser/Guess/ObjectType.php
@@ -126,6 +126,11 @@ class ObjectType extends Type
         return $this->getTypeHint($namespace);
     }
 
+    public function getClassName()
+    {
+        return $this->className;
+    }
+
     private function getFqdn($withRoot = true)
     {
         if ($withRoot) {

--- a/src/OpenApi/.jane
+++ b/src/OpenApi/.jane
@@ -1,11 +1,11 @@
 <?php
 
 return [
-    'json-schema-file' => __DIR__ . '/JsonSchema/version3.json',
+    'json-schema-file' => __DIR__ . '/version3.json',
     'root-class' => 'OpenApi',
     'namespace' => 'Jane\OpenApi\JsonSchema',
     'directory' => __DIR__ . DIRECTORY_SEPARATOR . 'JsonSchema',
     'reference' => true,
-    'cs-fixer' => true,
+    'use-fixer' => true,
     'strict' => false,
 ];

--- a/src/OpenApi/JsonSchema/Model/Components.php
+++ b/src/OpenApi/JsonSchema/Model/Components.php
@@ -13,7 +13,7 @@ namespace Jane\OpenApi\JsonSchema\Model;
 class Components extends \ArrayObject
 {
     /**
-     * @var Schema|Reference[]|null
+     * @var Reference|Schema[]|null
      */
     protected $schemas;
     /**
@@ -50,7 +50,7 @@ class Components extends \ArrayObject
     protected $callbacks;
 
     /**
-     * @return Schema|Reference[]
+     * @return Reference|Schema[]
      */
     public function getSchemas()
     {
@@ -58,7 +58,7 @@ class Components extends \ArrayObject
     }
 
     /**
-     * @param Schema|Reference[] $schemas
+     * @param Reference|Schema[] $schemas
      *
      * @return self
      */

--- a/src/OpenApi/JsonSchema/Model/Header.php
+++ b/src/OpenApi/JsonSchema/Model/Header.php
@@ -41,7 +41,7 @@ class Header extends \ArrayObject
      */
     protected $allowReserved = false;
     /**
-     * @var Schema|Reference|null
+     * @var Reference|Schema|null
      */
     protected $schema;
     /**
@@ -198,7 +198,7 @@ class Header extends \ArrayObject
     }
 
     /**
-     * @return Schema|Reference|null
+     * @return Reference|Schema|null
      */
     public function getSchema()
     {
@@ -206,7 +206,7 @@ class Header extends \ArrayObject
     }
 
     /**
-     * @param Schema|Reference|null $schema
+     * @param Reference|Schema|null $schema
      *
      * @return self
      */

--- a/src/OpenApi/JsonSchema/Model/MediaType.php
+++ b/src/OpenApi/JsonSchema/Model/MediaType.php
@@ -13,7 +13,7 @@ namespace Jane\OpenApi\JsonSchema\Model;
 class MediaType extends \ArrayObject
 {
     /**
-     * @var Schema|Reference|null
+     * @var Reference|Schema|null
      */
     protected $schema;
     /**
@@ -30,7 +30,7 @@ class MediaType extends \ArrayObject
     protected $encoding;
 
     /**
-     * @return Schema|Reference|null
+     * @return Reference|Schema|null
      */
     public function getSchema()
     {
@@ -38,7 +38,7 @@ class MediaType extends \ArrayObject
     }
 
     /**
-     * @param Schema|Reference|null $schema
+     * @param Reference|Schema|null $schema
      *
      * @return self
      */

--- a/src/OpenApi/JsonSchema/Model/Operation.php
+++ b/src/OpenApi/JsonSchema/Model/Operation.php
@@ -37,7 +37,7 @@ class Operation extends \ArrayObject
      */
     protected $parameters;
     /**
-     * @var RequestBody|Reference|null
+     * @var Reference|RequestBody|null
      */
     protected $requestBody;
     /**
@@ -182,7 +182,7 @@ class Operation extends \ArrayObject
     }
 
     /**
-     * @return RequestBody|Reference|null
+     * @return Reference|RequestBody|null
      */
     public function getRequestBody()
     {
@@ -190,7 +190,7 @@ class Operation extends \ArrayObject
     }
 
     /**
-     * @param RequestBody|Reference|null $requestBody
+     * @param Reference|RequestBody|null $requestBody
      *
      * @return self
      */

--- a/src/OpenApi/JsonSchema/Model/Parameter.php
+++ b/src/OpenApi/JsonSchema/Model/Parameter.php
@@ -49,7 +49,7 @@ class Parameter extends \ArrayObject
      */
     protected $allowReserved = false;
     /**
-     * @var Schema|Reference|null
+     * @var Reference|Schema|null
      */
     protected $schema;
     /**
@@ -246,7 +246,7 @@ class Parameter extends \ArrayObject
     }
 
     /**
-     * @return Schema|Reference|null
+     * @return Reference|Schema|null
      */
     public function getSchema()
     {
@@ -254,7 +254,7 @@ class Parameter extends \ArrayObject
     }
 
     /**
-     * @param Schema|Reference|null $schema
+     * @param Reference|Schema|null $schema
      *
      * @return self
      */

--- a/src/OpenApi/JsonSchema/Model/Responses.php
+++ b/src/OpenApi/JsonSchema/Model/Responses.php
@@ -13,12 +13,12 @@ namespace Jane\OpenApi\JsonSchema\Model;
 class Responses extends \ArrayObject
 {
     /**
-     * @var Response|Reference|null
+     * @var Reference|Response|null
      */
     protected $default;
 
     /**
-     * @return Response|Reference|null
+     * @return Reference|Response|null
      */
     public function getDefault()
     {
@@ -26,7 +26,7 @@ class Responses extends \ArrayObject
     }
 
     /**
-     * @param Response|Reference|null $default
+     * @param Reference|Response|null $default
      *
      * @return self
      */

--- a/src/OpenApi/JsonSchema/Model/Schema.php
+++ b/src/OpenApi/JsonSchema/Model/Schema.php
@@ -81,7 +81,7 @@ class Schema extends \ArrayObject
      */
     protected $type;
     /**
-     * @var Schema|Reference|null
+     * @var Reference|Schema|null
      */
     protected $not;
     /**
@@ -97,7 +97,7 @@ class Schema extends \ArrayObject
      */
     protected $anyOf;
     /**
-     * @var Schema|Reference|null
+     * @var Reference|Schema|null
      */
     protected $items;
     /**
@@ -105,7 +105,7 @@ class Schema extends \ArrayObject
      */
     protected $properties;
     /**
-     * @var Schema|Reference|bool|null
+     * @var Reference|Schema|bool|null
      */
     protected $additionalProperties = false;
     /**
@@ -494,7 +494,7 @@ class Schema extends \ArrayObject
     }
 
     /**
-     * @return Schema|Reference|null
+     * @return Reference|Schema|null
      */
     public function getNot()
     {
@@ -502,7 +502,7 @@ class Schema extends \ArrayObject
     }
 
     /**
-     * @param Schema|Reference|null $not
+     * @param Reference|Schema|null $not
      *
      * @return self
      */
@@ -574,7 +574,7 @@ class Schema extends \ArrayObject
     }
 
     /**
-     * @return Schema|Reference|null
+     * @return Reference|Schema|null
      */
     public function getItems()
     {
@@ -582,7 +582,7 @@ class Schema extends \ArrayObject
     }
 
     /**
-     * @param Schema|Reference|null $items
+     * @param Reference|Schema|null $items
      *
      * @return self
      */
@@ -614,7 +614,7 @@ class Schema extends \ArrayObject
     }
 
     /**
-     * @return Schema|Reference|bool|null
+     * @return Reference|Schema|bool|null
      */
     public function getAdditionalProperties()
     {
@@ -622,7 +622,7 @@ class Schema extends \ArrayObject
     }
 
     /**
-     * @param Schema|Reference|bool|null $additionalProperties
+     * @param Reference|Schema|bool|null $additionalProperties
      *
      * @return self
      */

--- a/src/OpenApi/JsonSchema/Normalizer/APIKeySecuritySchemeNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/APIKeySecuritySchemeNormalizer.php
@@ -41,6 +41,9 @@ class APIKeySecuritySchemeNormalizer implements DenormalizerInterface, Normalize
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\APIKeySecurityScheme();
         $data = clone $data;
         if (property_exists($data, 'type') && $data->{'type'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/AuthorizationCodeOAuthFlowNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/AuthorizationCodeOAuthFlowNormalizer.php
@@ -41,6 +41,9 @@ class AuthorizationCodeOAuthFlowNormalizer implements DenormalizerInterface, Nor
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\AuthorizationCodeOAuthFlow();
         $data = clone $data;
         if (property_exists($data, 'authorizationUrl') && $data->{'authorizationUrl'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/ClientCredentialsFlowNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ClientCredentialsFlowNormalizer.php
@@ -41,6 +41,9 @@ class ClientCredentialsFlowNormalizer implements DenormalizerInterface, Normaliz
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\ClientCredentialsFlow();
         $data = clone $data;
         if (property_exists($data, 'tokenUrl') && $data->{'tokenUrl'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/ComponentsNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ComponentsNormalizer.php
@@ -41,6 +41,9 @@ class ComponentsNormalizer implements DenormalizerInterface, NormalizerInterface
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Components();
         $data = clone $data;
         if (property_exists($data, 'schemas') && $data->{'schemas'} !== null) {
@@ -48,10 +51,10 @@ class ComponentsNormalizer implements DenormalizerInterface, NormalizerInterface
             foreach ($data->{'schemas'} as $key => $value) {
                 if (preg_match('/^[a-zA-Z0-9\.\-_]+$/', $key) && isset($value)) {
                     $value_1 = $value;
-                    if (is_object($value)) {
-                        $value_1 = $this->denormalizer->denormalize($value, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-                    } elseif (is_object($value) and isset($value->{'$ref'})) {
+                    if (is_object($value) and isset($value->{'$ref'})) {
                         $value_1 = $this->denormalizer->denormalize($value, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                    } elseif (is_object($value)) {
+                        $value_1 = $this->denormalizer->denormalize($value, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
                     }
                     $values[$key] = $value_1;
                     continue;

--- a/src/OpenApi/JsonSchema/Normalizer/ContactNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ContactNormalizer.php
@@ -41,6 +41,9 @@ class ContactNormalizer implements DenormalizerInterface, NormalizerInterface, D
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Contact();
         $data = clone $data;
         if (property_exists($data, 'name') && $data->{'name'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/DiscriminatorNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/DiscriminatorNormalizer.php
@@ -41,6 +41,9 @@ class DiscriminatorNormalizer implements DenormalizerInterface, NormalizerInterf
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Discriminator();
         if (property_exists($data, 'propertyName') && $data->{'propertyName'} !== null) {
             $object->setPropertyName($data->{'propertyName'});

--- a/src/OpenApi/JsonSchema/Normalizer/EncodingNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/EncodingNormalizer.php
@@ -41,6 +41,9 @@ class EncodingNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Encoding();
         if (property_exists($data, 'contentType') && $data->{'contentType'} !== null) {
             $object->setContentType($data->{'contentType'});

--- a/src/OpenApi/JsonSchema/Normalizer/ExampleNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ExampleNormalizer.php
@@ -41,6 +41,9 @@ class ExampleNormalizer implements DenormalizerInterface, NormalizerInterface, D
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Example();
         $data = clone $data;
         if (property_exists($data, 'summary') && $data->{'summary'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/ExternalDocumentationNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ExternalDocumentationNormalizer.php
@@ -41,6 +41,9 @@ class ExternalDocumentationNormalizer implements DenormalizerInterface, Normaliz
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\ExternalDocumentation();
         $data = clone $data;
         if (property_exists($data, 'description') && $data->{'description'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/HTTPSecuritySchemeNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/HTTPSecuritySchemeNormalizer.php
@@ -41,6 +41,9 @@ class HTTPSecuritySchemeNormalizer implements DenormalizerInterface, NormalizerI
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\HTTPSecurityScheme();
         $data = clone $data;
         if (property_exists($data, 'scheme') && $data->{'scheme'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/HTTPSecuritySchemeSubNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/HTTPSecuritySchemeSubNormalizer.php
@@ -41,6 +41,9 @@ class HTTPSecuritySchemeSubNormalizer implements DenormalizerInterface, Normaliz
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\HTTPSecuritySchemeSub();
         if (property_exists($data, 'scheme') && $data->{'scheme'} !== null) {
             $object->setScheme($data->{'scheme'});

--- a/src/OpenApi/JsonSchema/Normalizer/HeaderNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/HeaderNormalizer.php
@@ -41,6 +41,9 @@ class HeaderNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Header();
         $data = clone $data;
         if (property_exists($data, 'description') && $data->{'description'} !== null) {
@@ -73,10 +76,10 @@ class HeaderNormalizer implements DenormalizerInterface, NormalizerInterface, De
         }
         if (property_exists($data, 'schema') && $data->{'schema'} !== null) {
             $value = $data->{'schema'};
-            if (is_object($data->{'schema'})) {
-                $value = $this->denormalizer->denormalize($data->{'schema'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-            } elseif (is_object($data->{'schema'}) and isset($data->{'schema'}->{'$ref'})) {
+            if (is_object($data->{'schema'}) and isset($data->{'schema'}->{'$ref'})) {
                 $value = $this->denormalizer->denormalize($data->{'schema'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+            } elseif (is_object($data->{'schema'})) {
+                $value = $this->denormalizer->denormalize($data->{'schema'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
             }
             $object->setSchema($value);
             unset($data->{'schema'});
@@ -97,10 +100,10 @@ class HeaderNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'examples'} as $key_1 => $value_2) {
                 $value_3 = $value_2;
-                if (is_object($value_2)) {
-                    $value_3 = $this->denormalizer->denormalize($value_2, 'Jane\\OpenApi\\JsonSchema\\Model\\Example', 'json', $context);
-                } elseif (is_object($value_2) and isset($value_2->{'$ref'})) {
+                if (is_object($value_2) and isset($value_2->{'$ref'})) {
                     $value_3 = $this->denormalizer->denormalize($value_2, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_2)) {
+                    $value_3 = $this->denormalizer->denormalize($value_2, 'Jane\\OpenApi\\JsonSchema\\Model\\Example', 'json', $context);
                 }
                 $values_1[$key_1] = $value_3;
             }

--- a/src/OpenApi/JsonSchema/Normalizer/ImplicitOAuthFlowNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ImplicitOAuthFlowNormalizer.php
@@ -41,6 +41,9 @@ class ImplicitOAuthFlowNormalizer implements DenormalizerInterface, NormalizerIn
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\ImplicitOAuthFlow();
         $data = clone $data;
         if (property_exists($data, 'authorizationUrl') && $data->{'authorizationUrl'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/InfoNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/InfoNormalizer.php
@@ -41,6 +41,9 @@ class InfoNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Info();
         $data = clone $data;
         if (property_exists($data, 'title') && $data->{'title'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/LicenseNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/LicenseNormalizer.php
@@ -41,6 +41,9 @@ class LicenseNormalizer implements DenormalizerInterface, NormalizerInterface, D
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\License();
         $data = clone $data;
         if (property_exists($data, 'name') && $data->{'name'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/LinkNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/LinkNormalizer.php
@@ -41,6 +41,9 @@ class LinkNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Link();
         $data = clone $data;
         if (property_exists($data, 'operationId') && $data->{'operationId'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/MediaTypeNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/MediaTypeNormalizer.php
@@ -41,14 +41,17 @@ class MediaTypeNormalizer implements DenormalizerInterface, NormalizerInterface,
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\MediaType();
         $data = clone $data;
         if (property_exists($data, 'schema') && $data->{'schema'} !== null) {
             $value = $data->{'schema'};
-            if (is_object($data->{'schema'})) {
-                $value = $this->denormalizer->denormalize($data->{'schema'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-            } elseif (is_object($data->{'schema'}) and isset($data->{'schema'}->{'$ref'})) {
+            if (is_object($data->{'schema'}) and isset($data->{'schema'}->{'$ref'})) {
                 $value = $this->denormalizer->denormalize($data->{'schema'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+            } elseif (is_object($data->{'schema'})) {
+                $value = $this->denormalizer->denormalize($data->{'schema'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
             }
             $object->setSchema($value);
             unset($data->{'schema'});
@@ -61,10 +64,10 @@ class MediaTypeNormalizer implements DenormalizerInterface, NormalizerInterface,
             $values = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'examples'} as $key => $value_1) {
                 $value_2 = $value_1;
-                if (is_object($value_1)) {
-                    $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Example', 'json', $context);
-                } elseif (is_object($value_1) and isset($value_1->{'$ref'})) {
+                if (is_object($value_1) and isset($value_1->{'$ref'})) {
                     $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_1)) {
+                    $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Example', 'json', $context);
                 }
                 $values[$key] = $value_2;
             }

--- a/src/OpenApi/JsonSchema/Normalizer/OAuth2SecuritySchemeNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/OAuth2SecuritySchemeNormalizer.php
@@ -41,6 +41,9 @@ class OAuth2SecuritySchemeNormalizer implements DenormalizerInterface, Normalize
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\OAuth2SecurityScheme();
         $data = clone $data;
         if (property_exists($data, 'type') && $data->{'type'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/OAuthFlowsNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/OAuthFlowsNormalizer.php
@@ -41,6 +41,9 @@ class OAuthFlowsNormalizer implements DenormalizerInterface, NormalizerInterface
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\OAuthFlows();
         $data = clone $data;
         if (property_exists($data, 'implicit') && $data->{'implicit'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/OpenApiNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/OpenApiNormalizer.php
@@ -41,6 +41,9 @@ class OpenApiNormalizer implements DenormalizerInterface, NormalizerInterface, D
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\OpenApi();
         $data = clone $data;
         if (property_exists($data, 'openapi') && $data->{'openapi'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/OpenIdConnectSecuritySchemeNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/OpenIdConnectSecuritySchemeNormalizer.php
@@ -41,6 +41,9 @@ class OpenIdConnectSecuritySchemeNormalizer implements DenormalizerInterface, No
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\OpenIdConnectSecurityScheme();
         $data = clone $data;
         if (property_exists($data, 'type') && $data->{'type'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/OperationNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/OperationNormalizer.php
@@ -41,6 +41,9 @@ class OperationNormalizer implements DenormalizerInterface, NormalizerInterface,
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Operation();
         $data = clone $data;
         if (property_exists($data, 'tags') && $data->{'tags'} !== null) {
@@ -71,10 +74,10 @@ class OperationNormalizer implements DenormalizerInterface, NormalizerInterface,
             $values_1 = [];
             foreach ($data->{'parameters'} as $value_1) {
                 $value_2 = $value_1;
-                if (is_object($value_1) and isset($value_1->{'name'}) and isset($value_1->{'in'})) {
-                    $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Parameter', 'json', $context);
-                } elseif (is_object($value_1) and isset($value_1->{'$ref'})) {
+                if (is_object($value_1) and isset($value_1->{'$ref'})) {
                     $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_1) and isset($value_1->{'name'}) and isset($value_1->{'in'})) {
+                    $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Parameter', 'json', $context);
                 }
                 $values_1[] = $value_2;
             }
@@ -83,10 +86,10 @@ class OperationNormalizer implements DenormalizerInterface, NormalizerInterface,
         }
         if (property_exists($data, 'requestBody') && $data->{'requestBody'} !== null) {
             $value_3 = $data->{'requestBody'};
-            if (is_object($data->{'requestBody'}) and isset($data->{'requestBody'}->{'content'})) {
-                $value_3 = $this->denormalizer->denormalize($data->{'requestBody'}, 'Jane\\OpenApi\\JsonSchema\\Model\\RequestBody', 'json', $context);
-            } elseif (is_object($data->{'requestBody'}) and isset($data->{'requestBody'}->{'$ref'})) {
+            if (is_object($data->{'requestBody'}) and isset($data->{'requestBody'}->{'$ref'})) {
                 $value_3 = $this->denormalizer->denormalize($data->{'requestBody'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+            } elseif (is_object($data->{'requestBody'}) and isset($data->{'requestBody'}->{'content'})) {
+                $value_3 = $this->denormalizer->denormalize($data->{'requestBody'}, 'Jane\\OpenApi\\JsonSchema\\Model\\RequestBody', 'json', $context);
             }
             $object->setRequestBody($value_3);
             unset($data->{'requestBody'});

--- a/src/OpenApi/JsonSchema/Normalizer/ParameterNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ParameterNormalizer.php
@@ -41,6 +41,9 @@ class ParameterNormalizer implements DenormalizerInterface, NormalizerInterface,
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Parameter();
         $data = clone $data;
         if (property_exists($data, 'name') && $data->{'name'} !== null) {
@@ -81,10 +84,10 @@ class ParameterNormalizer implements DenormalizerInterface, NormalizerInterface,
         }
         if (property_exists($data, 'schema') && $data->{'schema'} !== null) {
             $value = $data->{'schema'};
-            if (is_object($data->{'schema'})) {
-                $value = $this->denormalizer->denormalize($data->{'schema'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-            } elseif (is_object($data->{'schema'}) and isset($data->{'schema'}->{'$ref'})) {
+            if (is_object($data->{'schema'}) and isset($data->{'schema'}->{'$ref'})) {
                 $value = $this->denormalizer->denormalize($data->{'schema'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+            } elseif (is_object($data->{'schema'})) {
+                $value = $this->denormalizer->denormalize($data->{'schema'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
             }
             $object->setSchema($value);
             unset($data->{'schema'});
@@ -105,10 +108,10 @@ class ParameterNormalizer implements DenormalizerInterface, NormalizerInterface,
             $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'examples'} as $key_1 => $value_2) {
                 $value_3 = $value_2;
-                if (is_object($value_2)) {
-                    $value_3 = $this->denormalizer->denormalize($value_2, 'Jane\\OpenApi\\JsonSchema\\Model\\Example', 'json', $context);
-                } elseif (is_object($value_2) and isset($value_2->{'$ref'})) {
+                if (is_object($value_2) and isset($value_2->{'$ref'})) {
                     $value_3 = $this->denormalizer->denormalize($value_2, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_2)) {
+                    $value_3 = $this->denormalizer->denormalize($value_2, 'Jane\\OpenApi\\JsonSchema\\Model\\Example', 'json', $context);
                 }
                 $values_1[$key_1] = $value_3;
             }

--- a/src/OpenApi/JsonSchema/Normalizer/PasswordOAuthFlowNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/PasswordOAuthFlowNormalizer.php
@@ -41,6 +41,9 @@ class PasswordOAuthFlowNormalizer implements DenormalizerInterface, NormalizerIn
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\PasswordOAuthFlow();
         $data = clone $data;
         if (property_exists($data, 'tokenUrl') && $data->{'tokenUrl'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/PathItemNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/PathItemNormalizer.php
@@ -41,6 +41,9 @@ class PathItemNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\PathItem();
         $data = clone $data;
         if (property_exists($data, '$ref') && $data->{'$ref'} !== null) {
@@ -99,10 +102,10 @@ class PathItemNormalizer implements DenormalizerInterface, NormalizerInterface, 
             $values_1 = [];
             foreach ($data->{'parameters'} as $value_1) {
                 $value_2 = $value_1;
-                if (is_object($value_1) and isset($value_1->{'name'}) and isset($value_1->{'in'})) {
-                    $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Parameter', 'json', $context);
-                } elseif (is_object($value_1) and isset($value_1->{'$ref'})) {
+                if (is_object($value_1) and isset($value_1->{'$ref'})) {
                     $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_1) and isset($value_1->{'name'}) and isset($value_1->{'in'})) {
+                    $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Parameter', 'json', $context);
                 }
                 $values_1[] = $value_2;
             }

--- a/src/OpenApi/JsonSchema/Normalizer/ReferenceNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ReferenceNormalizer.php
@@ -41,6 +41,9 @@ class ReferenceNormalizer implements DenormalizerInterface, NormalizerInterface,
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Reference();
         if (property_exists($data, '$ref') && $data->{'$ref'} !== null) {
             $object->setDollarRef($data->{'$ref'});

--- a/src/OpenApi/JsonSchema/Normalizer/RequestBodyNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/RequestBodyNormalizer.php
@@ -41,6 +41,9 @@ class RequestBodyNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\RequestBody();
         $data = clone $data;
         if (property_exists($data, 'description') && $data->{'description'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/ResponseNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ResponseNormalizer.php
@@ -41,6 +41,9 @@ class ResponseNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Response();
         $data = clone $data;
         if (property_exists($data, 'description') && $data->{'description'} !== null) {
@@ -51,10 +54,10 @@ class ResponseNormalizer implements DenormalizerInterface, NormalizerInterface, 
             $values = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'headers'} as $key => $value) {
                 $value_1 = $value;
-                if (is_object($value)) {
-                    $value_1 = $this->denormalizer->denormalize($value, 'Jane\\OpenApi\\JsonSchema\\Model\\Header', 'json', $context);
-                } elseif (is_object($value) and isset($value->{'$ref'})) {
+                if (is_object($value) and isset($value->{'$ref'})) {
                     $value_1 = $this->denormalizer->denormalize($value, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value)) {
+                    $value_1 = $this->denormalizer->denormalize($value, 'Jane\\OpenApi\\JsonSchema\\Model\\Header', 'json', $context);
                 }
                 $values[$key] = $value_1;
             }
@@ -73,10 +76,10 @@ class ResponseNormalizer implements DenormalizerInterface, NormalizerInterface, 
             $values_2 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'links'} as $key_2 => $value_3) {
                 $value_4 = $value_3;
-                if (is_object($value_3)) {
-                    $value_4 = $this->denormalizer->denormalize($value_3, 'Jane\\OpenApi\\JsonSchema\\Model\\Link', 'json', $context);
-                } elseif (is_object($value_3) and isset($value_3->{'$ref'})) {
+                if (is_object($value_3) and isset($value_3->{'$ref'})) {
                     $value_4 = $this->denormalizer->denormalize($value_3, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_3)) {
+                    $value_4 = $this->denormalizer->denormalize($value_3, 'Jane\\OpenApi\\JsonSchema\\Model\\Link', 'json', $context);
                 }
                 $values_2[$key_2] = $value_4;
             }

--- a/src/OpenApi/JsonSchema/Normalizer/ResponsesNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ResponsesNormalizer.php
@@ -41,14 +41,17 @@ class ResponsesNormalizer implements DenormalizerInterface, NormalizerInterface,
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Responses();
         $data = clone $data;
         if (property_exists($data, 'default') && $data->{'default'} !== null) {
             $value = $data->{'default'};
-            if (is_object($data->{'default'}) and isset($data->{'default'}->{'description'})) {
-                $value = $this->denormalizer->denormalize($data->{'default'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Response', 'json', $context);
-            } elseif (is_object($data->{'default'}) and isset($data->{'default'}->{'$ref'})) {
+            if (is_object($data->{'default'}) and isset($data->{'default'}->{'$ref'})) {
                 $value = $this->denormalizer->denormalize($data->{'default'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+            } elseif (is_object($data->{'default'}) and isset($data->{'default'}->{'description'})) {
+                $value = $this->denormalizer->denormalize($data->{'default'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Response', 'json', $context);
             }
             $object->setDefault($value);
             unset($data->{'default'});
@@ -56,10 +59,10 @@ class ResponsesNormalizer implements DenormalizerInterface, NormalizerInterface,
         foreach ($data as $key => $value_1) {
             if (preg_match('/^[1-5](?:\d{2}|XX)$/', $key)) {
                 $value_2 = $value_1;
-                if (is_object($value_1) and isset($value_1->{'description'})) {
-                    $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Response', 'json', $context);
-                } elseif (is_object($value_1) and isset($value_1->{'$ref'})) {
+                if (is_object($value_1) and isset($value_1->{'$ref'})) {
                     $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_1) and isset($value_1->{'description'})) {
+                    $value_2 = $this->denormalizer->denormalize($value_1, 'Jane\\OpenApi\\JsonSchema\\Model\\Response', 'json', $context);
                 }
                 $object[$key] = $value_2;
             }

--- a/src/OpenApi/JsonSchema/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/SchemaNormalizer.php
@@ -41,6 +41,9 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Schema();
         $data = clone $data;
         if (property_exists($data, 'title') && $data->{'title'} !== null) {
@@ -121,10 +124,10 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
         }
         if (property_exists($data, 'not') && $data->{'not'} !== null) {
             $value_2 = $data->{'not'};
-            if (is_object($data->{'not'})) {
-                $value_2 = $this->denormalizer->denormalize($data->{'not'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-            } elseif (is_object($data->{'not'}) and isset($data->{'not'}->{'$ref'})) {
+            if (is_object($data->{'not'}) and isset($data->{'not'}->{'$ref'})) {
                 $value_2 = $this->denormalizer->denormalize($data->{'not'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+            } elseif (is_object($data->{'not'})) {
+                $value_2 = $this->denormalizer->denormalize($data->{'not'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
             }
             $object->setNot($value_2);
             unset($data->{'not'});
@@ -133,10 +136,10 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $values_2 = [];
             foreach ($data->{'allOf'} as $value_3) {
                 $value_4 = $value_3;
-                if (is_object($value_3)) {
-                    $value_4 = $this->denormalizer->denormalize($value_3, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-                } elseif (is_object($value_3) and isset($value_3->{'$ref'})) {
+                if (is_object($value_3) and isset($value_3->{'$ref'})) {
                     $value_4 = $this->denormalizer->denormalize($value_3, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_3)) {
+                    $value_4 = $this->denormalizer->denormalize($value_3, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
                 }
                 $values_2[] = $value_4;
             }
@@ -147,10 +150,10 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $values_3 = [];
             foreach ($data->{'oneOf'} as $value_5) {
                 $value_6 = $value_5;
-                if (is_object($value_5)) {
-                    $value_6 = $this->denormalizer->denormalize($value_5, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-                } elseif (is_object($value_5) and isset($value_5->{'$ref'})) {
+                if (is_object($value_5) and isset($value_5->{'$ref'})) {
                     $value_6 = $this->denormalizer->denormalize($value_5, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_5)) {
+                    $value_6 = $this->denormalizer->denormalize($value_5, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
                 }
                 $values_3[] = $value_6;
             }
@@ -161,10 +164,10 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $values_4 = [];
             foreach ($data->{'anyOf'} as $value_7) {
                 $value_8 = $value_7;
-                if (is_object($value_7)) {
-                    $value_8 = $this->denormalizer->denormalize($value_7, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-                } elseif (is_object($value_7) and isset($value_7->{'$ref'})) {
+                if (is_object($value_7) and isset($value_7->{'$ref'})) {
                     $value_8 = $this->denormalizer->denormalize($value_7, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_7)) {
+                    $value_8 = $this->denormalizer->denormalize($value_7, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
                 }
                 $values_4[] = $value_8;
             }
@@ -173,10 +176,10 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
         }
         if (property_exists($data, 'items') && $data->{'items'} !== null) {
             $value_9 = $data->{'items'};
-            if (is_object($data->{'items'})) {
-                $value_9 = $this->denormalizer->denormalize($data->{'items'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-            } elseif (is_object($data->{'items'}) and isset($data->{'items'}->{'$ref'})) {
+            if (is_object($data->{'items'}) and isset($data->{'items'}->{'$ref'})) {
                 $value_9 = $this->denormalizer->denormalize($data->{'items'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+            } elseif (is_object($data->{'items'})) {
+                $value_9 = $this->denormalizer->denormalize($data->{'items'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
             }
             $object->setItems($value_9);
             unset($data->{'items'});
@@ -185,10 +188,10 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $values_5 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'properties'} as $key => $value_10) {
                 $value_11 = $value_10;
-                if (is_object($value_10)) {
-                    $value_11 = $this->denormalizer->denormalize($value_10, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-                } elseif (is_object($value_10) and isset($value_10->{'$ref'})) {
+                if (is_object($value_10) and isset($value_10->{'$ref'})) {
                     $value_11 = $this->denormalizer->denormalize($value_10, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+                } elseif (is_object($value_10)) {
+                    $value_11 = $this->denormalizer->denormalize($value_10, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
                 }
                 $values_5[$key] = $value_11;
             }
@@ -197,10 +200,10 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
         }
         if (property_exists($data, 'additionalProperties') && $data->{'additionalProperties'} !== null) {
             $value_12 = $data->{'additionalProperties'};
-            if (is_object($data->{'additionalProperties'})) {
-                $value_12 = $this->denormalizer->denormalize($data->{'additionalProperties'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
-            } elseif (is_object($data->{'additionalProperties'}) and isset($data->{'additionalProperties'}->{'$ref'})) {
+            if (is_object($data->{'additionalProperties'}) and isset($data->{'additionalProperties'}->{'$ref'})) {
                 $value_12 = $this->denormalizer->denormalize($data->{'additionalProperties'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
+            } elseif (is_object($data->{'additionalProperties'})) {
+                $value_12 = $this->denormalizer->denormalize($data->{'additionalProperties'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
             } elseif (is_bool($data->{'additionalProperties'})) {
                 $value_12 = $data->{'additionalProperties'};
             }

--- a/src/OpenApi/JsonSchema/Normalizer/ServerNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ServerNormalizer.php
@@ -41,6 +41,9 @@ class ServerNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Server();
         $data = clone $data;
         if (property_exists($data, 'url') && $data->{'url'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/ServerVariableNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ServerVariableNormalizer.php
@@ -41,6 +41,9 @@ class ServerVariableNormalizer implements DenormalizerInterface, NormalizerInter
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\ServerVariable();
         $data = clone $data;
         if (property_exists($data, 'enum') && $data->{'enum'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/TagNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/TagNormalizer.php
@@ -41,6 +41,9 @@ class TagNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\Tag();
         $data = clone $data;
         if (property_exists($data, 'name') && $data->{'name'} !== null) {

--- a/src/OpenApi/JsonSchema/Normalizer/XMLNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/XMLNormalizer.php
@@ -41,6 +41,9 @@ class XMLNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);
         }
+        if (isset($data->{'$recursiveRef'})) {
+            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+        }
         $object = new \Jane\OpenApi\JsonSchema\Model\XML();
         $data = clone $data;
         if (property_exists($data, 'name') && $data->{'name'} !== null) {

--- a/src/OpenApi/version3.json
+++ b/src/OpenApi/version3.json
@@ -334,7 +334,7 @@
                 "multipleOf": {
                     "type": "number",
                     "minimum": 0,
-                    "exclusiveMinimum": true
+                    "exclusiveMinimum": 0
                 },
                 "maximum": {
                     "type": "number"


### PR DESCRIPTION
In many files, there are incorrect if/elseif statements order (generated by Jane from OpenApi specs).

Example of generated code (src/OpenApi/JsonSchema/Normalizer/ComponentsNormalizer.php):
```
if (is_object($value)) {
    $value_1 = $this->denormalizer->denormalize($value, 'Jane\\OpenApi\\JsonSchema\\Model\\Schema', 'json', $context);
} elseif (is_object($value) and isset($value->{'$ref'})) {
    $value_1 = $this->denormalizer->denormalize($value, 'Jane\\OpenApi\\JsonSchema\\Model\\Reference', 'json', $context);
}
```

This pull-request fix order