### PR TITLE
More explicit message for denormalize exception

### DIFF
--- a/src/JsonSchema/Generator/Normalizer/DenormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/DenormalizerGenerator.php
@@ -157,7 +157,9 @@ trait DenormalizerGenerator
                 [
                     'stmts' => [
                         $context->isStrict() ?
-                            new Stmt\Throw_(new Expr\New_(new Name('InvalidArgumentException')))
+                            new Stmt\Throw_(new Expr\New_(new Name('InvalidArgumentException'), [
+                                new Expr\FuncCall(new Name('sprintf'), [new Arg(new Scalar\String_('Given $data is not an object (%s given). We need an object in order to continue denormalize method.')), new Arg(new Expr\FuncCall(new Name('gettype'), [new Arg(new Expr\Variable('data'))]))]),
+                            ]))
                             :
                             new Stmt\Return_(new Expr\ConstFetch(new Name('null'))),
                     ],

--- a/src/JsonSchema/Tests/fixtures/additional-properties/expected/Normalizer/AdditionalPropertiesNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/additional-properties/expected/Normalizer/AdditionalPropertiesNormalizer.php
@@ -25,7 +25,7 @@ class AdditionalPropertiesNormalizer implements DenormalizerInterface, Normalize
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/additional-properties/expected/Normalizer/PatternPropertiesNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/additional-properties/expected/Normalizer/PatternPropertiesNormalizer.php
@@ -25,7 +25,7 @@ class PatternPropertiesNormalizer implements DenormalizerInterface, NormalizerIn
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BarNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BarNormalizer.php
@@ -25,7 +25,7 @@ class BarNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Bar();
         if (property_exists($data, 'foo')) {

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazBazNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazBazNormalizer.php
@@ -25,7 +25,7 @@ class BazBazNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\BazBaz();
         if (property_exists($data, 'baz')) {

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazNormalizer.php
@@ -25,7 +25,7 @@ class BazNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Baz();
         if (property_exists($data, 'foo')) {

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/ChildtypeNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/ChildtypeNormalizer.php
@@ -25,7 +25,7 @@ class ChildtypeNormalizer implements DenormalizerInterface, NormalizerInterface,
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Childtype();
         if (property_exists($data, 'childProperty')) {

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Foo();
         if (property_exists($data, 'foo')) {

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/OtherchildtypeNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/OtherchildtypeNormalizer.php
@@ -25,7 +25,7 @@ class OtherchildtypeNormalizer implements DenormalizerInterface, NormalizerInter
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Otherchildtype();
         if (property_exists($data, 'inheritedProperty')) {

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/ParenttypeNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/ParenttypeNormalizer.php
@@ -25,7 +25,7 @@ class ParenttypeNormalizer implements DenormalizerInterface, NormalizerInterface
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Parenttype();
         if (property_exists($data, 'inheritedProperty')) {

--- a/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/TestNormalizer.php
@@ -25,7 +25,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Test();
         if (property_exists($data, 'child')) {

--- a/src/JsonSchema/Tests/fixtures/array-object-nullable/expected/Normalizer/AttributesNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/array-object-nullable/expected/Normalizer/AttributesNormalizer.php
@@ -25,7 +25,7 @@ class AttributesNormalizer implements DenormalizerInterface, NormalizerInterface
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/array-object-nullable/expected/Normalizer/DocumentNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/array-object-nullable/expected/Normalizer/DocumentNormalizer.php
@@ -25,7 +25,7 @@ class DocumentNormalizer implements DenormalizerInterface, NormalizerInterface, 
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
@@ -25,7 +25,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
@@ -25,7 +25,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/deep-object/expected/Normalizer/TestFooItemNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/deep-object/expected/Normalizer/TestFooItemNormalizer.php
@@ -25,7 +25,7 @@ class TestFooItemNormalizer implements DenormalizerInterface, NormalizerInterfac
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/deep-object/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/deep-object/expected/Normalizer/TestNormalizer.php
@@ -25,7 +25,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/BarItemNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/BarItemNormalizer.php
@@ -25,7 +25,7 @@ class BarItemNormalizer implements DenormalizerInterface, NormalizerInterface, D
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/HelloWorldNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/definitions/expected/Normalizer/HelloWorldNormalizer.php
@@ -25,7 +25,7 @@ class HelloWorldNormalizer implements DenormalizerInterface, NormalizerInterface
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/deprecated/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/deprecated/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/multi-files/expected/Normalizer/TestFooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/multi-files/expected/Normalizer/TestFooNormalizer.php
@@ -25,7 +25,7 @@ class TestFooNormalizer implements DenormalizerInterface, NormalizerInterface, D
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\TestFoo();
         if (property_exists($data, 'foo')) {

--- a/src/JsonSchema/Tests/fixtures/multi-files/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/multi-files/expected/Normalizer/TestNormalizer.php
@@ -25,7 +25,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Test();
         if (property_exists($data, 'foo')) {

--- a/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Normalizer/TestNormalizer.php
@@ -25,7 +25,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Schema1\Model\Test();
         if (property_exists($data, 'foo')) {

--- a/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema2/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema2/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Schema2\Model\Foo();
         if (property_exists($data, 'foo')) {

--- a/src/JsonSchema/Tests/fixtures/name-conflict/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/name-conflict/expected/Normalizer/TestNormalizer.php
@@ -25,7 +25,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/one-of/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/one-of/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/read-only/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/reserved-words/expected/Normalizer/ListNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/reserved-words/expected/Normalizer/ListNormalizer.php
@@ -25,7 +25,7 @@ class ListNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Normalizer/TestNormalizer.php
@@ -25,7 +25,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Test();
         if (property_exists($data, 'string')) {

--- a/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Normalizer/TestSubObjectNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-no-reference/expected/Normalizer/TestSubObjectNormalizer.php
@@ -25,7 +25,7 @@ class TestSubObjectNormalizer implements DenormalizerInterface, NormalizerInterf
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\TestSubObject();
         if (property_exists($data, 'foo')) {

--- a/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
@@ -25,7 +25,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (isset($data->{'$ref'})) {
             return new Reference($data->{'$ref'}, $context['document-origin']);

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/BarNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/BarNormalizer.php
@@ -25,7 +25,7 @@ class BarNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Bar();
         if (property_exists($data, 'bar')) {

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Foo();
         if (property_exists($data, 'bar')) {

--- a/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FuzNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/all-of-merge/expected/Normalizer/FuzNormalizer.php
@@ -25,7 +25,7 @@ class FuzNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Fuz();
         if (property_exists($data, 'bar')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BookNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BookNormalizer.php
@@ -25,7 +25,7 @@ class BookNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\Book();
         if (property_exists($data, 'isbn')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksGetResponse200HydraSearchHydraMappingItemNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksGetResponse200HydraSearchHydraMappingItemNormalizer.php
@@ -25,7 +25,7 @@ class BooksGetResponse200HydraSearchHydraMappingItemNormalizer implements Denorm
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\BooksGetResponse200HydraSearchHydraMappingItem();
         if (property_exists($data, '@type')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksGetResponse200HydraSearchNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksGetResponse200HydraSearchNormalizer.php
@@ -25,7 +25,7 @@ class BooksGetResponse200HydraSearchNormalizer implements DenormalizerInterface,
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\BooksGetResponse200HydraSearch();
         if (property_exists($data, '@type')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksGetResponse200HydraViewNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksGetResponse200HydraViewNormalizer.php
@@ -25,7 +25,7 @@ class BooksGetResponse200HydraViewNormalizer implements DenormalizerInterface, N
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\BooksGetResponse200HydraView();
         if (property_exists($data, '@id')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksGetResponse200Normalizer.php
@@ -25,7 +25,7 @@ class BooksGetResponse200Normalizer implements DenormalizerInterface, Normalizer
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\BooksGetResponse200();
         if (property_exists($data, 'hydra:member')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksIdReviewsGetResponse200HydraSearchHydraMappingItemNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksIdReviewsGetResponse200HydraSearchHydraMappingItemNormalizer.php
@@ -25,7 +25,7 @@ class BooksIdReviewsGetResponse200HydraSearchHydraMappingItemNormalizer implemen
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\BooksIdReviewsGetResponse200HydraSearchHydraMappingItem();
         if (property_exists($data, '@type')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksIdReviewsGetResponse200HydraSearchNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksIdReviewsGetResponse200HydraSearchNormalizer.php
@@ -25,7 +25,7 @@ class BooksIdReviewsGetResponse200HydraSearchNormalizer implements DenormalizerI
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\BooksIdReviewsGetResponse200HydraSearch();
         if (property_exists($data, '@type')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksIdReviewsGetResponse200HydraViewNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksIdReviewsGetResponse200HydraViewNormalizer.php
@@ -25,7 +25,7 @@ class BooksIdReviewsGetResponse200HydraViewNormalizer implements DenormalizerInt
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\BooksIdReviewsGetResponse200HydraView();
         if (property_exists($data, '@id')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksIdReviewsGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/BooksIdReviewsGetResponse200Normalizer.php
@@ -25,7 +25,7 @@ class BooksIdReviewsGetResponse200Normalizer implements DenormalizerInterface, N
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\BooksIdReviewsGetResponse200();
         if (property_exists($data, 'hydra:member')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentNormalizer.php
@@ -25,7 +25,7 @@ class ParchmentNormalizer implements DenormalizerInterface, NormalizerInterface,
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\Parchment();
         if (property_exists($data, 'title')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentsGetResponse200HydraSearchHydraMappingItemNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentsGetResponse200HydraSearchHydraMappingItemNormalizer.php
@@ -25,7 +25,7 @@ class ParchmentsGetResponse200HydraSearchHydraMappingItemNormalizer implements D
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\ParchmentsGetResponse200HydraSearchHydraMappingItem();
         if (property_exists($data, '@type')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentsGetResponse200HydraSearchNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentsGetResponse200HydraSearchNormalizer.php
@@ -25,7 +25,7 @@ class ParchmentsGetResponse200HydraSearchNormalizer implements DenormalizerInter
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\ParchmentsGetResponse200HydraSearch();
         if (property_exists($data, '@type')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentsGetResponse200HydraViewNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentsGetResponse200HydraViewNormalizer.php
@@ -25,7 +25,7 @@ class ParchmentsGetResponse200HydraViewNormalizer implements DenormalizerInterfa
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\ParchmentsGetResponse200HydraView();
         if (property_exists($data, '@id')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentsGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ParchmentsGetResponse200Normalizer.php
@@ -25,7 +25,7 @@ class ParchmentsGetResponse200Normalizer implements DenormalizerInterface, Norma
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\ParchmentsGetResponse200();
         if (property_exists($data, 'hydra:member')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ReviewNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ReviewNormalizer.php
@@ -25,7 +25,7 @@ class ReviewNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\Review();
         if (property_exists($data, 'body')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ReviewsGetResponse200HydraSearchHydraMappingItemNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ReviewsGetResponse200HydraSearchHydraMappingItemNormalizer.php
@@ -25,7 +25,7 @@ class ReviewsGetResponse200HydraSearchHydraMappingItemNormalizer implements Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\ReviewsGetResponse200HydraSearchHydraMappingItem();
         if (property_exists($data, '@type')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ReviewsGetResponse200HydraSearchNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ReviewsGetResponse200HydraSearchNormalizer.php
@@ -25,7 +25,7 @@ class ReviewsGetResponse200HydraSearchNormalizer implements DenormalizerInterfac
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\ReviewsGetResponse200HydraSearch();
         if (property_exists($data, '@type')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ReviewsGetResponse200HydraViewNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ReviewsGetResponse200HydraViewNormalizer.php
@@ -25,7 +25,7 @@ class ReviewsGetResponse200HydraViewNormalizer implements DenormalizerInterface,
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\ReviewsGetResponse200HydraView();
         if (property_exists($data, '@id')) {

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ReviewsGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Normalizer/ReviewsGetResponse200Normalizer.php
@@ -25,7 +25,7 @@ class ReviewsGetResponse200Normalizer implements DenormalizerInterface, Normaliz
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \ApiPlatform\Demo\Model\ReviewsGetResponse200();
         if (property_exists($data, 'hydra:member')) {

--- a/src/OpenApi/Tests/fixtures/array-definition/expected/Normalizer/BarItemNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/array-definition/expected/Normalizer/BarItemNormalizer.php
@@ -25,7 +25,7 @@ class BarItemNormalizer implements DenormalizerInterface, NormalizerInterface, D
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\BarItem();
         if (property_exists($data, 'bar')) {

--- a/src/OpenApi/Tests/fixtures/authentication-apiKey-header/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/authentication-apiKey-header/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Foo();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/authentication-apiKey-query/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/authentication-apiKey-query/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Foo();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/authentication-http-basic/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/authentication-http-basic/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Foo();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/authentication-http-bearer/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/authentication-http-bearer/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Foo();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
@@ -25,7 +25,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Schema();
         if (property_exists($data, 'stringProperty')) {

--- a/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/body-parameter/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -25,7 +25,7 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\SchemaObjectProperty();
         if (property_exists($data, 'stringProperty')) {

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
@@ -25,7 +25,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Schema();
         if (property_exists($data, 'stringProperty')) {

--- a/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/content-type/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -25,7 +25,7 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\SchemaObjectProperty();
         if (property_exists($data, 'stringProperty')) {

--- a/src/OpenApi/Tests/fixtures/deprecated/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/deprecated/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Foo();
         if (property_exists($data, 'email')) {

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/CatInSnakeCaseNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/CatInSnakeCaseNormalizer.php
@@ -25,7 +25,7 @@ class CatInSnakeCaseNormalizer implements DenormalizerInterface, NormalizerInter
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\CatInSnakeCase();
         if (property_exists($data, 'name')) {

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/DogInSnakeCaseNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/DogInSnakeCaseNormalizer.php
@@ -25,7 +25,7 @@ class DogInSnakeCaseNormalizer implements DenormalizerInterface, NormalizerInter
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\DogInSnakeCase();
         if (property_exists($data, 'name')) {

--- a/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/PetNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator-snake-case/expected/Normalizer/PetNormalizer.php
@@ -25,7 +25,7 @@ class PetNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (property_exists($data, 'petType') and 'cat_in_snake_case' === $data->{'petType'}) {
             return $this->denormalizer->denormalize($data, 'Jane\\OpenApi\\Tests\\Expected\\Model\\CatInSnakeCase', $format, $context);

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/CatNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/CatNormalizer.php
@@ -25,7 +25,7 @@ class CatNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Cat();
         if (property_exists($data, 'name')) {

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/DogNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/DogNormalizer.php
@@ -25,7 +25,7 @@ class DogNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Dog();
         if (property_exists($data, 'name')) {

--- a/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/PetNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/discriminator/expected/Normalizer/PetNormalizer.php
@@ -25,7 +25,7 @@ class PetNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         if (property_exists($data, 'petType') and 'Cat' === $data->{'petType'}) {
             return $this->denormalizer->denormalize($data, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Cat', $format, $context);

--- a/src/OpenApi/Tests/fixtures/exceptions/expected/Normalizer/ErrorNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/exceptions/expected/Normalizer/ErrorNormalizer.php
@@ -25,7 +25,7 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Error();
         if (property_exists($data, 'message')) {

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/ErrorNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/ErrorNormalizer.php
@@ -25,7 +25,7 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Error();
         if (property_exists($data, 'code')) {

--- a/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/PetNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/from-url/expected/Normalizer/PetNormalizer.php
@@ -25,7 +25,7 @@ class PetNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Pet();
         if (property_exists($data, 'id')) {

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/EmptySpaceNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/EmptySpaceNormalizer.php
@@ -25,7 +25,7 @@ class EmptySpaceNormalizer implements DenormalizerInterface, NormalizerInterface
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\EmptySpace();
         if (property_exists($data, 'stringProperty')) {

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/ErrorNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/ErrorNormalizer.php
@@ -25,7 +25,7 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Error();
         if (property_exists($data, 'message')) {

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
@@ -25,7 +25,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Schema();
         if (property_exists($data, 'stringProperty')) {

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -25,7 +25,7 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\SchemaObjectProperty();
         if (property_exists($data, 'stringProperty')) {

--- a/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/TestIdGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-in-response/expected/Normalizer/TestIdGetResponse200Normalizer.php
@@ -25,7 +25,7 @@ class TestIdGetResponse200Normalizer implements DenormalizerInterface, Normalize
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\TestIdGetResponse200();
         if (property_exists($data, 'id')) {

--- a/src/OpenApi/Tests/fixtures/model-type-reference/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/model-type-reference/expected/Normalizer/ModelNormalizer.php
@@ -25,7 +25,7 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Model();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Normalizer/BodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/multi-specs/expected/Api1/Normalizer/BodyNormalizer.php
@@ -25,7 +25,7 @@ class BodyNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Api1\Model\Body();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/BarNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/BarNormalizer.php
@@ -25,7 +25,7 @@ class BarNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Bar();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/FooNormalizer.php
@@ -25,7 +25,7 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Foo();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyBazNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyBazNormalizer.php
@@ -25,7 +25,7 @@ class TestGetBodyBazNormalizer implements DenormalizerInterface, NormalizerInter
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\TestGetBodyBaz();
         if (property_exists($data, 'baz')) {

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestGetBodyNormalizer.php
@@ -25,7 +25,7 @@ class TestGetBodyNormalizer implements DenormalizerInterface, NormalizerInterfac
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\TestGetBody();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestPostBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-body/expected/Normalizer/TestPostBodyNormalizer.php
@@ -25,7 +25,7 @@ class TestPostBodyNormalizer implements DenormalizerInterface, NormalizerInterfa
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\TestPostBody();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/no-reference-response/expected/Normalizer/TestPostResponse201Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-reference-response/expected/Normalizer/TestPostResponse201Normalizer.php
@@ -25,7 +25,7 @@ class TestPostResponse201Normalizer implements DenormalizerInterface, Normalizer
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\TestPostResponse201();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/operations/expected/Normalizer/ThingNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/operations/expected/Normalizer/ThingNormalizer.php
@@ -25,7 +25,7 @@ class ThingNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Thing();
         if (property_exists($data, 'name')) {

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Normalizer/TestFormFilePostBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Normalizer/TestFormFilePostBodyNormalizer.php
@@ -25,7 +25,7 @@ class TestFormFilePostBodyNormalizer implements DenormalizerInterface, Normalize
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\TestFormFilePostBody();
         if (property_exists($data, 'testFile')) {

--- a/src/OpenApi/Tests/fixtures/parameters/expected/Normalizer/TestFormPostBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/parameters/expected/Normalizer/TestFormPostBodyNormalizer.php
@@ -25,7 +25,7 @@ class TestFormPostBodyNormalizer implements DenormalizerInterface, NormalizerInt
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\TestFormPostBody();
         if (property_exists($data, 'testString')) {

--- a/src/OpenApi/Tests/fixtures/read-only-properties/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/read-only-properties/expected/Normalizer/ModelNormalizer.php
@@ -25,7 +25,7 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Model();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/response-reference/expected/Normalizer/ResponseCommonNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/response-reference/expected/Normalizer/ResponseCommonNormalizer.php
@@ -25,7 +25,7 @@ class ResponseCommonNormalizer implements DenormalizerInterface, NormalizerInter
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\ResponseCommon();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/response-type-reference/expected/Normalizer/FooGetResponse200Normalizer.php
+++ b/src/OpenApi/Tests/fixtures/response-type-reference/expected/Normalizer/FooGetResponse200Normalizer.php
@@ -25,7 +25,7 @@ class FooGetResponse200Normalizer implements DenormalizerInterface, NormalizerIn
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\FooGetResponse200();
         if (property_exists($data, 'id')) {

--- a/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Normalizer/ModelNormalizer.php
@@ -25,7 +25,7 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Model();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
@@ -25,7 +25,7 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Model();
         if (property_exists($data, 'foo')) {

--- a/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
@@ -26,7 +26,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Schema();
         if (property_exists($data, 'stringProperty')) {

--- a/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -26,7 +26,7 @@ class SchemaObjectPropertyNormalizer implements DenormalizerInterface, Normalize
     public function denormalize($data, $class, $format = null, array $context = array())
     {
         if (!is_object($data)) {
-            throw new InvalidArgumentException();
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\SchemaObjectProperty();
         if (property_exists($data, 'stringProperty')) {


### PR DESCRIPTION
Make denormalize exception more explicit including what was the type of given `$data` variable.