### PR TITLE
Error on references in requestbody

### DIFF
--- a/src/OpenApi/Generator/EndpointGenerator.php
+++ b/src/OpenApi/Generator/EndpointGenerator.php
@@ -160,13 +160,7 @@ abstract class EndpointGenerator
             }
         }
 
-        $requestBody = $operation->getOperation()->getRequestBody();
-
-        if ($requestBody instanceof Reference) {
-            [$_, $requestBody] = $this->resolve($requestBody, RequestBody::class);
-        }
-
-        if ($requestBody instanceof RequestBody && $requestBody->getContent()) {
+        if (($requestBody = $operation->getOperation()->getRequestBody()) instanceof RequestBody && null !== $requestBody->getContent()) {
             $bodyParam = $this->requestBodyGenerator->generateMethodParameter($requestBody, $operation->getReference() . '/requestBody', $context);
             $bodyDoc = $this->requestBodyGenerator->generateMethodDocParameter($requestBody, $operation->getReference() . '/requestBody', $context);
             $bodyAssign = new Stmt\Expression(new Expr\Assign(new Expr\PropertyFetch(new Expr\Variable('this'), 'body'), new Expr\Variable('requestBody')));

--- a/src/OpenApi/Guesser/OpenApiSchema/GuesserFactory.php
+++ b/src/OpenApi/Guesser/OpenApiSchema/GuesserFactory.php
@@ -17,7 +17,7 @@ class GuesserFactory
         $chainGuesser->addGuesser(new SecurityGuesser());
         $chainGuesser->addGuesser(new DateTimeGuesser($dateFormat));
         $chainGuesser->addGuesser(new ReferenceGuesser($serializer));
-        $chainGuesser->addGuesser(new OpenApiGuesser());
+        $chainGuesser->addGuesser(new OpenApiGuesser($serializer));
         $chainGuesser->addGuesser(new SchemaGuesser($naming, $serializer));
         $chainGuesser->addGuesser(new AdditionalPropertiesGuesser());
         $chainGuesser->addGuesser(new AllOfGuesser($serializer, $naming));

--- a/src/OpenApi/Guesser/OpenApiSchema/OpenApiGuesser.php
+++ b/src/OpenApi/Guesser/OpenApiSchema/OpenApiGuesser.php
@@ -11,6 +11,7 @@ use Jane\OpenApi\JsonSchema\Model\Components;
 use Jane\OpenApi\JsonSchema\Model\Operation;
 use Jane\OpenApi\JsonSchema\Model\Parameter;
 use Jane\OpenApi\JsonSchema\Model\PathItem;
+use Jane\OpenApi\JsonSchema\Model\RequestBody;
 use Jane\OpenApi\JsonSchema\Model\Response;
 use Jane\OpenApi\JsonSchema\Model\OpenApi;
 
@@ -104,7 +105,7 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
             }
         }
 
-        if (null !== $operation->getRequestBody() && is_iterable($operation->getRequestBody()->getContent())) {
+        if ($operation->getRequestBody() instanceof RequestBody && is_iterable($operation->getRequestBody()->getContent())) {
             foreach ($operation->getRequestBody()->getContent() as $contentType => $content) {
                 $this->chainGuesser->guessClass($content->getSchema(), $name . 'Body', $reference . '/requestBody/content/' . $contentType . '/schema', $registry);
             }

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi3.json',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/.jane-openapi
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'openapi-file' => __DIR__ . '/openapi3.json',
+    'openapi-file' => __DIR__ . '/openapi3.yaml',
     'namespace' => 'Jane\OpenApi\Tests\Expected',
     'directory' => __DIR__ . '/generated',
 ];

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Client.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    /**
+     * 
+     *
+     * @param string $parentId 
+     * @param string $childId 
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Jane\OpenApi\Tests\Expected\Model\Child|\Psr\Http\Message\ResponseInterface
+     */
+    public function getParentsByParentIdChildChildId(string $parentId, string $childId, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Endpoint\GetParentsByParentIdChildChildId($parentId, $childId), $fetch);
+    }
+    /**
+     * 
+     *
+     * @param string $parentId 
+     * @param string $childId 
+     * @param \Jane\OpenApi\Tests\Expected\Model\ParentsParentIdChildChildIdPatchBody $requestBody 
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Jane\OpenApi\Tests\Expected\Model\Child|\Psr\Http\Message\ResponseInterface
+     */
+    public function patchParentsByParentIdChildChildId(string $parentId, string $childId, \Jane\OpenApi\Tests\Expected\Model\ParentsParentIdChildChildIdPatchBody $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Endpoint\PatchParentsByParentIdChildChildId($parentId, $childId, $requestBody), $fetch);
+    }
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+            $plugins = array();
+            $uri = \Http\Discovery\UriFactoryDiscovery::find()->createUri('https://acme.localhost/v1');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Endpoint/GetParentsByParentIdChildChildId.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Endpoint/GetParentsByParentIdChildChildId.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Endpoint;
+
+class GetParentsByParentIdChildChildId extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    protected $parent_id;
+    protected $child_id;
+    /**
+     * 
+     *
+     * @param string $parentId 
+     * @param string $childId 
+     */
+    public function __construct(string $parentId, string $childId)
+    {
+        $this->parent_id = $parentId;
+        $this->child_id = $childId;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return str_replace(array('{parent_id}', '{child_id}'), array($this->parent_id, $this->child_id), '/parents/{parent_id}/child/child_id/');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\OpenApi\Tests\Expected\Model\Child
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
+            return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Child', 'json');
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Endpoint/PatchParentsByParentIdChildChildId.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Endpoint/PatchParentsByParentIdChildChildId.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Endpoint;
+
+class PatchParentsByParentIdChildChildId extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    protected $parent_id;
+    protected $child_id;
+    /**
+     * 
+     *
+     * @param string $parentId 
+     * @param string $childId 
+     * @param \Jane\OpenApi\Tests\Expected\Model\ParentsParentIdChildChildIdPatchBody $requestBody 
+     */
+    public function __construct(string $parentId, string $childId, \Jane\OpenApi\Tests\Expected\Model\ParentsParentIdChildChildIdPatchBody $requestBody)
+    {
+        $this->parent_id = $parentId;
+        $this->child_id = $childId;
+        $this->body = $requestBody;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'PATCH';
+    }
+    public function getUri() : string
+    {
+        return str_replace(array('{parent_id}', '{child_id}'), array($this->parent_id, $this->child_id), '/parents/{parent_id}/child/child_id/');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        if ($this->body instanceof \Jane\OpenApi\Tests\Expected\Model\ParentsParentIdChildChildIdPatchBody) {
+            return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));
+        }
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\OpenApi\Tests\Expected\Model\Child
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
+            return $serializer->deserialize($body, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Child', 'json');
+        }
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Model/Child.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Model/Child.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Child
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $id;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getId() : string
+    {
+        return $this->id;
+    }
+    /**
+     * 
+     *
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id) : self
+    {
+        $this->id = $id;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Model/Parent.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Model/Parent.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Parent
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $id;
+    /**
+     * 
+     *
+     * @var Child[]
+     */
+    protected $child;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getId() : string
+    {
+        return $this->id;
+    }
+    /**
+     * 
+     *
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id) : self
+    {
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return Child[]
+     */
+    public function getChild() : array
+    {
+        return $this->child;
+    }
+    /**
+     * 
+     *
+     * @param Child[] $child
+     *
+     * @return self
+     */
+    public function setChild(array $child) : self
+    {
+        $this->child = $child;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Model/ParentsParentIdChildChildIdPatchBody.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Model/ParentsParentIdChildChildIdPatchBody.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class ParentsParentIdChildChildIdPatchBody
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $id;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getId() : string
+    {
+        return $this->id;
+    }
+    /**
+     * 
+     *
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id) : self
+    {
+        $this->id = $id;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Normalizer/ChildNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Normalizer/ChildNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ChildNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Child';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Child';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Child();
+        if (property_exists($data, 'id')) {
+            $object->setId($data->{'id'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getId()) {
+            $data->{'id'} = $object->getId();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    protected $normalizers = array('Jane\\OpenApi\\Tests\\Expected\\Model\\Parent' => 'Jane\\OpenApi\\Tests\\Expected\\Normalizer\\ParentNormalizer', 'Jane\\OpenApi\\Tests\\Expected\\Model\\Child' => 'Jane\\OpenApi\\Tests\\Expected\\Normalizer\\ChildNormalizer', 'Jane\\OpenApi\\Tests\\Expected\\Model\\ParentsParentIdChildChildIdPatchBody' => 'Jane\\OpenApi\\Tests\\Expected\\Normalizer\\ParentsParentIdChildChildIdPatchBodyNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+@trigger_error('The "NormalizerFactory" class is deprecated since Jane 5.3, use "JaneObjectNormalizer" instead.', E_USER_DEPRECATED);
+/**
+ * @deprecated The "NormalizerFactory" class is deprecated since Jane 5.3, use "JaneObjectNormalizer" instead.
+ */
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new \Jane\OpenApi\Tests\Expected\Normalizer\JaneObjectNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Normalizer/ParentNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Normalizer/ParentNormalizer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ParentNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Parent';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Parent';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Parent();
+        if (property_exists($data, 'id')) {
+            $object->setId($data->{'id'});
+        }
+        if (property_exists($data, 'child')) {
+            $values = array();
+            foreach ($data->{'child'} as $value) {
+                $values[] = $this->denormalizer->denormalize($value, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Child', 'json', $context);
+            }
+            $object->setChild($values);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getId()) {
+            $data->{'id'} = $object->getId();
+        }
+        if (null !== $object->getChild()) {
+            $values = array();
+            foreach ($object->getChild() as $value) {
+                $values[] = $this->normalizer->normalize($value, 'json', $context);
+            }
+            $data->{'child'} = $values;
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Normalizer/ParentsParentIdChildChildIdPatchBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/expected/Normalizer/ParentsParentIdChildChildIdPatchBodyNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ParentsParentIdChildChildIdPatchBodyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\ParentsParentIdChildChildIdPatchBody';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\ParentsParentIdChildChildIdPatchBody';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\ParentsParentIdChildChildIdPatchBody();
+        if (property_exists($data, 'id')) {
+            $object->setId($data->{'id'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getId()) {
+            $data->{'id'} = $object->getId();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/openapi3.yaml
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/openapi3.yaml
@@ -5,7 +5,7 @@ info:
 servers:
   - url: https://acme.localhost/v1/
 paths:
-  "/parents/{parent_id}/child/child_id/":
+  '/parents/{parent_id}/child/child_id/':
     parameters:
       - name: parent_id
         in: path
@@ -21,7 +21,8 @@ paths:
           format: uuid
     get:
       responses:
-        200:
+        '200':
+          description: 'Get'
           content:
             application/json:
               schema:
@@ -30,7 +31,8 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/child'
       responses:
-        200:
+        '200':
+          description: 'Patch'
           content:
             application/json:
               schema:

--- a/src/OpenApi/Tests/fixtures/referenced-request-bodies/openapi3.yaml
+++ b/src/OpenApi/Tests/fixtures/referenced-request-bodies/openapi3.yaml
@@ -1,0 +1,65 @@
+openapi: '3.0.0'
+info:
+  version: 1.0.0
+  title: Referenced request bodies
+servers:
+  - url: https://acme.localhost/v1/
+paths:
+  "/parents/{parent_id}/child/child_id/":
+    parameters:
+      - name: parent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: child_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/child'
+    patch:
+      requestBody:
+        $ref: '#/components/requestBodies/child'
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/child'
+components:
+  schemas:
+    parent:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        child:
+          type: array
+          items:
+            $ref: '#/components/schemas/child'
+    child:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+  requestBodies:
+    child:
+      required: true
+      content:
+        application/json:
+          schema:
+            properties:
+              id:
+                type: string
+                format: uuid


### PR DESCRIPTION
Fixes #225 

I stumbled open 
```
Uncaught TypeError: Argument 1 passed to Jane\OpenApi\Generator\RequestBodyGenerator::getSerializeStatements() must be an instance of Jane\OpenApi\JsonSchema\Model\RequestBody or null, instance of Jane\JsonSchemaRuntime\Reference
```
and
```
Call to undefined method Jane\JsonSchemaRuntime\Reference::getContent()
```

when using an openapi specification with references in the request body. This is not an optimal fix but this will at least end up in a generated client. Whether the client is working correctly is still something to find out. I cannot provide a minimal example yet as I have to reduce the problem.

For now I need some feedback on that error and hints on solving this over all in this library.