### PR TITLE
Merge pull request #230 from Korbeil/fix/issue-229

### DIFF
--- a/src/JsonSchema/Generator/Normalizer/DenormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/DenormalizerGenerator.php
@@ -97,7 +97,7 @@ trait DenormalizerGenerator
                 new Stmt\Expression(new Expr\MethodCall($objectVariable, $this->getNaming()->getPrefixedMethodName('set', $property->getPhpName()), [$outputVar])),
             ], $unset ? [new Stmt\Unset_([$propertyVar])] : []);
 
-            if ($property->isNullable()) {
+            if (!$context->isStrict() || $property->isNullable()) {
                 $fullCondition = new Expr\BinaryOp\BooleanAnd(
                     $baseCondition,
                     new Expr\BinaryOp\NotIdentical(
@@ -111,7 +111,7 @@ trait DenormalizerGenerator
                 'stmts' => $mutatorStmt,
             ]);
 
-            if ($property->isNullable()) {
+            if (!$context->isStrict() || $property->isNullable()) {
                 $invertCondition = new Expr\BinaryOp\BooleanAnd(
                     $baseCondition,
                     new Expr\BinaryOp\Identical(

--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -101,7 +101,7 @@ trait NormalizerGenerator
 
                 $normalizationStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\PropertyFetch($dataVariable, sprintf("{'%s'}", $property->getName())), $outputVar));
 
-                if ($property->isNullable() || ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) || ($property->getType()->getName() === Type::TYPE_NULL)) {
+                if (!$context->isStrict() || $property->isNullable() || ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) || ($property->getType()->getName() === Type::TYPE_NULL)) {
                     if ($property->getType()->getName() !== Type::TYPE_NULL &&
                         (
                             $property->getType() instanceof DateTimeType ||

--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -102,14 +102,14 @@ trait NormalizerGenerator
                 $normalizationStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\PropertyFetch($dataVariable, sprintf("{'%s'}", $property->getName())), $outputVar));
 
                 if (!$context->isStrict() || $property->isNullable() || ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) || ($property->getType()->getName() === Type::TYPE_NULL)) {
-                    if ($property->getType()->getName() !== Type::TYPE_NULL &&
+                    if (!$context->isStrict() || ($property->getType()->getName() !== Type::TYPE_NULL &&
                         (
                             $property->getType() instanceof DateTimeType ||
                             $property->getType() instanceof MapType ||
                             $property->getType() instanceof ObjectType ||
                             $property->getType() instanceof PatternMultipleType ||
                             $property->getType() instanceof ArrayType
-                        )) {
+                        ))) {
                         $statements[] = new Stmt\If_(
                             new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $propertyVar),
                             [

--- a/src/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/NormalizerGenerator.php
@@ -72,8 +72,6 @@ class NormalizerGenerator implements GeneratorInterface
      */
     public function generate(Schema $schema, string $className, Context $context): void
     {
-        $classes = [];
-
         $normalizers = [];
 
         foreach ($schema->getClasses() as $class) {
@@ -94,7 +92,6 @@ class NormalizerGenerator implements GeneratorInterface
                 $methods,
                 $this->useCacheableSupportsMethod
             );
-            $classes[] = $normalizerClass->name;
 
             $useStmts = [
                 new Stmt\Use_([new Stmt\UseUse(new Name('Jane\JsonSchemaRuntime\Reference'))]),

--- a/src/JsonSchema/Normalizer/JsonSchemaNormalizer.php
+++ b/src/JsonSchema/Normalizer/JsonSchemaNormalizer.php
@@ -45,7 +45,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
         }
         $object = new \Jane\JsonSchema\Model\JsonSchema();
-        if (property_exists($data, 'definitions')) {
+        if (property_exists($data, 'definitions') && $data->{'definitions'} !== null) {
             $values = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'definitions'} as $key => $value) {
                 $value_1 = $value;
@@ -57,8 +57,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values[$key] = $value_1;
             }
             $object->setDefinitions($values);
+        } elseif (property_exists($data, 'definitions') && $data->{'definitions'} === null) {
+            $object->setDefinitions(null);
         }
-        if (property_exists($data, 'dependencies')) {
+        if (property_exists($data, 'dependencies') && $data->{'dependencies'} !== null) {
             $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'dependencies'} as $key_1 => $value_2) {
                 $value_3 = $value_2;
@@ -76,8 +78,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_1[$key_1] = $value_3;
             }
             $object->setDependencies($values_1);
+        } elseif (property_exists($data, 'dependencies') && $data->{'dependencies'} === null) {
+            $object->setDependencies(null);
         }
-        if (property_exists($data, 'additionalItems')) {
+        if (property_exists($data, 'additionalItems') && $data->{'additionalItems'} !== null) {
             $value_5 = $data->{'additionalItems'};
             if (is_object($data->{'additionalItems'})) {
                 $value_5 = $this->denormalizer->denormalize($data->{'additionalItems'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -85,8 +89,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_5 = $data->{'additionalItems'};
             }
             $object->setAdditionalItems($value_5);
+        } elseif (property_exists($data, 'additionalItems') && $data->{'additionalItems'} === null) {
+            $object->setAdditionalItems(null);
         }
-        if (property_exists($data, 'unevaluatedItems')) {
+        if (property_exists($data, 'unevaluatedItems') && $data->{'unevaluatedItems'} !== null) {
             $value_6 = $data->{'unevaluatedItems'};
             if (is_object($data->{'unevaluatedItems'})) {
                 $value_6 = $this->denormalizer->denormalize($data->{'unevaluatedItems'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -94,8 +100,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_6 = $data->{'unevaluatedItems'};
             }
             $object->setUnevaluatedItems($value_6);
+        } elseif (property_exists($data, 'unevaluatedItems') && $data->{'unevaluatedItems'} === null) {
+            $object->setUnevaluatedItems(null);
         }
-        if (property_exists($data, 'items')) {
+        if (property_exists($data, 'items') && $data->{'items'} !== null) {
             $value_7 = $data->{'items'};
             if (is_object($data->{'items'})) {
                 $value_7 = $this->denormalizer->denormalize($data->{'items'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -115,8 +123,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_7 = $values_3;
             }
             $object->setItems($value_7);
+        } elseif (property_exists($data, 'items') && $data->{'items'} === null) {
+            $object->setItems(null);
         }
-        if (property_exists($data, 'contains')) {
+        if (property_exists($data, 'contains') && $data->{'contains'} !== null) {
             $value_10 = $data->{'contains'};
             if (is_object($data->{'contains'})) {
                 $value_10 = $this->denormalizer->denormalize($data->{'contains'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -124,8 +134,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_10 = $data->{'contains'};
             }
             $object->setContains($value_10);
+        } elseif (property_exists($data, 'contains') && $data->{'contains'} === null) {
+            $object->setContains(null);
         }
-        if (property_exists($data, 'additionalProperties')) {
+        if (property_exists($data, 'additionalProperties') && $data->{'additionalProperties'} !== null) {
             $value_11 = $data->{'additionalProperties'};
             if (is_object($data->{'additionalProperties'})) {
                 $value_11 = $this->denormalizer->denormalize($data->{'additionalProperties'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -133,8 +145,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_11 = $data->{'additionalProperties'};
             }
             $object->setAdditionalProperties($value_11);
+        } elseif (property_exists($data, 'additionalProperties') && $data->{'additionalProperties'} === null) {
+            $object->setAdditionalProperties(null);
         }
-        if (property_exists($data, 'unevaluatedProperties')) {
+        if (property_exists($data, 'unevaluatedProperties') && $data->{'unevaluatedProperties'} !== null) {
             $values_4 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'unevaluatedProperties'} as $key_2 => $value_12) {
                 $value_13 = $value_12;
@@ -146,8 +160,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_4[$key_2] = $value_13;
             }
             $object->setUnevaluatedProperties($values_4);
+        } elseif (property_exists($data, 'unevaluatedProperties') && $data->{'unevaluatedProperties'} === null) {
+            $object->setUnevaluatedProperties(null);
         }
-        if (property_exists($data, 'properties')) {
+        if (property_exists($data, 'properties') && $data->{'properties'} !== null) {
             $values_5 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'properties'} as $key_3 => $value_14) {
                 $value_15 = $value_14;
@@ -159,8 +175,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_5[$key_3] = $value_15;
             }
             $object->setProperties($values_5);
+        } elseif (property_exists($data, 'properties') && $data->{'properties'} === null) {
+            $object->setProperties(null);
         }
-        if (property_exists($data, 'patternProperties')) {
+        if (property_exists($data, 'patternProperties') && $data->{'patternProperties'} !== null) {
             $values_6 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'patternProperties'} as $key_4 => $value_16) {
                 $value_17 = $value_16;
@@ -172,8 +190,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_6[$key_4] = $value_17;
             }
             $object->setPatternProperties($values_6);
+        } elseif (property_exists($data, 'patternProperties') && $data->{'patternProperties'} === null) {
+            $object->setPatternProperties(null);
         }
-        if (property_exists($data, 'dependentSchemas')) {
+        if (property_exists($data, 'dependentSchemas') && $data->{'dependentSchemas'} !== null) {
             $values_7 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'dependentSchemas'} as $key_5 => $value_18) {
                 $value_19 = $value_18;
@@ -185,8 +205,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_7[$key_5] = $value_19;
             }
             $object->setDependentSchemas($values_7);
+        } elseif (property_exists($data, 'dependentSchemas') && $data->{'dependentSchemas'} === null) {
+            $object->setDependentSchemas(null);
         }
-        if (property_exists($data, 'propertyNames')) {
+        if (property_exists($data, 'propertyNames') && $data->{'propertyNames'} !== null) {
             $value_20 = $data->{'propertyNames'};
             if (is_object($data->{'propertyNames'})) {
                 $value_20 = $this->denormalizer->denormalize($data->{'propertyNames'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -194,8 +216,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_20 = $data->{'propertyNames'};
             }
             $object->setPropertyNames($value_20);
+        } elseif (property_exists($data, 'propertyNames') && $data->{'propertyNames'} === null) {
+            $object->setPropertyNames(null);
         }
-        if (property_exists($data, 'if')) {
+        if (property_exists($data, 'if') && $data->{'if'} !== null) {
             $value_21 = $data->{'if'};
             if (is_object($data->{'if'})) {
                 $value_21 = $this->denormalizer->denormalize($data->{'if'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -203,8 +227,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_21 = $data->{'if'};
             }
             $object->setIf($value_21);
+        } elseif (property_exists($data, 'if') && $data->{'if'} === null) {
+            $object->setIf(null);
         }
-        if (property_exists($data, 'then')) {
+        if (property_exists($data, 'then') && $data->{'then'} !== null) {
             $value_22 = $data->{'then'};
             if (is_object($data->{'then'})) {
                 $value_22 = $this->denormalizer->denormalize($data->{'then'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -212,8 +238,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_22 = $data->{'then'};
             }
             $object->setThen($value_22);
+        } elseif (property_exists($data, 'then') && $data->{'then'} === null) {
+            $object->setThen(null);
         }
-        if (property_exists($data, 'else')) {
+        if (property_exists($data, 'else') && $data->{'else'} !== null) {
             $value_23 = $data->{'else'};
             if (is_object($data->{'else'})) {
                 $value_23 = $this->denormalizer->denormalize($data->{'else'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -221,8 +249,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_23 = $data->{'else'};
             }
             $object->setElse($value_23);
+        } elseif (property_exists($data, 'else') && $data->{'else'} === null) {
+            $object->setElse(null);
         }
-        if (property_exists($data, 'allOf')) {
+        if (property_exists($data, 'allOf') && $data->{'allOf'} !== null) {
             $values_8 = [];
             foreach ($data->{'allOf'} as $value_24) {
                 $value_25 = $value_24;
@@ -234,8 +264,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_8[] = $value_25;
             }
             $object->setAllOf($values_8);
+        } elseif (property_exists($data, 'allOf') && $data->{'allOf'} === null) {
+            $object->setAllOf(null);
         }
-        if (property_exists($data, 'anyOf')) {
+        if (property_exists($data, 'anyOf') && $data->{'anyOf'} !== null) {
             $values_9 = [];
             foreach ($data->{'anyOf'} as $value_26) {
                 $value_27 = $value_26;
@@ -247,8 +279,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_9[] = $value_27;
             }
             $object->setAnyOf($values_9);
+        } elseif (property_exists($data, 'anyOf') && $data->{'anyOf'} === null) {
+            $object->setAnyOf(null);
         }
-        if (property_exists($data, 'oneOf')) {
+        if (property_exists($data, 'oneOf') && $data->{'oneOf'} !== null) {
             $values_10 = [];
             foreach ($data->{'oneOf'} as $value_28) {
                 $value_29 = $value_28;
@@ -260,8 +294,10 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_10[] = $value_29;
             }
             $object->setOneOf($values_10);
+        } elseif (property_exists($data, 'oneOf') && $data->{'oneOf'} === null) {
+            $object->setOneOf(null);
         }
-        if (property_exists($data, 'not')) {
+        if (property_exists($data, 'not') && $data->{'not'} !== null) {
             $value_30 = $data->{'not'};
             if (is_object($data->{'not'})) {
                 $value_30 = $this->denormalizer->denormalize($data->{'not'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -269,14 +305,20 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_30 = $data->{'not'};
             }
             $object->setNot($value_30);
+        } elseif (property_exists($data, 'not') && $data->{'not'} === null) {
+            $object->setNot(null);
         }
-        if (property_exists($data, 'contentMediaType')) {
+        if (property_exists($data, 'contentMediaType') && $data->{'contentMediaType'} !== null) {
             $object->setContentMediaType($data->{'contentMediaType'});
+        } elseif (property_exists($data, 'contentMediaType') && $data->{'contentMediaType'} === null) {
+            $object->setContentMediaType(null);
         }
-        if (property_exists($data, 'contentEncoding')) {
+        if (property_exists($data, 'contentEncoding') && $data->{'contentEncoding'} !== null) {
             $object->setContentEncoding($data->{'contentEncoding'});
+        } elseif (property_exists($data, 'contentEncoding') && $data->{'contentEncoding'} === null) {
+            $object->setContentEncoding(null);
         }
-        if (property_exists($data, 'contentSchema')) {
+        if (property_exists($data, 'contentSchema') && $data->{'contentSchema'} !== null) {
             $value_31 = $data->{'contentSchema'};
             if (is_object($data->{'contentSchema'})) {
                 $value_31 = $this->denormalizer->denormalize($data->{'contentSchema'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -284,36 +326,54 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_31 = $data->{'contentSchema'};
             }
             $object->setContentSchema($value_31);
+        } elseif (property_exists($data, 'contentSchema') && $data->{'contentSchema'} === null) {
+            $object->setContentSchema(null);
         }
-        if (property_exists($data, '$id')) {
+        if (property_exists($data, '$id') && $data->{'$id'} !== null) {
             $object->setDollarId($data->{'$id'});
+        } elseif (property_exists($data, '$id') && $data->{'$id'} === null) {
+            $object->setDollarId(null);
         }
-        if (property_exists($data, '$schema')) {
+        if (property_exists($data, '$schema') && $data->{'$schema'} !== null) {
             $object->setDollarSchema($data->{'$schema'});
+        } elseif (property_exists($data, '$schema') && $data->{'$schema'} === null) {
+            $object->setDollarSchema(null);
         }
-        if (property_exists($data, '$anchor')) {
+        if (property_exists($data, '$anchor') && $data->{'$anchor'} !== null) {
             $object->setDollarAnchor($data->{'$anchor'});
+        } elseif (property_exists($data, '$anchor') && $data->{'$anchor'} === null) {
+            $object->setDollarAnchor(null);
         }
-        if (property_exists($data, '$ref')) {
+        if (property_exists($data, '$ref') && $data->{'$ref'} !== null) {
             $object->setDollarRef($data->{'$ref'});
+        } elseif (property_exists($data, '$ref') && $data->{'$ref'} === null) {
+            $object->setDollarRef(null);
         }
-        if (property_exists($data, '$recursiveRef')) {
+        if (property_exists($data, '$recursiveRef') && $data->{'$recursiveRef'} !== null) {
             $object->setDollarRecursiveRef($data->{'$recursiveRef'});
+        } elseif (property_exists($data, '$recursiveRef') && $data->{'$recursiveRef'} === null) {
+            $object->setDollarRecursiveRef(null);
         }
-        if (property_exists($data, '$recursiveAnchor')) {
+        if (property_exists($data, '$recursiveAnchor') && $data->{'$recursiveAnchor'} !== null) {
             $object->setDollarRecursiveAnchor($data->{'$recursiveAnchor'});
+        } elseif (property_exists($data, '$recursiveAnchor') && $data->{'$recursiveAnchor'} === null) {
+            $object->setDollarRecursiveAnchor(null);
         }
-        if (property_exists($data, '$vocabulary')) {
+        if (property_exists($data, '$vocabulary') && $data->{'$vocabulary'} !== null) {
             $values_11 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'$vocabulary'} as $key_6 => $value_32) {
                 $values_11[$key_6] = $value_32;
             }
             $object->setDollarVocabulary($values_11);
+        } elseif (property_exists($data, '$vocabulary') && $data->{'$vocabulary'} === null) {
+            $object->setDollarVocabulary(null);
         }
-        if (property_exists($data, '$comment')) {
+        if (property_exists($data, '$comment') && $data->{'$comment'} !== null) {
             $object->setDollarComment($data->{'$comment'});
+        } elseif (property_exists($data, '$comment') && $data->{'$comment'} === null) {
+            $object->setDollarComment(null);
         }
-        if (property_exists($data, '$defs')) {
+        if (property_exists($data, '$defs') && $data->{'$defs'} !== null) {
             $values_12 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'$defs'} as $key_7 => $value_33) {
                 $value_34 = $value_33;
@@ -325,88 +385,138 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_12[$key_7] = $value_34;
             }
             $object->setDollarDefs($values_12);
+        } elseif (property_exists($data, '$defs') && $data->{'$defs'} === null) {
+            $object->setDollarDefs(null);
         }
-        if (property_exists($data, 'format')) {
+        if (property_exists($data, 'format') && $data->{'format'} !== null) {
             $object->setFormat($data->{'format'});
+        } elseif (property_exists($data, 'format') && $data->{'format'} === null) {
+            $object->setFormat(null);
         }
-        if (property_exists($data, 'title')) {
+        if (property_exists($data, 'title') && $data->{'title'} !== null) {
             $object->setTitle($data->{'title'});
+        } elseif (property_exists($data, 'title') && $data->{'title'} === null) {
+            $object->setTitle(null);
         }
-        if (property_exists($data, 'description')) {
+        if (property_exists($data, 'description') && $data->{'description'} !== null) {
             $object->setDescription($data->{'description'});
+        } elseif (property_exists($data, 'description') && $data->{'description'} === null) {
+            $object->setDescription(null);
         }
-        if (property_exists($data, 'default')) {
+        if (property_exists($data, 'default') && $data->{'default'} !== null) {
             $object->setDefault($data->{'default'});
+        } elseif (property_exists($data, 'default') && $data->{'default'} === null) {
+            $object->setDefault(null);
         }
-        if (property_exists($data, 'deprecated')) {
+        if (property_exists($data, 'deprecated') && $data->{'deprecated'} !== null) {
             $object->setDeprecated($data->{'deprecated'});
+        } elseif (property_exists($data, 'deprecated') && $data->{'deprecated'} === null) {
+            $object->setDeprecated(null);
         }
-        if (property_exists($data, 'readOnly')) {
+        if (property_exists($data, 'readOnly') && $data->{'readOnly'} !== null) {
             $object->setReadOnly($data->{'readOnly'});
+        } elseif (property_exists($data, 'readOnly') && $data->{'readOnly'} === null) {
+            $object->setReadOnly(null);
         }
-        if (property_exists($data, 'writeOnly')) {
+        if (property_exists($data, 'writeOnly') && $data->{'writeOnly'} !== null) {
             $object->setWriteOnly($data->{'writeOnly'});
+        } elseif (property_exists($data, 'writeOnly') && $data->{'writeOnly'} === null) {
+            $object->setWriteOnly(null);
         }
-        if (property_exists($data, 'examples')) {
+        if (property_exists($data, 'examples') && $data->{'examples'} !== null) {
             $values_13 = [];
             foreach ($data->{'examples'} as $value_35) {
                 $values_13[] = $value_35;
             }
             $object->setExamples($values_13);
+        } elseif (property_exists($data, 'examples') && $data->{'examples'} === null) {
+            $object->setExamples(null);
         }
-        if (property_exists($data, 'multipleOf')) {
+        if (property_exists($data, 'multipleOf') && $data->{'multipleOf'} !== null) {
             $object->setMultipleOf($data->{'multipleOf'});
+        } elseif (property_exists($data, 'multipleOf') && $data->{'multipleOf'} === null) {
+            $object->setMultipleOf(null);
         }
-        if (property_exists($data, 'maximum')) {
+        if (property_exists($data, 'maximum') && $data->{'maximum'} !== null) {
             $object->setMaximum($data->{'maximum'});
+        } elseif (property_exists($data, 'maximum') && $data->{'maximum'} === null) {
+            $object->setMaximum(null);
         }
-        if (property_exists($data, 'exclusiveMaximum')) {
+        if (property_exists($data, 'exclusiveMaximum') && $data->{'exclusiveMaximum'} !== null) {
             $object->setExclusiveMaximum($data->{'exclusiveMaximum'});
+        } elseif (property_exists($data, 'exclusiveMaximum') && $data->{'exclusiveMaximum'} === null) {
+            $object->setExclusiveMaximum(null);
         }
-        if (property_exists($data, 'minimum')) {
+        if (property_exists($data, 'minimum') && $data->{'minimum'} !== null) {
             $object->setMinimum($data->{'minimum'});
+        } elseif (property_exists($data, 'minimum') && $data->{'minimum'} === null) {
+            $object->setMinimum(null);
         }
-        if (property_exists($data, 'exclusiveMinimum')) {
+        if (property_exists($data, 'exclusiveMinimum') && $data->{'exclusiveMinimum'} !== null) {
             $object->setExclusiveMinimum($data->{'exclusiveMinimum'});
+        } elseif (property_exists($data, 'exclusiveMinimum') && $data->{'exclusiveMinimum'} === null) {
+            $object->setExclusiveMinimum(null);
         }
-        if (property_exists($data, 'maxLength')) {
+        if (property_exists($data, 'maxLength') && $data->{'maxLength'} !== null) {
             $object->setMaxLength($data->{'maxLength'});
+        } elseif (property_exists($data, 'maxLength') && $data->{'maxLength'} === null) {
+            $object->setMaxLength(null);
         }
-        if (property_exists($data, 'minLength')) {
+        if (property_exists($data, 'minLength') && $data->{'minLength'} !== null) {
             $object->setMinLength($data->{'minLength'});
+        } elseif (property_exists($data, 'minLength') && $data->{'minLength'} === null) {
+            $object->setMinLength(null);
         }
-        if (property_exists($data, 'pattern')) {
+        if (property_exists($data, 'pattern') && $data->{'pattern'} !== null) {
             $object->setPattern($data->{'pattern'});
+        } elseif (property_exists($data, 'pattern') && $data->{'pattern'} === null) {
+            $object->setPattern(null);
         }
-        if (property_exists($data, 'maxItems')) {
+        if (property_exists($data, 'maxItems') && $data->{'maxItems'} !== null) {
             $object->setMaxItems($data->{'maxItems'});
+        } elseif (property_exists($data, 'maxItems') && $data->{'maxItems'} === null) {
+            $object->setMaxItems(null);
         }
-        if (property_exists($data, 'minItems')) {
+        if (property_exists($data, 'minItems') && $data->{'minItems'} !== null) {
             $object->setMinItems($data->{'minItems'});
+        } elseif (property_exists($data, 'minItems') && $data->{'minItems'} === null) {
+            $object->setMinItems(null);
         }
-        if (property_exists($data, 'uniqueItems')) {
+        if (property_exists($data, 'uniqueItems') && $data->{'uniqueItems'} !== null) {
             $object->setUniqueItems($data->{'uniqueItems'});
+        } elseif (property_exists($data, 'uniqueItems') && $data->{'uniqueItems'} === null) {
+            $object->setUniqueItems(null);
         }
-        if (property_exists($data, 'maxContains')) {
+        if (property_exists($data, 'maxContains') && $data->{'maxContains'} !== null) {
             $object->setMaxContains($data->{'maxContains'});
+        } elseif (property_exists($data, 'maxContains') && $data->{'maxContains'} === null) {
+            $object->setMaxContains(null);
         }
-        if (property_exists($data, 'minContains')) {
+        if (property_exists($data, 'minContains') && $data->{'minContains'} !== null) {
             $object->setMinContains($data->{'minContains'});
+        } elseif (property_exists($data, 'minContains') && $data->{'minContains'} === null) {
+            $object->setMinContains(null);
         }
-        if (property_exists($data, 'maxProperties')) {
+        if (property_exists($data, 'maxProperties') && $data->{'maxProperties'} !== null) {
             $object->setMaxProperties($data->{'maxProperties'});
+        } elseif (property_exists($data, 'maxProperties') && $data->{'maxProperties'} === null) {
+            $object->setMaxProperties(null);
         }
-        if (property_exists($data, 'minProperties')) {
+        if (property_exists($data, 'minProperties') && $data->{'minProperties'} !== null) {
             $object->setMinProperties($data->{'minProperties'});
+        } elseif (property_exists($data, 'minProperties') && $data->{'minProperties'} === null) {
+            $object->setMinProperties(null);
         }
-        if (property_exists($data, 'required')) {
+        if (property_exists($data, 'required') && $data->{'required'} !== null) {
             $values_14 = [];
             foreach ($data->{'required'} as $value_36) {
                 $values_14[] = $value_36;
             }
             $object->setRequired($values_14);
+        } elseif (property_exists($data, 'required') && $data->{'required'} === null) {
+            $object->setRequired(null);
         }
-        if (property_exists($data, 'dependentRequired')) {
+        if (property_exists($data, 'dependentRequired') && $data->{'dependentRequired'} !== null) {
             $values_15 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'dependentRequired'} as $key_8 => $value_37) {
                 $values_16 = [];
@@ -416,18 +526,24 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_15[$key_8] = $values_16;
             }
             $object->setDependentRequired($values_15);
+        } elseif (property_exists($data, 'dependentRequired') && $data->{'dependentRequired'} === null) {
+            $object->setDependentRequired(null);
         }
-        if (property_exists($data, 'const')) {
+        if (property_exists($data, 'const') && $data->{'const'} !== null) {
             $object->setConst($data->{'const'});
+        } elseif (property_exists($data, 'const') && $data->{'const'} === null) {
+            $object->setConst(null);
         }
-        if (property_exists($data, 'enum')) {
+        if (property_exists($data, 'enum') && $data->{'enum'} !== null) {
             $values_17 = [];
             foreach ($data->{'enum'} as $value_39) {
                 $values_17[] = $value_39;
             }
             $object->setEnum($values_17);
+        } elseif (property_exists($data, 'enum') && $data->{'enum'} === null) {
+            $object->setEnum(null);
         }
-        if (property_exists($data, 'type')) {
+        if (property_exists($data, 'type') && $data->{'type'} !== null) {
             $value_40 = $data->{'type'};
             if (is_array($data->{'type'})) {
                 $values_18 = [];
@@ -439,6 +555,8 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_40 = $data->{'type'};
             }
             $object->setType($value_40);
+        } elseif (property_exists($data, 'type') && $data->{'type'} === null) {
+            $object->setType(null);
         }
 
         return $object;
@@ -459,6 +577,8 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values->{$key} = $value_1;
             }
             $data->{'definitions'} = $values;
+        } else {
+            $data->{'definitions'} = null;
         }
         if (null !== $object->getDependencies()) {
             $values_1 = new \stdClass();
@@ -478,64 +598,56 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_1->{$key_1} = $value_3;
             }
             $data->{'dependencies'} = $values_1;
+        } else {
+            $data->{'dependencies'} = null;
         }
-        if (null !== $object->getAdditionalItems()) {
+        $value_5 = $object->getAdditionalItems();
+        if (is_object($object->getAdditionalItems())) {
+            $value_5 = $this->normalizer->normalize($object->getAdditionalItems(), 'json', $context);
+        } elseif (is_bool($object->getAdditionalItems())) {
             $value_5 = $object->getAdditionalItems();
-            if (is_object($object->getAdditionalItems())) {
-                $value_5 = $this->normalizer->normalize($object->getAdditionalItems(), 'json', $context);
-            } elseif (is_bool($object->getAdditionalItems())) {
-                $value_5 = $object->getAdditionalItems();
-            }
-            $data->{'additionalItems'} = $value_5;
         }
-        if (null !== $object->getUnevaluatedItems()) {
+        $data->{'additionalItems'} = $value_5;
+        $value_6 = $object->getUnevaluatedItems();
+        if (is_object($object->getUnevaluatedItems())) {
+            $value_6 = $this->normalizer->normalize($object->getUnevaluatedItems(), 'json', $context);
+        } elseif (is_bool($object->getUnevaluatedItems())) {
             $value_6 = $object->getUnevaluatedItems();
-            if (is_object($object->getUnevaluatedItems())) {
-                $value_6 = $this->normalizer->normalize($object->getUnevaluatedItems(), 'json', $context);
-            } elseif (is_bool($object->getUnevaluatedItems())) {
-                $value_6 = $object->getUnevaluatedItems();
-            }
-            $data->{'unevaluatedItems'} = $value_6;
         }
-        if (null !== $object->getItems()) {
+        $data->{'unevaluatedItems'} = $value_6;
+        $value_7 = $object->getItems();
+        if (is_object($object->getItems())) {
+            $value_7 = $this->normalizer->normalize($object->getItems(), 'json', $context);
+        } elseif (is_bool($object->getItems())) {
             $value_7 = $object->getItems();
-            if (is_object($object->getItems())) {
-                $value_7 = $this->normalizer->normalize($object->getItems(), 'json', $context);
-            } elseif (is_bool($object->getItems())) {
-                $value_7 = $object->getItems();
-            } elseif (is_array($object->getItems())) {
-                $values_3 = [];
-                foreach ($object->getItems() as $value_8) {
+        } elseif (is_array($object->getItems())) {
+            $values_3 = [];
+            foreach ($object->getItems() as $value_8) {
+                $value_9 = $value_8;
+                if (is_object($value_8)) {
+                    $value_9 = $this->normalizer->normalize($value_8, 'json', $context);
+                } elseif (is_bool($value_8)) {
                     $value_9 = $value_8;
-                    if (is_object($value_8)) {
-                        $value_9 = $this->normalizer->normalize($value_8, 'json', $context);
-                    } elseif (is_bool($value_8)) {
-                        $value_9 = $value_8;
-                    }
-                    $values_3[] = $value_9;
                 }
-                $value_7 = $values_3;
+                $values_3[] = $value_9;
             }
-            $data->{'items'} = $value_7;
+            $value_7 = $values_3;
         }
-        if (null !== $object->getContains()) {
+        $data->{'items'} = $value_7;
+        $value_10 = $object->getContains();
+        if (is_object($object->getContains())) {
+            $value_10 = $this->normalizer->normalize($object->getContains(), 'json', $context);
+        } elseif (is_bool($object->getContains())) {
             $value_10 = $object->getContains();
-            if (is_object($object->getContains())) {
-                $value_10 = $this->normalizer->normalize($object->getContains(), 'json', $context);
-            } elseif (is_bool($object->getContains())) {
-                $value_10 = $object->getContains();
-            }
-            $data->{'contains'} = $value_10;
         }
-        if (null !== $object->getAdditionalProperties()) {
+        $data->{'contains'} = $value_10;
+        $value_11 = $object->getAdditionalProperties();
+        if (is_object($object->getAdditionalProperties())) {
+            $value_11 = $this->normalizer->normalize($object->getAdditionalProperties(), 'json', $context);
+        } elseif (is_bool($object->getAdditionalProperties())) {
             $value_11 = $object->getAdditionalProperties();
-            if (is_object($object->getAdditionalProperties())) {
-                $value_11 = $this->normalizer->normalize($object->getAdditionalProperties(), 'json', $context);
-            } elseif (is_bool($object->getAdditionalProperties())) {
-                $value_11 = $object->getAdditionalProperties();
-            }
-            $data->{'additionalProperties'} = $value_11;
         }
+        $data->{'additionalProperties'} = $value_11;
         if (null !== $object->getUnevaluatedProperties()) {
             $values_4 = new \stdClass();
             foreach ($object->getUnevaluatedProperties() as $key_2 => $value_12) {
@@ -548,6 +660,8 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_4->{$key_2} = $value_13;
             }
             $data->{'unevaluatedProperties'} = $values_4;
+        } else {
+            $data->{'unevaluatedProperties'} = null;
         }
         if (null !== $object->getProperties()) {
             $values_5 = new \stdClass();
@@ -561,6 +675,8 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_5->{$key_3} = $value_15;
             }
             $data->{'properties'} = $values_5;
+        } else {
+            $data->{'properties'} = null;
         }
         if (null !== $object->getPatternProperties()) {
             $values_6 = new \stdClass();
@@ -574,6 +690,8 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_6->{$key_4} = $value_17;
             }
             $data->{'patternProperties'} = $values_6;
+        } else {
+            $data->{'patternProperties'} = null;
         }
         if (null !== $object->getDependentSchemas()) {
             $values_7 = new \stdClass();
@@ -587,43 +705,37 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_7->{$key_5} = $value_19;
             }
             $data->{'dependentSchemas'} = $values_7;
+        } else {
+            $data->{'dependentSchemas'} = null;
         }
-        if (null !== $object->getPropertyNames()) {
+        $value_20 = $object->getPropertyNames();
+        if (is_object($object->getPropertyNames())) {
+            $value_20 = $this->normalizer->normalize($object->getPropertyNames(), 'json', $context);
+        } elseif (is_bool($object->getPropertyNames())) {
             $value_20 = $object->getPropertyNames();
-            if (is_object($object->getPropertyNames())) {
-                $value_20 = $this->normalizer->normalize($object->getPropertyNames(), 'json', $context);
-            } elseif (is_bool($object->getPropertyNames())) {
-                $value_20 = $object->getPropertyNames();
-            }
-            $data->{'propertyNames'} = $value_20;
         }
-        if (null !== $object->getIf()) {
+        $data->{'propertyNames'} = $value_20;
+        $value_21 = $object->getIf();
+        if (is_object($object->getIf())) {
+            $value_21 = $this->normalizer->normalize($object->getIf(), 'json', $context);
+        } elseif (is_bool($object->getIf())) {
             $value_21 = $object->getIf();
-            if (is_object($object->getIf())) {
-                $value_21 = $this->normalizer->normalize($object->getIf(), 'json', $context);
-            } elseif (is_bool($object->getIf())) {
-                $value_21 = $object->getIf();
-            }
-            $data->{'if'} = $value_21;
         }
-        if (null !== $object->getThen()) {
+        $data->{'if'} = $value_21;
+        $value_22 = $object->getThen();
+        if (is_object($object->getThen())) {
+            $value_22 = $this->normalizer->normalize($object->getThen(), 'json', $context);
+        } elseif (is_bool($object->getThen())) {
             $value_22 = $object->getThen();
-            if (is_object($object->getThen())) {
-                $value_22 = $this->normalizer->normalize($object->getThen(), 'json', $context);
-            } elseif (is_bool($object->getThen())) {
-                $value_22 = $object->getThen();
-            }
-            $data->{'then'} = $value_22;
         }
-        if (null !== $object->getElse()) {
+        $data->{'then'} = $value_22;
+        $value_23 = $object->getElse();
+        if (is_object($object->getElse())) {
+            $value_23 = $this->normalizer->normalize($object->getElse(), 'json', $context);
+        } elseif (is_bool($object->getElse())) {
             $value_23 = $object->getElse();
-            if (is_object($object->getElse())) {
-                $value_23 = $this->normalizer->normalize($object->getElse(), 'json', $context);
-            } elseif (is_bool($object->getElse())) {
-                $value_23 = $object->getElse();
-            }
-            $data->{'else'} = $value_23;
         }
+        $data->{'else'} = $value_23;
         if (null !== $object->getAllOf()) {
             $values_8 = [];
             foreach ($object->getAllOf() as $value_24) {
@@ -636,6 +748,8 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_8[] = $value_25;
             }
             $data->{'allOf'} = $values_8;
+        } else {
+            $data->{'allOf'} = null;
         }
         if (null !== $object->getAnyOf()) {
             $values_9 = [];
@@ -649,6 +763,8 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_9[] = $value_27;
             }
             $data->{'anyOf'} = $values_9;
+        } else {
+            $data->{'anyOf'} = null;
         }
         if (null !== $object->getOneOf()) {
             $values_10 = [];
@@ -662,59 +778,41 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_10[] = $value_29;
             }
             $data->{'oneOf'} = $values_10;
+        } else {
+            $data->{'oneOf'} = null;
         }
-        if (null !== $object->getNot()) {
+        $value_30 = $object->getNot();
+        if (is_object($object->getNot())) {
+            $value_30 = $this->normalizer->normalize($object->getNot(), 'json', $context);
+        } elseif (is_bool($object->getNot())) {
             $value_30 = $object->getNot();
-            if (is_object($object->getNot())) {
-                $value_30 = $this->normalizer->normalize($object->getNot(), 'json', $context);
-            } elseif (is_bool($object->getNot())) {
-                $value_30 = $object->getNot();
-            }
-            $data->{'not'} = $value_30;
         }
-        if (null !== $object->getContentMediaType()) {
-            $data->{'contentMediaType'} = $object->getContentMediaType();
-        }
-        if (null !== $object->getContentEncoding()) {
-            $data->{'contentEncoding'} = $object->getContentEncoding();
-        }
-        if (null !== $object->getContentSchema()) {
+        $data->{'not'} = $value_30;
+        $data->{'contentMediaType'} = $object->getContentMediaType();
+        $data->{'contentEncoding'} = $object->getContentEncoding();
+        $value_31 = $object->getContentSchema();
+        if (is_object($object->getContentSchema())) {
+            $value_31 = $this->normalizer->normalize($object->getContentSchema(), 'json', $context);
+        } elseif (is_bool($object->getContentSchema())) {
             $value_31 = $object->getContentSchema();
-            if (is_object($object->getContentSchema())) {
-                $value_31 = $this->normalizer->normalize($object->getContentSchema(), 'json', $context);
-            } elseif (is_bool($object->getContentSchema())) {
-                $value_31 = $object->getContentSchema();
-            }
-            $data->{'contentSchema'} = $value_31;
         }
-        if (null !== $object->getDollarId()) {
-            $data->{'$id'} = $object->getDollarId();
-        }
-        if (null !== $object->getDollarSchema()) {
-            $data->{'$schema'} = $object->getDollarSchema();
-        }
-        if (null !== $object->getDollarAnchor()) {
-            $data->{'$anchor'} = $object->getDollarAnchor();
-        }
-        if (null !== $object->getDollarRef()) {
-            $data->{'$ref'} = $object->getDollarRef();
-        }
-        if (null !== $object->getDollarRecursiveRef()) {
-            $data->{'$recursiveRef'} = $object->getDollarRecursiveRef();
-        }
-        if (null !== $object->getDollarRecursiveAnchor()) {
-            $data->{'$recursiveAnchor'} = $object->getDollarRecursiveAnchor();
-        }
+        $data->{'contentSchema'} = $value_31;
+        $data->{'$id'} = $object->getDollarId();
+        $data->{'$schema'} = $object->getDollarSchema();
+        $data->{'$anchor'} = $object->getDollarAnchor();
+        $data->{'$ref'} = $object->getDollarRef();
+        $data->{'$recursiveRef'} = $object->getDollarRecursiveRef();
+        $data->{'$recursiveAnchor'} = $object->getDollarRecursiveAnchor();
         if (null !== $object->getDollarVocabulary()) {
             $values_11 = new \stdClass();
             foreach ($object->getDollarVocabulary() as $key_6 => $value_32) {
                 $values_11->{$key_6} = $value_32;
             }
             $data->{'$vocabulary'} = $values_11;
+        } else {
+            $data->{'$vocabulary'} = null;
         }
-        if (null !== $object->getDollarComment()) {
-            $data->{'$comment'} = $object->getDollarComment();
-        }
+        $data->{'$comment'} = $object->getDollarComment();
         if (null !== $object->getDollarDefs()) {
             $values_12 = new \stdClass();
             foreach ($object->getDollarDefs() as $key_7 => $value_33) {
@@ -727,86 +825,48 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_12->{$key_7} = $value_34;
             }
             $data->{'$defs'} = $values_12;
+        } else {
+            $data->{'$defs'} = null;
         }
-        if (null !== $object->getFormat()) {
-            $data->{'format'} = $object->getFormat();
-        }
-        if (null !== $object->getTitle()) {
-            $data->{'title'} = $object->getTitle();
-        }
-        if (null !== $object->getDescription()) {
-            $data->{'description'} = $object->getDescription();
-        }
-        if (null !== $object->getDefault()) {
-            $data->{'default'} = $object->getDefault();
-        }
-        if (null !== $object->getDeprecated()) {
-            $data->{'deprecated'} = $object->getDeprecated();
-        }
-        if (null !== $object->getReadOnly()) {
-            $data->{'readOnly'} = $object->getReadOnly();
-        }
-        if (null !== $object->getWriteOnly()) {
-            $data->{'writeOnly'} = $object->getWriteOnly();
-        }
+        $data->{'format'} = $object->getFormat();
+        $data->{'title'} = $object->getTitle();
+        $data->{'description'} = $object->getDescription();
+        $data->{'default'} = $object->getDefault();
+        $data->{'deprecated'} = $object->getDeprecated();
+        $data->{'readOnly'} = $object->getReadOnly();
+        $data->{'writeOnly'} = $object->getWriteOnly();
         if (null !== $object->getExamples()) {
             $values_13 = [];
             foreach ($object->getExamples() as $value_35) {
                 $values_13[] = $value_35;
             }
             $data->{'examples'} = $values_13;
+        } else {
+            $data->{'examples'} = null;
         }
-        if (null !== $object->getMultipleOf()) {
-            $data->{'multipleOf'} = $object->getMultipleOf();
-        }
-        if (null !== $object->getMaximum()) {
-            $data->{'maximum'} = $object->getMaximum();
-        }
-        if (null !== $object->getExclusiveMaximum()) {
-            $data->{'exclusiveMaximum'} = $object->getExclusiveMaximum();
-        }
-        if (null !== $object->getMinimum()) {
-            $data->{'minimum'} = $object->getMinimum();
-        }
-        if (null !== $object->getExclusiveMinimum()) {
-            $data->{'exclusiveMinimum'} = $object->getExclusiveMinimum();
-        }
-        if (null !== $object->getMaxLength()) {
-            $data->{'maxLength'} = $object->getMaxLength();
-        }
-        if (null !== $object->getMinLength()) {
-            $data->{'minLength'} = $object->getMinLength();
-        }
-        if (null !== $object->getPattern()) {
-            $data->{'pattern'} = $object->getPattern();
-        }
-        if (null !== $object->getMaxItems()) {
-            $data->{'maxItems'} = $object->getMaxItems();
-        }
-        if (null !== $object->getMinItems()) {
-            $data->{'minItems'} = $object->getMinItems();
-        }
-        if (null !== $object->getUniqueItems()) {
-            $data->{'uniqueItems'} = $object->getUniqueItems();
-        }
-        if (null !== $object->getMaxContains()) {
-            $data->{'maxContains'} = $object->getMaxContains();
-        }
-        if (null !== $object->getMinContains()) {
-            $data->{'minContains'} = $object->getMinContains();
-        }
-        if (null !== $object->getMaxProperties()) {
-            $data->{'maxProperties'} = $object->getMaxProperties();
-        }
-        if (null !== $object->getMinProperties()) {
-            $data->{'minProperties'} = $object->getMinProperties();
-        }
+        $data->{'multipleOf'} = $object->getMultipleOf();
+        $data->{'maximum'} = $object->getMaximum();
+        $data->{'exclusiveMaximum'} = $object->getExclusiveMaximum();
+        $data->{'minimum'} = $object->getMinimum();
+        $data->{'exclusiveMinimum'} = $object->getExclusiveMinimum();
+        $data->{'maxLength'} = $object->getMaxLength();
+        $data->{'minLength'} = $object->getMinLength();
+        $data->{'pattern'} = $object->getPattern();
+        $data->{'maxItems'} = $object->getMaxItems();
+        $data->{'minItems'} = $object->getMinItems();
+        $data->{'uniqueItems'} = $object->getUniqueItems();
+        $data->{'maxContains'} = $object->getMaxContains();
+        $data->{'minContains'} = $object->getMinContains();
+        $data->{'maxProperties'} = $object->getMaxProperties();
+        $data->{'minProperties'} = $object->getMinProperties();
         if (null !== $object->getRequired()) {
             $values_14 = [];
             foreach ($object->getRequired() as $value_36) {
                 $values_14[] = $value_36;
             }
             $data->{'required'} = $values_14;
+        } else {
+            $data->{'required'} = null;
         }
         if (null !== $object->getDependentRequired()) {
             $values_15 = new \stdClass();
@@ -818,30 +878,30 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_15->{$key_8} = $values_16;
             }
             $data->{'dependentRequired'} = $values_15;
+        } else {
+            $data->{'dependentRequired'} = null;
         }
-        if (null !== $object->getConst()) {
-            $data->{'const'} = $object->getConst();
-        }
+        $data->{'const'} = $object->getConst();
         if (null !== $object->getEnum()) {
             $values_17 = [];
             foreach ($object->getEnum() as $value_39) {
                 $values_17[] = $value_39;
             }
             $data->{'enum'} = $values_17;
+        } else {
+            $data->{'enum'} = null;
         }
-        if (null !== $object->getType()) {
-            $value_40 = $object->getType();
-            if (is_array($object->getType())) {
-                $values_18 = [];
-                foreach ($object->getType() as $value_41) {
-                    $values_18[] = $value_41;
-                }
-                $value_40 = $values_18;
-            } elseif (!is_null($object->getType())) {
-                $value_40 = $object->getType();
+        $value_40 = $object->getType();
+        if (is_array($object->getType())) {
+            $values_18 = [];
+            foreach ($object->getType() as $value_41) {
+                $values_18[] = $value_41;
             }
-            $data->{'type'} = $value_40;
+            $value_40 = $values_18;
+        } elseif (!is_null($object->getType())) {
+            $value_40 = $object->getType();
         }
+        $data->{'type'} = $value_40;
 
         return $data;
     }

--- a/src/JsonSchema/Normalizer/JsonSchemaNormalizer.php
+++ b/src/JsonSchema/Normalizer/JsonSchemaNormalizer.php
@@ -45,7 +45,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
         }
         $object = new \Jane\JsonSchema\Model\JsonSchema();
-        if (property_exists($data, 'definitions') && $data->{'definitions'} !== null) {
+        if (property_exists($data, 'definitions')) {
             $values = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'definitions'} as $key => $value) {
                 $value_1 = $value;
@@ -58,7 +58,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setDefinitions($values);
         }
-        if (property_exists($data, 'dependencies') && $data->{'dependencies'} !== null) {
+        if (property_exists($data, 'dependencies')) {
             $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'dependencies'} as $key_1 => $value_2) {
                 $value_3 = $value_2;
@@ -77,7 +77,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setDependencies($values_1);
         }
-        if (property_exists($data, 'additionalItems') && $data->{'additionalItems'} !== null) {
+        if (property_exists($data, 'additionalItems')) {
             $value_5 = $data->{'additionalItems'};
             if (is_object($data->{'additionalItems'})) {
                 $value_5 = $this->denormalizer->denormalize($data->{'additionalItems'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -86,7 +86,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setAdditionalItems($value_5);
         }
-        if (property_exists($data, 'unevaluatedItems') && $data->{'unevaluatedItems'} !== null) {
+        if (property_exists($data, 'unevaluatedItems')) {
             $value_6 = $data->{'unevaluatedItems'};
             if (is_object($data->{'unevaluatedItems'})) {
                 $value_6 = $this->denormalizer->denormalize($data->{'unevaluatedItems'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -95,7 +95,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setUnevaluatedItems($value_6);
         }
-        if (property_exists($data, 'items') && $data->{'items'} !== null) {
+        if (property_exists($data, 'items')) {
             $value_7 = $data->{'items'};
             if (is_object($data->{'items'})) {
                 $value_7 = $this->denormalizer->denormalize($data->{'items'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -116,7 +116,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setItems($value_7);
         }
-        if (property_exists($data, 'contains') && $data->{'contains'} !== null) {
+        if (property_exists($data, 'contains')) {
             $value_10 = $data->{'contains'};
             if (is_object($data->{'contains'})) {
                 $value_10 = $this->denormalizer->denormalize($data->{'contains'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -125,7 +125,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setContains($value_10);
         }
-        if (property_exists($data, 'additionalProperties') && $data->{'additionalProperties'} !== null) {
+        if (property_exists($data, 'additionalProperties')) {
             $value_11 = $data->{'additionalProperties'};
             if (is_object($data->{'additionalProperties'})) {
                 $value_11 = $this->denormalizer->denormalize($data->{'additionalProperties'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -134,7 +134,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setAdditionalProperties($value_11);
         }
-        if (property_exists($data, 'unevaluatedProperties') && $data->{'unevaluatedProperties'} !== null) {
+        if (property_exists($data, 'unevaluatedProperties')) {
             $values_4 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'unevaluatedProperties'} as $key_2 => $value_12) {
                 $value_13 = $value_12;
@@ -147,7 +147,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setUnevaluatedProperties($values_4);
         }
-        if (property_exists($data, 'properties') && $data->{'properties'} !== null) {
+        if (property_exists($data, 'properties')) {
             $values_5 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'properties'} as $key_3 => $value_14) {
                 $value_15 = $value_14;
@@ -160,7 +160,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setProperties($values_5);
         }
-        if (property_exists($data, 'patternProperties') && $data->{'patternProperties'} !== null) {
+        if (property_exists($data, 'patternProperties')) {
             $values_6 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'patternProperties'} as $key_4 => $value_16) {
                 $value_17 = $value_16;
@@ -173,7 +173,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setPatternProperties($values_6);
         }
-        if (property_exists($data, 'dependentSchemas') && $data->{'dependentSchemas'} !== null) {
+        if (property_exists($data, 'dependentSchemas')) {
             $values_7 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'dependentSchemas'} as $key_5 => $value_18) {
                 $value_19 = $value_18;
@@ -186,7 +186,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setDependentSchemas($values_7);
         }
-        if (property_exists($data, 'propertyNames') && $data->{'propertyNames'} !== null) {
+        if (property_exists($data, 'propertyNames')) {
             $value_20 = $data->{'propertyNames'};
             if (is_object($data->{'propertyNames'})) {
                 $value_20 = $this->denormalizer->denormalize($data->{'propertyNames'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -195,7 +195,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setPropertyNames($value_20);
         }
-        if (property_exists($data, 'if') && $data->{'if'} !== null) {
+        if (property_exists($data, 'if')) {
             $value_21 = $data->{'if'};
             if (is_object($data->{'if'})) {
                 $value_21 = $this->denormalizer->denormalize($data->{'if'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -204,7 +204,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setIf($value_21);
         }
-        if (property_exists($data, 'then') && $data->{'then'} !== null) {
+        if (property_exists($data, 'then')) {
             $value_22 = $data->{'then'};
             if (is_object($data->{'then'})) {
                 $value_22 = $this->denormalizer->denormalize($data->{'then'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -213,7 +213,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setThen($value_22);
         }
-        if (property_exists($data, 'else') && $data->{'else'} !== null) {
+        if (property_exists($data, 'else')) {
             $value_23 = $data->{'else'};
             if (is_object($data->{'else'})) {
                 $value_23 = $this->denormalizer->denormalize($data->{'else'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -222,7 +222,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setElse($value_23);
         }
-        if (property_exists($data, 'allOf') && $data->{'allOf'} !== null) {
+        if (property_exists($data, 'allOf')) {
             $values_8 = [];
             foreach ($data->{'allOf'} as $value_24) {
                 $value_25 = $value_24;
@@ -235,7 +235,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setAllOf($values_8);
         }
-        if (property_exists($data, 'anyOf') && $data->{'anyOf'} !== null) {
+        if (property_exists($data, 'anyOf')) {
             $values_9 = [];
             foreach ($data->{'anyOf'} as $value_26) {
                 $value_27 = $value_26;
@@ -248,7 +248,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setAnyOf($values_9);
         }
-        if (property_exists($data, 'oneOf') && $data->{'oneOf'} !== null) {
+        if (property_exists($data, 'oneOf')) {
             $values_10 = [];
             foreach ($data->{'oneOf'} as $value_28) {
                 $value_29 = $value_28;
@@ -261,7 +261,7 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setOneOf($values_10);
         }
-        if (property_exists($data, 'not') && $data->{'not'} !== null) {
+        if (property_exists($data, 'not')) {
             $value_30 = $data->{'not'};
             if (is_object($data->{'not'})) {
                 $value_30 = $this->denormalizer->denormalize($data->{'not'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -270,13 +270,13 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setNot($value_30);
         }
-        if (property_exists($data, 'contentMediaType') && $data->{'contentMediaType'} !== null) {
+        if (property_exists($data, 'contentMediaType')) {
             $object->setContentMediaType($data->{'contentMediaType'});
         }
-        if (property_exists($data, 'contentEncoding') && $data->{'contentEncoding'} !== null) {
+        if (property_exists($data, 'contentEncoding')) {
             $object->setContentEncoding($data->{'contentEncoding'});
         }
-        if (property_exists($data, 'contentSchema') && $data->{'contentSchema'} !== null) {
+        if (property_exists($data, 'contentSchema')) {
             $value_31 = $data->{'contentSchema'};
             if (is_object($data->{'contentSchema'})) {
                 $value_31 = $this->denormalizer->denormalize($data->{'contentSchema'}, 'Jane\\JsonSchema\\Model\\JsonSchema', 'json', $context);
@@ -285,35 +285,35 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setContentSchema($value_31);
         }
-        if (property_exists($data, '$id') && $data->{'$id'} !== null) {
+        if (property_exists($data, '$id')) {
             $object->setDollarId($data->{'$id'});
         }
-        if (property_exists($data, '$schema') && $data->{'$schema'} !== null) {
+        if (property_exists($data, '$schema')) {
             $object->setDollarSchema($data->{'$schema'});
         }
-        if (property_exists($data, '$anchor') && $data->{'$anchor'} !== null) {
+        if (property_exists($data, '$anchor')) {
             $object->setDollarAnchor($data->{'$anchor'});
         }
-        if (property_exists($data, '$ref') && $data->{'$ref'} !== null) {
+        if (property_exists($data, '$ref')) {
             $object->setDollarRef($data->{'$ref'});
         }
-        if (property_exists($data, '$recursiveRef') && $data->{'$recursiveRef'} !== null) {
+        if (property_exists($data, '$recursiveRef')) {
             $object->setDollarRecursiveRef($data->{'$recursiveRef'});
         }
-        if (property_exists($data, '$recursiveAnchor') && $data->{'$recursiveAnchor'} !== null) {
+        if (property_exists($data, '$recursiveAnchor')) {
             $object->setDollarRecursiveAnchor($data->{'$recursiveAnchor'});
         }
-        if (property_exists($data, '$vocabulary') && $data->{'$vocabulary'} !== null) {
+        if (property_exists($data, '$vocabulary')) {
             $values_11 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'$vocabulary'} as $key_6 => $value_32) {
                 $values_11[$key_6] = $value_32;
             }
             $object->setDollarVocabulary($values_11);
         }
-        if (property_exists($data, '$comment') && $data->{'$comment'} !== null) {
+        if (property_exists($data, '$comment')) {
             $object->setDollarComment($data->{'$comment'});
         }
-        if (property_exists($data, '$defs') && $data->{'$defs'} !== null) {
+        if (property_exists($data, '$defs')) {
             $values_12 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'$defs'} as $key_7 => $value_33) {
                 $value_34 = $value_33;
@@ -326,87 +326,87 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setDollarDefs($values_12);
         }
-        if (property_exists($data, 'format') && $data->{'format'} !== null) {
+        if (property_exists($data, 'format')) {
             $object->setFormat($data->{'format'});
         }
-        if (property_exists($data, 'title') && $data->{'title'} !== null) {
+        if (property_exists($data, 'title')) {
             $object->setTitle($data->{'title'});
         }
-        if (property_exists($data, 'description') && $data->{'description'} !== null) {
+        if (property_exists($data, 'description')) {
             $object->setDescription($data->{'description'});
         }
-        if (property_exists($data, 'default') && $data->{'default'} !== null) {
+        if (property_exists($data, 'default')) {
             $object->setDefault($data->{'default'});
         }
-        if (property_exists($data, 'deprecated') && $data->{'deprecated'} !== null) {
+        if (property_exists($data, 'deprecated')) {
             $object->setDeprecated($data->{'deprecated'});
         }
-        if (property_exists($data, 'readOnly') && $data->{'readOnly'} !== null) {
+        if (property_exists($data, 'readOnly')) {
             $object->setReadOnly($data->{'readOnly'});
         }
-        if (property_exists($data, 'writeOnly') && $data->{'writeOnly'} !== null) {
+        if (property_exists($data, 'writeOnly')) {
             $object->setWriteOnly($data->{'writeOnly'});
         }
-        if (property_exists($data, 'examples') && $data->{'examples'} !== null) {
+        if (property_exists($data, 'examples')) {
             $values_13 = [];
             foreach ($data->{'examples'} as $value_35) {
                 $values_13[] = $value_35;
             }
             $object->setExamples($values_13);
         }
-        if (property_exists($data, 'multipleOf') && $data->{'multipleOf'} !== null) {
+        if (property_exists($data, 'multipleOf')) {
             $object->setMultipleOf($data->{'multipleOf'});
         }
-        if (property_exists($data, 'maximum') && $data->{'maximum'} !== null) {
+        if (property_exists($data, 'maximum')) {
             $object->setMaximum($data->{'maximum'});
         }
-        if (property_exists($data, 'exclusiveMaximum') && $data->{'exclusiveMaximum'} !== null) {
+        if (property_exists($data, 'exclusiveMaximum')) {
             $object->setExclusiveMaximum($data->{'exclusiveMaximum'});
         }
-        if (property_exists($data, 'minimum') && $data->{'minimum'} !== null) {
+        if (property_exists($data, 'minimum')) {
             $object->setMinimum($data->{'minimum'});
         }
-        if (property_exists($data, 'exclusiveMinimum') && $data->{'exclusiveMinimum'} !== null) {
+        if (property_exists($data, 'exclusiveMinimum')) {
             $object->setExclusiveMinimum($data->{'exclusiveMinimum'});
         }
-        if (property_exists($data, 'maxLength') && $data->{'maxLength'} !== null) {
+        if (property_exists($data, 'maxLength')) {
             $object->setMaxLength($data->{'maxLength'});
         }
-        if (property_exists($data, 'minLength') && $data->{'minLength'} !== null) {
+        if (property_exists($data, 'minLength')) {
             $object->setMinLength($data->{'minLength'});
         }
-        if (property_exists($data, 'pattern') && $data->{'pattern'} !== null) {
+        if (property_exists($data, 'pattern')) {
             $object->setPattern($data->{'pattern'});
         }
-        if (property_exists($data, 'maxItems') && $data->{'maxItems'} !== null) {
+        if (property_exists($data, 'maxItems')) {
             $object->setMaxItems($data->{'maxItems'});
         }
-        if (property_exists($data, 'minItems') && $data->{'minItems'} !== null) {
+        if (property_exists($data, 'minItems')) {
             $object->setMinItems($data->{'minItems'});
         }
-        if (property_exists($data, 'uniqueItems') && $data->{'uniqueItems'} !== null) {
+        if (property_exists($data, 'uniqueItems')) {
             $object->setUniqueItems($data->{'uniqueItems'});
         }
-        if (property_exists($data, 'maxContains') && $data->{'maxContains'} !== null) {
+        if (property_exists($data, 'maxContains')) {
             $object->setMaxContains($data->{'maxContains'});
         }
-        if (property_exists($data, 'minContains') && $data->{'minContains'} !== null) {
+        if (property_exists($data, 'minContains')) {
             $object->setMinContains($data->{'minContains'});
         }
-        if (property_exists($data, 'maxProperties') && $data->{'maxProperties'} !== null) {
+        if (property_exists($data, 'maxProperties')) {
             $object->setMaxProperties($data->{'maxProperties'});
         }
-        if (property_exists($data, 'minProperties') && $data->{'minProperties'} !== null) {
+        if (property_exists($data, 'minProperties')) {
             $object->setMinProperties($data->{'minProperties'});
         }
-        if (property_exists($data, 'required') && $data->{'required'} !== null) {
+        if (property_exists($data, 'required')) {
             $values_14 = [];
             foreach ($data->{'required'} as $value_36) {
                 $values_14[] = $value_36;
             }
             $object->setRequired($values_14);
         }
-        if (property_exists($data, 'dependentRequired') && $data->{'dependentRequired'} !== null) {
+        if (property_exists($data, 'dependentRequired')) {
             $values_15 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'dependentRequired'} as $key_8 => $value_37) {
                 $values_16 = [];
@@ -417,17 +417,17 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             }
             $object->setDependentRequired($values_15);
         }
-        if (property_exists($data, 'const') && $data->{'const'} !== null) {
+        if (property_exists($data, 'const')) {
             $object->setConst($data->{'const'});
         }
-        if (property_exists($data, 'enum') && $data->{'enum'} !== null) {
+        if (property_exists($data, 'enum')) {
             $values_17 = [];
             foreach ($data->{'enum'} as $value_39) {
                 $values_17[] = $value_39;
             }
             $object->setEnum($values_17);
         }
-        if (property_exists($data, 'type') && $data->{'type'} !== null) {
+        if (property_exists($data, 'type')) {
             $value_40 = $data->{'type'};
             if (is_array($data->{'type'})) {
                 $values_18 = [];

--- a/src/JsonSchema/Normalizer/JsonSchemaNormalizer.php
+++ b/src/JsonSchema/Normalizer/JsonSchemaNormalizer.php
@@ -601,53 +601,73 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         } else {
             $data->{'dependencies'} = null;
         }
-        $value_5 = $object->getAdditionalItems();
-        if (is_object($object->getAdditionalItems())) {
-            $value_5 = $this->normalizer->normalize($object->getAdditionalItems(), 'json', $context);
-        } elseif (is_bool($object->getAdditionalItems())) {
+        if (null !== $object->getAdditionalItems()) {
             $value_5 = $object->getAdditionalItems();
-        }
-        $data->{'additionalItems'} = $value_5;
-        $value_6 = $object->getUnevaluatedItems();
-        if (is_object($object->getUnevaluatedItems())) {
-            $value_6 = $this->normalizer->normalize($object->getUnevaluatedItems(), 'json', $context);
-        } elseif (is_bool($object->getUnevaluatedItems())) {
-            $value_6 = $object->getUnevaluatedItems();
-        }
-        $data->{'unevaluatedItems'} = $value_6;
-        $value_7 = $object->getItems();
-        if (is_object($object->getItems())) {
-            $value_7 = $this->normalizer->normalize($object->getItems(), 'json', $context);
-        } elseif (is_bool($object->getItems())) {
-            $value_7 = $object->getItems();
-        } elseif (is_array($object->getItems())) {
-            $values_3 = [];
-            foreach ($object->getItems() as $value_8) {
-                $value_9 = $value_8;
-                if (is_object($value_8)) {
-                    $value_9 = $this->normalizer->normalize($value_8, 'json', $context);
-                } elseif (is_bool($value_8)) {
-                    $value_9 = $value_8;
-                }
-                $values_3[] = $value_9;
+            if (is_object($object->getAdditionalItems())) {
+                $value_5 = $this->normalizer->normalize($object->getAdditionalItems(), 'json', $context);
+            } elseif (is_bool($object->getAdditionalItems())) {
+                $value_5 = $object->getAdditionalItems();
             }
-            $value_7 = $values_3;
+            $data->{'additionalItems'} = $value_5;
+        } else {
+            $data->{'additionalItems'} = null;
         }
-        $data->{'items'} = $value_7;
-        $value_10 = $object->getContains();
-        if (is_object($object->getContains())) {
-            $value_10 = $this->normalizer->normalize($object->getContains(), 'json', $context);
-        } elseif (is_bool($object->getContains())) {
+        if (null !== $object->getUnevaluatedItems()) {
+            $value_6 = $object->getUnevaluatedItems();
+            if (is_object($object->getUnevaluatedItems())) {
+                $value_6 = $this->normalizer->normalize($object->getUnevaluatedItems(), 'json', $context);
+            } elseif (is_bool($object->getUnevaluatedItems())) {
+                $value_6 = $object->getUnevaluatedItems();
+            }
+            $data->{'unevaluatedItems'} = $value_6;
+        } else {
+            $data->{'unevaluatedItems'} = null;
+        }
+        if (null !== $object->getItems()) {
+            $value_7 = $object->getItems();
+            if (is_object($object->getItems())) {
+                $value_7 = $this->normalizer->normalize($object->getItems(), 'json', $context);
+            } elseif (is_bool($object->getItems())) {
+                $value_7 = $object->getItems();
+            } elseif (is_array($object->getItems())) {
+                $values_3 = [];
+                foreach ($object->getItems() as $value_8) {
+                    $value_9 = $value_8;
+                    if (is_object($value_8)) {
+                        $value_9 = $this->normalizer->normalize($value_8, 'json', $context);
+                    } elseif (is_bool($value_8)) {
+                        $value_9 = $value_8;
+                    }
+                    $values_3[] = $value_9;
+                }
+                $value_7 = $values_3;
+            }
+            $data->{'items'} = $value_7;
+        } else {
+            $data->{'items'} = null;
+        }
+        if (null !== $object->getContains()) {
             $value_10 = $object->getContains();
+            if (is_object($object->getContains())) {
+                $value_10 = $this->normalizer->normalize($object->getContains(), 'json', $context);
+            } elseif (is_bool($object->getContains())) {
+                $value_10 = $object->getContains();
+            }
+            $data->{'contains'} = $value_10;
+        } else {
+            $data->{'contains'} = null;
         }
-        $data->{'contains'} = $value_10;
-        $value_11 = $object->getAdditionalProperties();
-        if (is_object($object->getAdditionalProperties())) {
-            $value_11 = $this->normalizer->normalize($object->getAdditionalProperties(), 'json', $context);
-        } elseif (is_bool($object->getAdditionalProperties())) {
+        if (null !== $object->getAdditionalProperties()) {
             $value_11 = $object->getAdditionalProperties();
+            if (is_object($object->getAdditionalProperties())) {
+                $value_11 = $this->normalizer->normalize($object->getAdditionalProperties(), 'json', $context);
+            } elseif (is_bool($object->getAdditionalProperties())) {
+                $value_11 = $object->getAdditionalProperties();
+            }
+            $data->{'additionalProperties'} = $value_11;
+        } else {
+            $data->{'additionalProperties'} = null;
         }
-        $data->{'additionalProperties'} = $value_11;
         if (null !== $object->getUnevaluatedProperties()) {
             $values_4 = new \stdClass();
             foreach ($object->getUnevaluatedProperties() as $key_2 => $value_12) {
@@ -708,34 +728,50 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         } else {
             $data->{'dependentSchemas'} = null;
         }
-        $value_20 = $object->getPropertyNames();
-        if (is_object($object->getPropertyNames())) {
-            $value_20 = $this->normalizer->normalize($object->getPropertyNames(), 'json', $context);
-        } elseif (is_bool($object->getPropertyNames())) {
+        if (null !== $object->getPropertyNames()) {
             $value_20 = $object->getPropertyNames();
+            if (is_object($object->getPropertyNames())) {
+                $value_20 = $this->normalizer->normalize($object->getPropertyNames(), 'json', $context);
+            } elseif (is_bool($object->getPropertyNames())) {
+                $value_20 = $object->getPropertyNames();
+            }
+            $data->{'propertyNames'} = $value_20;
+        } else {
+            $data->{'propertyNames'} = null;
         }
-        $data->{'propertyNames'} = $value_20;
-        $value_21 = $object->getIf();
-        if (is_object($object->getIf())) {
-            $value_21 = $this->normalizer->normalize($object->getIf(), 'json', $context);
-        } elseif (is_bool($object->getIf())) {
+        if (null !== $object->getIf()) {
             $value_21 = $object->getIf();
+            if (is_object($object->getIf())) {
+                $value_21 = $this->normalizer->normalize($object->getIf(), 'json', $context);
+            } elseif (is_bool($object->getIf())) {
+                $value_21 = $object->getIf();
+            }
+            $data->{'if'} = $value_21;
+        } else {
+            $data->{'if'} = null;
         }
-        $data->{'if'} = $value_21;
-        $value_22 = $object->getThen();
-        if (is_object($object->getThen())) {
-            $value_22 = $this->normalizer->normalize($object->getThen(), 'json', $context);
-        } elseif (is_bool($object->getThen())) {
+        if (null !== $object->getThen()) {
             $value_22 = $object->getThen();
+            if (is_object($object->getThen())) {
+                $value_22 = $this->normalizer->normalize($object->getThen(), 'json', $context);
+            } elseif (is_bool($object->getThen())) {
+                $value_22 = $object->getThen();
+            }
+            $data->{'then'} = $value_22;
+        } else {
+            $data->{'then'} = null;
         }
-        $data->{'then'} = $value_22;
-        $value_23 = $object->getElse();
-        if (is_object($object->getElse())) {
-            $value_23 = $this->normalizer->normalize($object->getElse(), 'json', $context);
-        } elseif (is_bool($object->getElse())) {
+        if (null !== $object->getElse()) {
             $value_23 = $object->getElse();
+            if (is_object($object->getElse())) {
+                $value_23 = $this->normalizer->normalize($object->getElse(), 'json', $context);
+            } elseif (is_bool($object->getElse())) {
+                $value_23 = $object->getElse();
+            }
+            $data->{'else'} = $value_23;
+        } else {
+            $data->{'else'} = null;
         }
-        $data->{'else'} = $value_23;
         if (null !== $object->getAllOf()) {
             $values_8 = [];
             foreach ($object->getAllOf() as $value_24) {
@@ -781,28 +817,68 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         } else {
             $data->{'oneOf'} = null;
         }
-        $value_30 = $object->getNot();
-        if (is_object($object->getNot())) {
-            $value_30 = $this->normalizer->normalize($object->getNot(), 'json', $context);
-        } elseif (is_bool($object->getNot())) {
+        if (null !== $object->getNot()) {
             $value_30 = $object->getNot();
+            if (is_object($object->getNot())) {
+                $value_30 = $this->normalizer->normalize($object->getNot(), 'json', $context);
+            } elseif (is_bool($object->getNot())) {
+                $value_30 = $object->getNot();
+            }
+            $data->{'not'} = $value_30;
+        } else {
+            $data->{'not'} = null;
         }
-        $data->{'not'} = $value_30;
-        $data->{'contentMediaType'} = $object->getContentMediaType();
-        $data->{'contentEncoding'} = $object->getContentEncoding();
-        $value_31 = $object->getContentSchema();
-        if (is_object($object->getContentSchema())) {
-            $value_31 = $this->normalizer->normalize($object->getContentSchema(), 'json', $context);
-        } elseif (is_bool($object->getContentSchema())) {
+        if (null !== $object->getContentMediaType()) {
+            $data->{'contentMediaType'} = $object->getContentMediaType();
+        } else {
+            $data->{'contentMediaType'} = null;
+        }
+        if (null !== $object->getContentEncoding()) {
+            $data->{'contentEncoding'} = $object->getContentEncoding();
+        } else {
+            $data->{'contentEncoding'} = null;
+        }
+        if (null !== $object->getContentSchema()) {
             $value_31 = $object->getContentSchema();
+            if (is_object($object->getContentSchema())) {
+                $value_31 = $this->normalizer->normalize($object->getContentSchema(), 'json', $context);
+            } elseif (is_bool($object->getContentSchema())) {
+                $value_31 = $object->getContentSchema();
+            }
+            $data->{'contentSchema'} = $value_31;
+        } else {
+            $data->{'contentSchema'} = null;
         }
-        $data->{'contentSchema'} = $value_31;
-        $data->{'$id'} = $object->getDollarId();
-        $data->{'$schema'} = $object->getDollarSchema();
-        $data->{'$anchor'} = $object->getDollarAnchor();
-        $data->{'$ref'} = $object->getDollarRef();
-        $data->{'$recursiveRef'} = $object->getDollarRecursiveRef();
-        $data->{'$recursiveAnchor'} = $object->getDollarRecursiveAnchor();
+        if (null !== $object->getDollarId()) {
+            $data->{'$id'} = $object->getDollarId();
+        } else {
+            $data->{'$id'} = null;
+        }
+        if (null !== $object->getDollarSchema()) {
+            $data->{'$schema'} = $object->getDollarSchema();
+        } else {
+            $data->{'$schema'} = null;
+        }
+        if (null !== $object->getDollarAnchor()) {
+            $data->{'$anchor'} = $object->getDollarAnchor();
+        } else {
+            $data->{'$anchor'} = null;
+        }
+        if (null !== $object->getDollarRef()) {
+            $data->{'$ref'} = $object->getDollarRef();
+        } else {
+            $data->{'$ref'} = null;
+        }
+        if (null !== $object->getDollarRecursiveRef()) {
+            $data->{'$recursiveRef'} = $object->getDollarRecursiveRef();
+        } else {
+            $data->{'$recursiveRef'} = null;
+        }
+        if (null !== $object->getDollarRecursiveAnchor()) {
+            $data->{'$recursiveAnchor'} = $object->getDollarRecursiveAnchor();
+        } else {
+            $data->{'$recursiveAnchor'} = null;
+        }
         if (null !== $object->getDollarVocabulary()) {
             $values_11 = new \stdClass();
             foreach ($object->getDollarVocabulary() as $key_6 => $value_32) {
@@ -812,7 +888,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         } else {
             $data->{'$vocabulary'} = null;
         }
-        $data->{'$comment'} = $object->getDollarComment();
+        if (null !== $object->getDollarComment()) {
+            $data->{'$comment'} = $object->getDollarComment();
+        } else {
+            $data->{'$comment'} = null;
+        }
         if (null !== $object->getDollarDefs()) {
             $values_12 = new \stdClass();
             foreach ($object->getDollarDefs() as $key_7 => $value_33) {
@@ -828,13 +908,41 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         } else {
             $data->{'$defs'} = null;
         }
-        $data->{'format'} = $object->getFormat();
-        $data->{'title'} = $object->getTitle();
-        $data->{'description'} = $object->getDescription();
-        $data->{'default'} = $object->getDefault();
-        $data->{'deprecated'} = $object->getDeprecated();
-        $data->{'readOnly'} = $object->getReadOnly();
-        $data->{'writeOnly'} = $object->getWriteOnly();
+        if (null !== $object->getFormat()) {
+            $data->{'format'} = $object->getFormat();
+        } else {
+            $data->{'format'} = null;
+        }
+        if (null !== $object->getTitle()) {
+            $data->{'title'} = $object->getTitle();
+        } else {
+            $data->{'title'} = null;
+        }
+        if (null !== $object->getDescription()) {
+            $data->{'description'} = $object->getDescription();
+        } else {
+            $data->{'description'} = null;
+        }
+        if (null !== $object->getDefault()) {
+            $data->{'default'} = $object->getDefault();
+        } else {
+            $data->{'default'} = null;
+        }
+        if (null !== $object->getDeprecated()) {
+            $data->{'deprecated'} = $object->getDeprecated();
+        } else {
+            $data->{'deprecated'} = null;
+        }
+        if (null !== $object->getReadOnly()) {
+            $data->{'readOnly'} = $object->getReadOnly();
+        } else {
+            $data->{'readOnly'} = null;
+        }
+        if (null !== $object->getWriteOnly()) {
+            $data->{'writeOnly'} = $object->getWriteOnly();
+        } else {
+            $data->{'writeOnly'} = null;
+        }
         if (null !== $object->getExamples()) {
             $values_13 = [];
             foreach ($object->getExamples() as $value_35) {
@@ -844,21 +952,81 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         } else {
             $data->{'examples'} = null;
         }
-        $data->{'multipleOf'} = $object->getMultipleOf();
-        $data->{'maximum'} = $object->getMaximum();
-        $data->{'exclusiveMaximum'} = $object->getExclusiveMaximum();
-        $data->{'minimum'} = $object->getMinimum();
-        $data->{'exclusiveMinimum'} = $object->getExclusiveMinimum();
-        $data->{'maxLength'} = $object->getMaxLength();
-        $data->{'minLength'} = $object->getMinLength();
-        $data->{'pattern'} = $object->getPattern();
-        $data->{'maxItems'} = $object->getMaxItems();
-        $data->{'minItems'} = $object->getMinItems();
-        $data->{'uniqueItems'} = $object->getUniqueItems();
-        $data->{'maxContains'} = $object->getMaxContains();
-        $data->{'minContains'} = $object->getMinContains();
-        $data->{'maxProperties'} = $object->getMaxProperties();
-        $data->{'minProperties'} = $object->getMinProperties();
+        if (null !== $object->getMultipleOf()) {
+            $data->{'multipleOf'} = $object->getMultipleOf();
+        } else {
+            $data->{'multipleOf'} = null;
+        }
+        if (null !== $object->getMaximum()) {
+            $data->{'maximum'} = $object->getMaximum();
+        } else {
+            $data->{'maximum'} = null;
+        }
+        if (null !== $object->getExclusiveMaximum()) {
+            $data->{'exclusiveMaximum'} = $object->getExclusiveMaximum();
+        } else {
+            $data->{'exclusiveMaximum'} = null;
+        }
+        if (null !== $object->getMinimum()) {
+            $data->{'minimum'} = $object->getMinimum();
+        } else {
+            $data->{'minimum'} = null;
+        }
+        if (null !== $object->getExclusiveMinimum()) {
+            $data->{'exclusiveMinimum'} = $object->getExclusiveMinimum();
+        } else {
+            $data->{'exclusiveMinimum'} = null;
+        }
+        if (null !== $object->getMaxLength()) {
+            $data->{'maxLength'} = $object->getMaxLength();
+        } else {
+            $data->{'maxLength'} = null;
+        }
+        if (null !== $object->getMinLength()) {
+            $data->{'minLength'} = $object->getMinLength();
+        } else {
+            $data->{'minLength'} = null;
+        }
+        if (null !== $object->getPattern()) {
+            $data->{'pattern'} = $object->getPattern();
+        } else {
+            $data->{'pattern'} = null;
+        }
+        if (null !== $object->getMaxItems()) {
+            $data->{'maxItems'} = $object->getMaxItems();
+        } else {
+            $data->{'maxItems'} = null;
+        }
+        if (null !== $object->getMinItems()) {
+            $data->{'minItems'} = $object->getMinItems();
+        } else {
+            $data->{'minItems'} = null;
+        }
+        if (null !== $object->getUniqueItems()) {
+            $data->{'uniqueItems'} = $object->getUniqueItems();
+        } else {
+            $data->{'uniqueItems'} = null;
+        }
+        if (null !== $object->getMaxContains()) {
+            $data->{'maxContains'} = $object->getMaxContains();
+        } else {
+            $data->{'maxContains'} = null;
+        }
+        if (null !== $object->getMinContains()) {
+            $data->{'minContains'} = $object->getMinContains();
+        } else {
+            $data->{'minContains'} = null;
+        }
+        if (null !== $object->getMaxProperties()) {
+            $data->{'maxProperties'} = $object->getMaxProperties();
+        } else {
+            $data->{'maxProperties'} = null;
+        }
+        if (null !== $object->getMinProperties()) {
+            $data->{'minProperties'} = $object->getMinProperties();
+        } else {
+            $data->{'minProperties'} = null;
+        }
         if (null !== $object->getRequired()) {
             $values_14 = [];
             foreach ($object->getRequired() as $value_36) {
@@ -881,7 +1049,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         } else {
             $data->{'dependentRequired'} = null;
         }
-        $data->{'const'} = $object->getConst();
+        if (null !== $object->getConst()) {
+            $data->{'const'} = $object->getConst();
+        } else {
+            $data->{'const'} = null;
+        }
         if (null !== $object->getEnum()) {
             $values_17 = [];
             foreach ($object->getEnum() as $value_39) {
@@ -891,17 +1063,21 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         } else {
             $data->{'enum'} = null;
         }
-        $value_40 = $object->getType();
-        if (is_array($object->getType())) {
-            $values_18 = [];
-            foreach ($object->getType() as $value_41) {
-                $values_18[] = $value_41;
-            }
-            $value_40 = $values_18;
-        } elseif (!is_null($object->getType())) {
+        if (null !== $object->getType()) {
             $value_40 = $object->getType();
+            if (is_array($object->getType())) {
+                $values_18 = [];
+                foreach ($object->getType() as $value_41) {
+                    $values_18[] = $value_41;
+                }
+                $value_40 = $values_18;
+            } elseif (!is_null($object->getType())) {
+                $value_40 = $object->getType();
+            }
+            $data->{'type'} = $value_40;
+        } else {
+            $data->{'type'} = null;
         }
-        $data->{'type'} = $value_40;
 
         return $data;
     }

--- a/src/JsonSchema/Tests/fixtures/array-object-nullable/expected/Normalizer/DocumentNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/array-object-nullable/expected/Normalizer/DocumentNormalizer.php
@@ -34,7 +34,7 @@ class DocumentNormalizer implements DenormalizerInterface, NormalizerInterface, 
             return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Document();
-        if (property_exists($data, 'attributes')) {
+        if (property_exists($data, 'attributes') && $data->{'attributes'} !== null) {
             $value = $data->{'attributes'};
             if (is_array($data->{'attributes'})) {
                 $values = array();
@@ -46,6 +46,9 @@ class DocumentNormalizer implements DenormalizerInterface, NormalizerInterface, 
                 $value = $data->{'attributes'};
             }
             $object->setAttributes($value);
+        }
+        elseif (property_exists($data, 'attributes') && $data->{'attributes'} === null) {
+            $object->setAttributes(null);
         }
         return $object;
     }

--- a/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
@@ -37,7 +37,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (property_exists($data, 'date')) {
             $object->setDate(\DateTime::createFromFormat("l, d-M-y H:i:s T", $data->{'date'}));
         }
-        if (property_exists($data, 'dateOrNull')) {
+        if (property_exists($data, 'dateOrNull') && $data->{'dateOrNull'} !== null) {
             $value = $data->{'dateOrNull'};
             if (is_string($data->{'dateOrNull'}) and false !== \DateTime::createFromFormat("l, d-M-y H:i:s T", $data->{'dateOrNull'})) {
                 $value = \DateTime::createFromFormat("l, d-M-y H:i:s T", $data->{'dateOrNull'});
@@ -46,7 +46,10 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             }
             $object->setDateOrNull($value);
         }
-        if (property_exists($data, 'dateOrNullOrInt')) {
+        elseif (property_exists($data, 'dateOrNull') && $data->{'dateOrNull'} === null) {
+            $object->setDateOrNull(null);
+        }
+        if (property_exists($data, 'dateOrNullOrInt') && $data->{'dateOrNullOrInt'} !== null) {
             $value_1 = $data->{'dateOrNullOrInt'};
             if (is_string($data->{'dateOrNullOrInt'}) and false !== \DateTime::createFromFormat("l, d-M-y H:i:s T", $data->{'dateOrNullOrInt'})) {
                 $value_1 = \DateTime::createFromFormat("l, d-M-y H:i:s T", $data->{'dateOrNullOrInt'});
@@ -56,6 +59,9 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
                 $value_1 = $data->{'dateOrNullOrInt'};
             }
             $object->setDateOrNullOrInt($value_1);
+        }
+        elseif (property_exists($data, 'dateOrNullOrInt') && $data->{'dateOrNullOrInt'} === null) {
+            $object->setDateOrNullOrInt(null);
         }
         return $object;
     }

--- a/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
@@ -37,7 +37,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (property_exists($data, 'date')) {
             $object->setDate(\DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'date'}));
         }
-        if (property_exists($data, 'dateOrNull')) {
+        if (property_exists($data, 'dateOrNull') && $data->{'dateOrNull'} !== null) {
             $value = $data->{'dateOrNull'};
             if (is_string($data->{'dateOrNull'}) and false !== \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNull'})) {
                 $value = \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNull'});
@@ -46,7 +46,10 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             }
             $object->setDateOrNull($value);
         }
-        if (property_exists($data, 'dateOrNullOrInt')) {
+        elseif (property_exists($data, 'dateOrNull') && $data->{'dateOrNull'} === null) {
+            $object->setDateOrNull(null);
+        }
+        if (property_exists($data, 'dateOrNullOrInt') && $data->{'dateOrNullOrInt'} !== null) {
             $value_1 = $data->{'dateOrNullOrInt'};
             if (is_string($data->{'dateOrNullOrInt'}) and false !== \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNullOrInt'})) {
                 $value_1 = \DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'dateOrNullOrInt'});
@@ -56,6 +59,9 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
                 $value_1 = $data->{'dateOrNullOrInt'};
             }
             $object->setDateOrNullOrInt($value_1);
+        }
+        elseif (property_exists($data, 'dateOrNullOrInt') && $data->{'dateOrNullOrInt'} === null) {
+            $object->setDateOrNullOrInt(null);
         }
         return $object;
     }

--- a/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestNormalizer.php
@@ -34,58 +34,74 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Test();
-        if (property_exists($data, 'string')) {
+        if (property_exists($data, 'string') && $data->{'string'} !== null) {
             $object->setString($data->{'string'});
         }
-        if (property_exists($data, 'bool')) {
+        elseif (property_exists($data, 'string') && $data->{'string'} === null) {
+            $object->setString(null);
+        }
+        if (property_exists($data, 'bool') && $data->{'bool'} !== null) {
             $object->setBool($data->{'bool'});
         }
-        if (property_exists($data, 'integer')) {
+        elseif (property_exists($data, 'bool') && $data->{'bool'} === null) {
+            $object->setBool(null);
+        }
+        if (property_exists($data, 'integer') && $data->{'integer'} !== null) {
             $object->setInteger($data->{'integer'});
         }
-        if (property_exists($data, 'float')) {
+        elseif (property_exists($data, 'integer') && $data->{'integer'} === null) {
+            $object->setInteger(null);
+        }
+        if (property_exists($data, 'float') && $data->{'float'} !== null) {
             $object->setFloat($data->{'float'});
         }
-        if (property_exists($data, 'array')) {
+        elseif (property_exists($data, 'float') && $data->{'float'} === null) {
+            $object->setFloat(null);
+        }
+        if (property_exists($data, 'array') && $data->{'array'} !== null) {
             $values = array();
             foreach ($data->{'array'} as $value) {
                 $values[] = $value;
             }
             $object->setArray($values);
         }
-        if (property_exists($data, 'object')) {
+        elseif (property_exists($data, 'array') && $data->{'array'} === null) {
+            $object->setArray(null);
+        }
+        if (property_exists($data, 'object') && $data->{'object'} !== null) {
             $values_1 = array();
             foreach ($data->{'object'} as $value_1) {
                 $values_1[] = $value_1;
             }
             $object->setObject($values_1);
         }
-        if (property_exists($data, 'subObject')) {
+        elseif (property_exists($data, 'object') && $data->{'object'} === null) {
+            $object->setObject(null);
+        }
+        if (property_exists($data, 'subObject') && $data->{'subObject'} !== null) {
             $object->setSubObject($this->denormalizer->denormalize($data->{'subObject'}, 'Jane\\JsonSchema\\Tests\\Expected\\Model\\TestSubObject', 'json', $context));
+        }
+        elseif (property_exists($data, 'subObject') && $data->{'subObject'} === null) {
+            $object->setSubObject(null);
         }
         return $object;
     }
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        if (null !== $object->getString()) {
-            $data->{'string'} = $object->getString();
-        }
-        if (null !== $object->getBool()) {
-            $data->{'bool'} = $object->getBool();
-        }
-        if (null !== $object->getInteger()) {
-            $data->{'integer'} = $object->getInteger();
-        }
-        if (null !== $object->getFloat()) {
-            $data->{'float'} = $object->getFloat();
-        }
+        $data->{'string'} = $object->getString();
+        $data->{'bool'} = $object->getBool();
+        $data->{'integer'} = $object->getInteger();
+        $data->{'float'} = $object->getFloat();
         if (null !== $object->getArray()) {
             $values = array();
             foreach ($object->getArray() as $value) {
                 $values[] = $value;
             }
             $data->{'array'} = $values;
+        }
+        else {
+            $data->{'array'} = null;
         }
         if (null !== $object->getObject()) {
             $values_1 = array();
@@ -94,8 +110,14 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             }
             $data->{'object'} = $values_1;
         }
+        else {
+            $data->{'object'} = null;
+        }
         if (null !== $object->getSubObject()) {
             $data->{'subObject'} = $this->normalizer->normalize($object->getSubObject(), 'json', $context);
+        }
+        else {
+            $data->{'subObject'} = null;
         }
         return $data;
     }

--- a/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestNormalizer.php
@@ -34,33 +34,33 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Test();
-        if (property_exists($data, 'string') && $data->{'string'} !== null) {
+        if (property_exists($data, 'string')) {
             $object->setString($data->{'string'});
         }
-        if (property_exists($data, 'bool') && $data->{'bool'} !== null) {
+        if (property_exists($data, 'bool')) {
             $object->setBool($data->{'bool'});
         }
-        if (property_exists($data, 'integer') && $data->{'integer'} !== null) {
+        if (property_exists($data, 'integer')) {
             $object->setInteger($data->{'integer'});
         }
-        if (property_exists($data, 'float') && $data->{'float'} !== null) {
+        if (property_exists($data, 'float')) {
             $object->setFloat($data->{'float'});
         }
-        if (property_exists($data, 'array') && $data->{'array'} !== null) {
+        if (property_exists($data, 'array')) {
             $values = array();
             foreach ($data->{'array'} as $value) {
                 $values[] = $value;
             }
             $object->setArray($values);
         }
-        if (property_exists($data, 'object') && $data->{'object'} !== null) {
+        if (property_exists($data, 'object')) {
             $values_1 = array();
             foreach ($data->{'object'} as $value_1) {
                 $values_1[] = $value_1;
             }
             $object->setObject($values_1);
         }
-        if (property_exists($data, 'subObject') && $data->{'subObject'} !== null) {
+        if (property_exists($data, 'subObject')) {
             $object->setSubObject($this->denormalizer->denormalize($data->{'subObject'}, 'Jane\\JsonSchema\\Tests\\Expected\\Model\\TestSubObject', 'json', $context));
         }
         return $object;

--- a/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestNormalizer.php
@@ -89,10 +89,30 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'string'} = $object->getString();
-        $data->{'bool'} = $object->getBool();
-        $data->{'integer'} = $object->getInteger();
-        $data->{'float'} = $object->getFloat();
+        if (null !== $object->getString()) {
+            $data->{'string'} = $object->getString();
+        }
+        else {
+            $data->{'string'} = null;
+        }
+        if (null !== $object->getBool()) {
+            $data->{'bool'} = $object->getBool();
+        }
+        else {
+            $data->{'bool'} = null;
+        }
+        if (null !== $object->getInteger()) {
+            $data->{'integer'} = $object->getInteger();
+        }
+        else {
+            $data->{'integer'} = null;
+        }
+        if (null !== $object->getFloat()) {
+            $data->{'float'} = $object->getFloat();
+        }
+        else {
+            $data->{'float'} = null;
+        }
         if (null !== $object->getArray()) {
             $values = array();
             foreach ($object->getArray() as $value) {

--- a/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestSubObjectNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestSubObjectNormalizer.php
@@ -45,7 +45,12 @@ class TestSubObjectNormalizer implements DenormalizerInterface, NormalizerInterf
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'foo'} = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data->{'foo'} = $object->getFoo();
+        }
+        else {
+            $data->{'foo'} = null;
+        }
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestSubObjectNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestSubObjectNormalizer.php
@@ -34,17 +34,18 @@ class TestSubObjectNormalizer implements DenormalizerInterface, NormalizerInterf
             return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\TestSubObject();
-        if (property_exists($data, 'foo')) {
+        if (property_exists($data, 'foo') && $data->{'foo'} !== null) {
             $object->setFoo($data->{'foo'});
+        }
+        elseif (property_exists($data, 'foo') && $data->{'foo'} === null) {
+            $object->setFoo(null);
         }
         return $object;
     }
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        if (null !== $object->getFoo()) {
-            $data->{'foo'} = $object->getFoo();
-        }
+        $data->{'foo'} = $object->getFoo();
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestSubObjectNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestSubObjectNormalizer.php
@@ -34,7 +34,7 @@ class TestSubObjectNormalizer implements DenormalizerInterface, NormalizerInterf
             return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\TestSubObject();
-        if (property_exists($data, 'foo') && $data->{'foo'} !== null) {
+        if (property_exists($data, 'foo')) {
             $object->setFoo($data->{'foo'});
         }
         return $object;

--- a/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
@@ -37,6 +37,9 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (property_exists($data, 'onlyNull') && $data->{'onlyNull'} !== null) {
             $object->setOnlyNull($data->{'onlyNull'});
         }
+        elseif (property_exists($data, 'onlyNull') && $data->{'onlyNull'} === null) {
+            $object->setOnlyNull(null);
+        }
         if (property_exists($data, 'nullOrString') && $data->{'nullOrString'} !== null) {
             $value = $data->{'nullOrString'};
             if (is_string($data->{'nullOrString'})) {
@@ -46,14 +49,17 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             }
             $object->setNullOrString($value);
         }
-        if (property_exists($data, 'array') && $data->{'array'} !== null) {
+        elseif (property_exists($data, 'nullOrString') && $data->{'nullOrString'} === null) {
+            $object->setNullOrString(null);
+        }
+        if (property_exists($data, 'array')) {
             $values = array();
             foreach ($data->{'array'} as $value_1) {
                 $values[] = $value_1;
             }
             $object->setArray($values);
         }
-        if (property_exists($data, 'object') && $data->{'object'} !== null) {
+        if (property_exists($data, 'object')) {
             $values_1 = new \ArrayObject(array(), \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'object'} as $key => $value_2) {
                 $values_1[$key] = $value_2;

--- a/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
@@ -77,14 +77,24 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = new \stdClass();
-        $data->{'onlyNull'} = $object->getOnlyNull();
-        $value = $object->getNullOrString();
-        if (is_string($object->getNullOrString())) {
-            $value = $object->getNullOrString();
-        } elseif (is_null($object->getNullOrString())) {
-            $value = $object->getNullOrString();
+        if (null !== $object->getOnlyNull()) {
+            $data->{'onlyNull'} = $object->getOnlyNull();
         }
-        $data->{'nullOrString'} = $value;
+        else {
+            $data->{'onlyNull'} = null;
+        }
+        if (null !== $object->getNullOrString()) {
+            $value = $object->getNullOrString();
+            if (is_string($object->getNullOrString())) {
+                $value = $object->getNullOrString();
+            } elseif (is_null($object->getNullOrString())) {
+                $value = $object->getNullOrString();
+            }
+            $data->{'nullOrString'} = $value;
+        }
+        else {
+            $data->{'nullOrString'} = null;
+        }
         if (null !== $object->getArray()) {
             $values = array();
             foreach ($object->getArray() as $value_1) {

--- a/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Normalizer/TestNormalizer.php
@@ -52,19 +52,25 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         elseif (property_exists($data, 'nullOrString') && $data->{'nullOrString'} === null) {
             $object->setNullOrString(null);
         }
-        if (property_exists($data, 'array')) {
+        if (property_exists($data, 'array') && $data->{'array'} !== null) {
             $values = array();
             foreach ($data->{'array'} as $value_1) {
                 $values[] = $value_1;
             }
             $object->setArray($values);
         }
-        if (property_exists($data, 'object')) {
+        elseif (property_exists($data, 'array') && $data->{'array'} === null) {
+            $object->setArray(null);
+        }
+        if (property_exists($data, 'object') && $data->{'object'} !== null) {
             $values_1 = new \ArrayObject(array(), \ArrayObject::ARRAY_AS_PROPS);
             foreach ($data->{'object'} as $key => $value_2) {
                 $values_1[$key] = $value_2;
             }
             $object->setObject($values_1);
+        }
+        elseif (property_exists($data, 'object') && $data->{'object'} === null) {
+            $object->setObject(null);
         }
         return $object;
     }
@@ -86,12 +92,18 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             }
             $data->{'array'} = $values;
         }
+        else {
+            $data->{'array'} = null;
+        }
         if (null !== $object->getObject()) {
             $values_1 = new \stdClass();
             foreach ($object->getObject() as $key => $value_2) {
                 $values_1->{$key} = $value_2;
             }
             $data->{'object'} = $values_1;
+        }
+        else {
+            $data->{'object'} = null;
         }
         return $data;
     }

--- a/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
@@ -34,10 +34,13 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
         }
         $object = new \Jane\JsonSchema\Tests\Expected\Model\Test();
-        if (property_exists($data, 'onlyNull')) {
+        if (property_exists($data, 'onlyNull') && $data->{'onlyNull'} !== null) {
             $object->setOnlyNull($data->{'onlyNull'});
         }
-        if (property_exists($data, 'nullOrString')) {
+        elseif (property_exists($data, 'onlyNull') && $data->{'onlyNull'} === null) {
+            $object->setOnlyNull(null);
+        }
+        if (property_exists($data, 'nullOrString') && $data->{'nullOrString'} !== null) {
             $value = $data->{'nullOrString'};
             if (is_string($data->{'nullOrString'})) {
                 $value = $data->{'nullOrString'};
@@ -45,6 +48,9 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
                 $value = $data->{'nullOrString'};
             }
             $object->setNullOrString($value);
+        }
+        elseif (property_exists($data, 'nullOrString') && $data->{'nullOrString'} === null) {
+            $object->setNullOrString(null);
         }
         return $object;
     }

--- a/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable-array/expected/Normalizer/ModelNormalizer.php
@@ -28,15 +28,21 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
             throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Model();
-        if (property_exists($data, 'foo')) {
+        if (property_exists($data, 'foo') && $data->{'foo'} !== null) {
             $object->setFoo($data->{'foo'});
         }
-        if (property_exists($data, 'bar')) {
+        elseif (property_exists($data, 'foo') && $data->{'foo'} === null) {
+            $object->setFoo(null);
+        }
+        if (property_exists($data, 'bar') && $data->{'bar'} !== null) {
             $values = array();
             foreach ($data->{'bar'} as $value) {
                 $values[] = $value;
             }
             $object->setBar($values);
+        }
+        elseif (property_exists($data, 'bar') && $data->{'bar'} === null) {
+            $object->setBar(null);
         }
         return $object;
     }

--- a/src/OpenApi/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
@@ -28,14 +28,20 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
             throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
         }
         $object = new \Jane\OpenApi\Tests\Expected\Model\Model();
-        if (property_exists($data, 'foo')) {
+        if (property_exists($data, 'foo') && $data->{'foo'} !== null) {
             $object->setFoo($data->{'foo'});
+        }
+        elseif (property_exists($data, 'foo') && $data->{'foo'} === null) {
+            $object->setFoo(null);
         }
         if (property_exists($data, 'bar')) {
             $object->setBar($data->{'bar'});
         }
-        if (property_exists($data, 'date')) {
+        if (property_exists($data, 'date') && $data->{'date'} !== null) {
             $object->setDate(\DateTime::createFromFormat("Y-m-d\TH:i:sP", $data->{'date'}));
+        }
+        elseif (property_exists($data, 'date') && $data->{'date'} === null) {
+            $object->setDate(null);
         }
         return $object;
     }


### PR DESCRIPTION
Fixes #229 

When generating Normalizers we were relying only on `strict` parameter and not checking if a given paramter was nullable or not, let's just rely on `Property::isNullable()`. This method is already including `strict` paramter so we won't have BC Break here :wink: