### PR TITLE
Fixed JsonSchema dependencies

### DIFF
--- a/src/JsonSchema/composer.json
+++ b/src/JsonSchema/composer.json
@@ -21,7 +21,7 @@
         "symfony/console": "^3.1 || ^4.0 || ^5.0",
         "symfony/filesystem": "^3.1 || ^4.0 || ^5.0",
         "symfony/options-resolver": "^3.1 || ^4.0 || ^5.0",
-        "symfony/property-access": "^3.1 || ^4.0 || ^5.0",
+        "symfony/serializer": "^4.2 || ^5.0",
         "symfony/yaml": "^3.1 || ^4.0 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
`symfony/serializer` dependency is used but was not explicitly required in `composer.json`.

I set it to `"4.2 || ^5.0` since the lower versions are not supported.