### PR TITLE
Fix variable conflict in authentication generator

### DIFF
--- a/src/OpenApiCommon/Generator/AuthenticationGenerator.php
+++ b/src/OpenApiCommon/Generator/AuthenticationGenerator.php
@@ -36,7 +36,7 @@ class AuthenticationGenerator implements GeneratorInterface
     public function generate(BaseSchema $schema, string $className, Context $context): void
     {
         if ($schema instanceof Schema) {
-            $namespace = sprintf('%s\\%s', $schema->getNamespace(), self::REFERENCE);
+            $baseNamespace = sprintf('%s\\%s', $schema->getNamespace(), self::REFERENCE);
 
             $securitySchemes = $schema->getSecuritySchemes();
             foreach ($securitySchemes as $securityScheme) {
@@ -50,7 +50,7 @@ class AuthenticationGenerator implements GeneratorInterface
                 ];
 
                 $authentication = $this->createAuthentication($className, $properties, $methods);
-                $namespace = new Stmt\Namespace_(new Name($namespace), [$authentication]);
+                $namespace = new Stmt\Namespace_(new Name($baseNamespace), [$authentication]);
 
                 $schema->addFile(new File(sprintf('%s/%s/%s.php', $schema->getDirectory(), self::REFERENCE, $className), $namespace, self::FILE_TYPE_AUTH));
             }


### PR DESCRIPTION
When you have many authentication types defined in OpenApi v3 specs:
```
   jwt:
      type: http
      scheme: bearer
      bearerFormat: JWT
    apiKey:
      type: apiKey
      in: header
      name: X-API-KEY
```

there is a variable conflit in Authentication generator. The $namespace variable is overwrited in `foreach` and doesn't contain the original value (string type) for next loops.