### PR TITLE
Allow references override attributes from their referred object on resolving

### DIFF
--- a/src/JsonSchema/Guesser/GuesserResolverTrait.php
+++ b/src/JsonSchema/Guesser/GuesserResolverTrait.php
@@ -3,6 +3,7 @@
 namespace Jane\JsonSchema\Guesser;
 
 use Jane\JsonSchemaRuntime\Reference;
+use Jane\OpenApi\JsonSchema\Model\Schema;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 trait GuesserResolverTrait
@@ -23,6 +24,28 @@ trait GuesserResolverTrait
                     'document-origin' => (string) $result->getMergedUri()->withFragment(''),
                 ]);
             });
+        }
+
+        if ($result instanceof Reference || $result instanceof Schema) {
+            $result->setTitle($reference->getTitle() ?? $result->getTitle());
+            $result->setMultipleOf($reference->getMultipleOf() ?? $result->getMultipleOf());
+            $result->setMaximum($reference->getMaximum() ?? $result->getMaximum());
+            $result->setExclusiveMaximum($reference->getExclusiveMaximum() ?? $result->getExclusiveMaximum());
+            $result->setMinimum($reference->getMinimum() ?? $result->getMinimum());
+            $result->setExclusiveMinimum($reference->getExclusiveMinimum() ?? $result->getExclusiveMinimum());
+            $result->setMaxLength($reference->getMaxLength() ?? $result->getMaxLength());
+            $result->setMinLength($reference->getMinLength() ?? $result->getMinLength());
+            $result->setPattern($reference->getPattern() ?? $result->getPattern());
+            $result->setMaxItems($reference->getMaxItems() ?? $result->getMaxItems());
+            $result->setMinItems($reference->getMinItems() ?? $result->getMinItems());
+            $result->setUniqueItems($reference->getUniqueItems() ?? $result->getUniqueItems());
+            $result->setType($reference->getType() ?? $result->getType());
+            $result->setDescription($reference->getDescription() ?? $result->getDescription());
+            $result->setFormat($reference->getFormat() ?? $result->getFormat());
+            $result->setNullable($reference->getNullable() ?? $result->getNullable());
+            $result->setReadOnly($reference->getReadOnly() ?? $result->getReadOnly());
+            $result->setWriteOnly($reference->getWriteOnly() ?? $result->getWriteOnly());
+            $result->setDeprecated($reference->getDeprecated() ?? $result->getDeprecated());
         }
 
         return $result;

--- a/src/JsonSchemaRuntime/Reference.php
+++ b/src/JsonSchemaRuntime/Reference.php
@@ -27,6 +27,106 @@ class Reference
 
     private $mergedUri;
 
+    /**
+     * @var string|null
+     */
+    protected $title;
+
+    /**
+     * @var float|null
+     */
+    protected $multipleOf;
+
+    /**
+     * @var float|null
+     */
+    protected $maximum;
+
+    /**
+     * @var bool|null
+     */
+    protected $exclusiveMaximum;
+
+    /**
+     * @var float|null
+     */
+    protected $minimum;
+
+    /**
+     * @var bool|null
+     */
+    protected $exclusiveMinimum;
+
+    /**
+     * @var int|null
+     */
+    protected $maxLength;
+
+    /**
+     * @var int|null
+     */
+    protected $minLength;
+
+    /**
+     * @var string|null
+     */
+    protected $pattern;
+
+    /**
+     * @var int|null
+     */
+    protected $maxItems;
+
+    /**
+     * @var int|null
+     */
+    protected $minItems;
+
+    /**
+     * @var bool|null
+     */
+    protected $uniqueItems;
+
+    /**
+     * @var string|null
+     */
+    protected $type;
+
+    /**
+     * @var string|null
+     */
+    protected $description;
+
+    /**
+     * @var string|null
+     */
+    protected $format;
+
+    /**
+     * @var bool|null
+     */
+    protected $nullable;
+
+    /**
+     * @var bool|null
+     */
+    protected $readOnly;
+
+    /**
+     * @var bool|null
+     */
+    protected $writeOnly;
+
+    /**
+     * @var mixed|null
+     */
+    protected $example;
+
+    /**
+     * @var bool|null
+     */
+    protected $deprecated;
+
     public function __construct(string $reference, string $origin)
     {
         $originParts = (new Parser())->parse($origin);
@@ -116,7 +216,7 @@ class Reference
             $this->mergedUri->getPath() === $this->originUri->getPath()
             &&
             $this->mergedUri->getQuery() === $this->originUri->getQuery()
-        ;
+            ;
     }
 
     public function getMergedUri(): AbstractUri
@@ -132,6 +232,366 @@ class Reference
     public function getOriginUri(): AbstractUri
     {
         return $this->originUri;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string|null $title
+     *
+     * @return Reference
+     */
+    public function setTitle(?string $title): self
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getMultipleOf(): ?float
+    {
+        return $this->multipleOf;
+    }
+
+    /**
+     * @param float|null $multipleOf
+     *
+     * @return Reference
+     */
+    public function setMultipleOf(?float $multipleOf): self
+    {
+        $this->multipleOf = $multipleOf;
+        return $this;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getMaximum(): ?float
+    {
+        return $this->maximum;
+    }
+
+    /**
+     * @param float|null $maximum
+     *
+     * @return Reference
+     */
+    public function setMaximum(?float $maximum): self
+    {
+        $this->maximum = $maximum;
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getExclusiveMaximum(): ?bool
+    {
+        return $this->exclusiveMaximum;
+    }
+
+    /**
+     * @param bool|null $exclusiveMaximum
+     *
+     * @return Reference
+     */
+    public function setExclusiveMaximum(?bool $exclusiveMaximum): self
+    {
+        $this->exclusiveMaximum = $exclusiveMaximum;
+        return $this;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getMinimum(): ?float
+    {
+        return $this->minimum;
+    }
+
+    /**
+     * @param float|null $minimum
+     *
+     * @return Reference
+     */
+    public function setMinimum(?float $minimum): self
+    {
+        $this->minimum = $minimum;
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getExclusiveMinimum(): ?bool
+    {
+        return $this->exclusiveMinimum;
+    }
+
+    /**
+     * @param bool|null $exclusiveMinimum
+     *
+     * @return Reference
+     */
+    public function setExclusiveMinimum(?bool $exclusiveMinimum): self
+    {
+        $this->exclusiveMinimum = $exclusiveMinimum;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMaxLength(): ?int
+    {
+        return $this->maxLength;
+    }
+
+    /**
+     * @param int|null $maxLength
+     *
+     * @return Reference
+     */
+    public function setMaxLength(?int $maxLength): self
+    {
+        $this->maxLength = $maxLength;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMinLength(): ?int
+    {
+        return $this->minLength;
+    }
+
+    /**
+     * @param int|null $minLength
+     *
+     * @return Reference
+     */
+    public function setMinLength(?int $minLength): self
+    {
+        $this->minLength = $minLength;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPattern(): ?string
+    {
+        return $this->pattern;
+    }
+
+    /**
+     * @param string|null $pattern
+     *
+     * @return Reference
+     */
+    public function setPattern(?string $pattern): self
+    {
+        $this->pattern = $pattern;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMaxItems(): ?int
+    {
+        return $this->maxItems;
+    }
+
+    /**
+     * @param int|null $maxItems
+     *
+     * @return Reference
+     */
+    public function setMaxItems(?int $maxItems): self
+    {
+        $this->maxItems = $maxItems;
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMinItems(): ?int
+    {
+        return $this->minItems;
+    }
+
+    /**
+     * @param int|null $minItems
+     *
+     * @return Reference
+     */
+    public function setMinItems(?int $minItems): self
+    {
+        $this->minItems = $minItems;
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getUniqueItems(): ?bool
+    {
+        return $this->uniqueItems;
+    }
+
+    /**
+     * @param bool|null $uniqueItems
+     *
+     * @return Reference
+     */
+    public function setUniqueItems(?bool $uniqueItems): self
+    {
+        $this->uniqueItems = $uniqueItems;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string|null $type
+     *
+     * @return Reference
+     */
+    public function setType(?string $type): self
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string|null $description
+     *
+     * @return Reference
+     */
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFormat(): ?string
+    {
+        return $this->format;
+    }
+
+    /**
+     * @param string|null $format
+     *
+     * @return Reference
+     */
+    public function setFormat(?string $format): self
+    {
+        $this->format = $format;
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getNullable(): ?bool
+    {
+        return $this->nullable;
+    }
+
+    /**
+     * @param bool|null $nullable
+     *
+     * @return Reference
+     */
+    public function setNullable(?bool $nullable): self
+    {
+        $this->nullable = $nullable;
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getReadOnly(): ?bool
+    {
+        return $this->readOnly;
+    }
+
+    /**
+     * @param bool|null $readOnly
+     *
+     * @return Reference
+     */
+    public function setReadOnly(?bool $readOnly): self
+    {
+        $this->readOnly = $readOnly;
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getWriteOnly(): ?bool
+    {
+        return $this->writeOnly;
+    }
+
+    /**
+     * @param bool|null $writeOnly
+     * @return Reference
+     */
+    public function setWriteOnly(?bool $writeOnly): self
+    {
+        $this->writeOnly = $writeOnly;
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getDeprecated(): ?bool
+    {
+        return $this->deprecated;
+    }
+
+    /**
+     * @param bool|null $deprecated
+     *
+     * @return Reference
+     */
+    public function setDeprecated(?bool $deprecated): self
+    {
+        $this->deprecated = $deprecated;
+        return $this;
     }
 
     /**

--- a/src/JsonSchemaRuntime/Reference.php
+++ b/src/JsonSchemaRuntime/Reference.php
@@ -250,6 +250,7 @@ class Reference
     public function setTitle(?string $title): self
     {
         $this->title = $title;
+
         return $this;
     }
 
@@ -269,6 +270,7 @@ class Reference
     public function setMultipleOf(?float $multipleOf): self
     {
         $this->multipleOf = $multipleOf;
+
         return $this;
     }
 
@@ -288,6 +290,7 @@ class Reference
     public function setMaximum(?float $maximum): self
     {
         $this->maximum = $maximum;
+
         return $this;
     }
 
@@ -307,6 +310,7 @@ class Reference
     public function setExclusiveMaximum(?bool $exclusiveMaximum): self
     {
         $this->exclusiveMaximum = $exclusiveMaximum;
+
         return $this;
     }
 
@@ -326,6 +330,7 @@ class Reference
     public function setMinimum(?float $minimum): self
     {
         $this->minimum = $minimum;
+
         return $this;
     }
 
@@ -345,6 +350,7 @@ class Reference
     public function setExclusiveMinimum(?bool $exclusiveMinimum): self
     {
         $this->exclusiveMinimum = $exclusiveMinimum;
+
         return $this;
     }
 
@@ -364,6 +370,7 @@ class Reference
     public function setMaxLength(?int $maxLength): self
     {
         $this->maxLength = $maxLength;
+
         return $this;
     }
 
@@ -383,6 +390,7 @@ class Reference
     public function setMinLength(?int $minLength): self
     {
         $this->minLength = $minLength;
+
         return $this;
     }
 
@@ -402,6 +410,7 @@ class Reference
     public function setPattern(?string $pattern): self
     {
         $this->pattern = $pattern;
+
         return $this;
     }
 
@@ -421,6 +430,7 @@ class Reference
     public function setMaxItems(?int $maxItems): self
     {
         $this->maxItems = $maxItems;
+
         return $this;
     }
 
@@ -440,6 +450,7 @@ class Reference
     public function setMinItems(?int $minItems): self
     {
         $this->minItems = $minItems;
+
         return $this;
     }
 
@@ -459,6 +470,7 @@ class Reference
     public function setUniqueItems(?bool $uniqueItems): self
     {
         $this->uniqueItems = $uniqueItems;
+
         return $this;
     }
 
@@ -478,6 +490,7 @@ class Reference
     public function setType(?string $type): self
     {
         $this->type = $type;
+
         return $this;
     }
 
@@ -497,6 +510,7 @@ class Reference
     public function setDescription(?string $description): self
     {
         $this->description = $description;
+
         return $this;
     }
 
@@ -516,6 +530,7 @@ class Reference
     public function setFormat(?string $format): self
     {
         $this->format = $format;
+
         return $this;
     }
 
@@ -535,6 +550,7 @@ class Reference
     public function setNullable(?bool $nullable): self
     {
         $this->nullable = $nullable;
+
         return $this;
     }
 
@@ -554,6 +570,7 @@ class Reference
     public function setReadOnly(?bool $readOnly): self
     {
         $this->readOnly = $readOnly;
+
         return $this;
     }
 
@@ -567,11 +584,13 @@ class Reference
 
     /**
      * @param bool|null $writeOnly
+     *
      * @return Reference
      */
     public function setWriteOnly(?bool $writeOnly): self
     {
         $this->writeOnly = $writeOnly;
+
         return $this;
     }
 
@@ -591,6 +610,7 @@ class Reference
     public function setDeprecated(?bool $deprecated): self
     {
         $this->deprecated = $deprecated;
+
         return $this;
     }
 

--- a/src/OpenApi/JsonSchema/Normalizer/ReferenceNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/ReferenceNormalizer.php
@@ -38,15 +38,121 @@ class ReferenceNormalizer implements DenormalizerInterface, NormalizerInterface,
         if (!is_object($data)) {
             return null;
         }
+
+        $object = null;
+        $data = clone $data;
+
         if (isset($data->{'$ref'})) {
-            return new Reference($data->{'$ref'}, $context['document-origin']);
+            $object = new Reference($data->{'$ref'}, $context['document-origin']);
+            unset($data->{'$ref'});
         }
+
         if (isset($data->{'$recursiveRef'})) {
-            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+            $object = new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+            unset($data->{'$recursiveRef'});
         }
-        $object = new \Jane\OpenApi\JsonSchema\Model\Reference();
+
+        if ($object === null) {
+            return null;
+        }
+
         if (property_exists($data, '$ref') && $data->{'$ref'} !== null) {
             $object->setDollarRef($data->{'$ref'});
+        }
+
+        if (property_exists($data, 'title') && $data->{'title'} !== null) {
+            $object->setTitle($data->{'title'});
+            unset($data->{'title'});
+        }
+
+        if (property_exists($data, 'multipleOf') && $data->{'multipleOf'} !== null) {
+            $object->setMultipleOf($data->{'multipleOf'});
+            unset($data->{'multipleOf'});
+        }
+
+        if (property_exists($data, 'maximum') && $data->{'maximum'} !== null) {
+            $object->setMaximum($data->{'maximum'});
+            unset($data->{'maximum'});
+        }
+
+        if (property_exists($data, 'exclusiveMaximum') && $data->{'exclusiveMaximum'} !== null) {
+            $object->setExclusiveMaximum($data->{'exclusiveMaximum'});
+            unset($data->{'exclusiveMaximum'});
+        }
+
+        if (property_exists($data, 'minimum') && $data->{'minimum'} !== null) {
+            $object->setMinimum($data->{'minimum'});
+            unset($data->{'minimum'});
+        }
+
+        if (property_exists($data, 'exclusiveMinimum') && $data->{'exclusiveMinimum'} !== null) {
+            $object->setExclusiveMinimum($data->{'exclusiveMinimum'});
+            unset($data->{'exclusiveMinimum'});
+        }
+
+        if (property_exists($data, 'maxLength') && $data->{'maxLength'} !== null) {
+            $object->setMaxLength($data->{'maxLength'});
+            unset($data->{'maxLength'});
+        }
+
+        if (property_exists($data, 'minLength') && $data->{'minLength'} !== null) {
+            $object->setMinLength($data->{'minLength'});
+            unset($data->{'minLength'});
+        }
+
+        if (property_exists($data, 'pattern') && $data->{'pattern'} !== null) {
+            $object->setPattern($data->{'pattern'});
+            unset($data->{'pattern'});
+        }
+
+        if (property_exists($data, 'maxItems') && $data->{'maxItems'} !== null) {
+            $object->setMaxItems($data->{'maxItems'});
+            unset($data->{'maxItems'});
+        }
+
+        if (property_exists($data, 'minItems') && $data->{'minItems'} !== null) {
+            $object->setMinItems($data->{'minItems'});
+            unset($data->{'minItems'});
+        }
+
+        if (property_exists($data, 'uniqueItems') && $data->{'uniqueItems'} !== null) {
+            $object->setUniqueItems($data->{'uniqueItems'});
+            unset($data->{'uniqueItems'});
+        }
+
+        if (property_exists($data, 'type') && $data->{'type'} !== null) {
+            $object->setType($data->{'type'});
+            unset($data->{'type'});
+        }
+
+        if (property_exists($data, 'description') && $data->{'description'} !== null) {
+            $object->setDescription($data->{'description'});
+            unset($data->{'description'});
+        }
+
+        if (property_exists($data, 'format') && $data->{'format'} !== null) {
+            $object->setFormat($data->{'format'});
+            unset($data->{'format'});
+        }
+
+        if (property_exists($data, 'nullable') && $data->{'nullable'} !== null) {
+            $object->setNullable($data->{'nullable'});
+            unset($data->{'nullable'});
+        }
+
+        if (property_exists($data, 'readOnly') && $data->{'readOnly'} !== null) {
+            $object->setReadOnly($data->{'readOnly'});
+            unset($data->{'readOnly'});
+        }
+
+        if (property_exists($data, 'writeOnly') && $data->{'writeOnly'} !== null) {
+            $object->setWriteOnly($data->{'writeOnly'});
+            unset($data->{'writeOnly'});
+        }
+
+        if (property_exists($data, 'deprecated') && $data->{'deprecated'} !== null) {
+            $object->setDeprecated($data->{'deprecated'});
+            unset($data->{'deprecated'});
         }
 
         return $object;
@@ -57,6 +163,82 @@ class ReferenceNormalizer implements DenormalizerInterface, NormalizerInterface,
         $data = new \stdClass();
         if (null !== $object->getDollarRef()) {
             $data->{'$ref'} = $object->getDollarRef();
+        }
+
+        if (null !== $object->getTitle()) {
+            $data->{'title'} = $object->getTitle();
+        }
+
+        if (null !== $object->getMultipleOf()) {
+            $data->{'multipleOf'} = $object->getMultipleOf();
+        }
+
+        if (null !== $object->getMaximum()) {
+            $data->{'maximum'} = $object->getMaximum();
+        }
+
+        if (null !== $object->getExclusiveMaximum()) {
+            $data->{'exclusiveMaximum'} = $object->getExclusiveMaximum();
+        }
+
+        if (null !== $object->getMinimum()) {
+            $data->{'minimum'} = $object->getMinimum();
+        }
+
+        if (null !== $object->getExclusiveMinimum()) {
+            $data->{'exclusiveMinimum'} = $object->getExclusiveMinimum();
+        }
+
+        if (null !== $object->getMaxLength()) {
+            $data->{'maxLength'} = $object->getMaxLength();
+        }
+
+        if (null !== $object->getMinLength()) {
+            $data->{'minLength'} = $object->getMinLength();
+        }
+
+        if (null !== $object->getPattern()) {
+            $data->{'pattern'} = $object->getPattern();
+        }
+
+        if (null !== $object->getMaxItems()) {
+            $data->{'maxItems'} = $object->getMaxItems();
+        }
+
+        if (null !== $object->getMinItems()) {
+            $data->{'minItems'} = $object->getMinItems();
+        }
+
+        if (null !== $object->getUniqueItems()) {
+            $data->{'uniqueItems'} = $object->getUniqueItems();
+        }
+
+        if (null !== $object->getType()) {
+            $data->{'type'} = $object->getType();
+        }
+
+        if (null !== $object->getDescription()) {
+            $data->{'description'} = $object->getDescription();
+        }
+
+        if (null !== $object->getFormat()) {
+            $data->{'format'} = $object->getFormat();
+        }
+
+        if (null !== $object->getNullable()) {
+            $data->{'nullable'} = $object->getNullable();
+        }
+
+        if (null !== $object->getReadOnly()) {
+            $data->{'readOnly'} = $object->getReadOnly();
+        }
+
+        if (null !== $object->getWriteOnly()) {
+            $data->{'writeOnly'} = $object->getWriteOnly();
+        }
+
+        if (null !== $object->getDeprecated()) {
+            $data->{'deprecated'} = $object->getDeprecated();
         }
 
         return $data;

--- a/src/OpenApi/JsonSchema/Normalizer/SchemaNormalizer.php
+++ b/src/OpenApi/JsonSchema/Normalizer/SchemaNormalizer.php
@@ -38,14 +38,20 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (!is_object($data)) {
             return null;
         }
-        if (isset($data->{'$ref'})) {
-            return new Reference($data->{'$ref'}, $context['document-origin']);
-        }
-        if (isset($data->{'$recursiveRef'})) {
-            return new Reference($data->{'$recursiveRef'}, $context['document-origin']);
-        }
+
         $object = new \Jane\OpenApi\JsonSchema\Model\Schema();
         $data = clone $data;
+
+        if (isset($data->{'$ref'})) {
+            $object = new Reference($data->{'$ref'}, $context['document-origin']);
+            unset($data->{'$ref'});
+        }
+
+        if (isset($data->{'$recursiveRef'})) {
+            $object = new Reference($data->{'$recursiveRef'}, $context['document-origin']);
+            unset($data->{'$recursiveRef'});
+        }
+
         if (property_exists($data, 'title') && $data->{'title'} !== null) {
             $object->setTitle($data->{'title'});
             unset($data->{'title'});
@@ -94,14 +100,49 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $object->setUniqueItems($data->{'uniqueItems'});
             unset($data->{'uniqueItems'});
         }
+        if (property_exists($data, 'type') && $data->{'type'} !== null) {
+            $object->setType($data->{'type'});
+            unset($data->{'type'});
+        }
+        if (property_exists($data, 'description') && $data->{'description'} !== null) {
+            $object->setDescription($data->{'description'});
+            unset($data->{'description'});
+        }
+        if (property_exists($data, 'format') && $data->{'format'} !== null) {
+            $object->setFormat($data->{'format'});
+            unset($data->{'format'});
+        }
+        if (property_exists($data, 'nullable') && $data->{'nullable'} !== null) {
+            $object->setNullable($data->{'nullable'});
+            unset($data->{'nullable'});
+        }
+        if (property_exists($data, 'readOnly') && $data->{'readOnly'} !== null) {
+            $object->setReadOnly($data->{'readOnly'});
+            unset($data->{'readOnly'});
+        }
+        if (property_exists($data, 'writeOnly') && $data->{'writeOnly'} !== null) {
+            $object->setWriteOnly($data->{'writeOnly'});
+            unset($data->{'writeOnly'});
+        }
+        if (property_exists($data, 'deprecated') && $data->{'deprecated'} !== null) {
+            $object->setDeprecated($data->{'deprecated'});
+            unset($data->{'deprecated'});
+        }
+
+        if ($object instanceof Reference) {
+            return $object;
+        }
+
         if (property_exists($data, 'maxProperties') && $data->{'maxProperties'} !== null) {
             $object->setMaxProperties($data->{'maxProperties'});
             unset($data->{'maxProperties'});
         }
+
         if (property_exists($data, 'minProperties') && $data->{'minProperties'} !== null) {
             $object->setMinProperties($data->{'minProperties'});
             unset($data->{'minProperties'});
         }
+
         if (property_exists($data, 'required') && $data->{'required'} !== null) {
             $values = [];
             foreach ($data->{'required'} as $value) {
@@ -110,6 +151,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $object->setRequired($values);
             unset($data->{'required'});
         }
+
         if (property_exists($data, 'enum') && $data->{'enum'} !== null) {
             $values_1 = [];
             foreach ($data->{'enum'} as $value_1) {
@@ -118,10 +160,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $object->setEnum($values_1);
             unset($data->{'enum'});
         }
-        if (property_exists($data, 'type') && $data->{'type'} !== null) {
-            $object->setType($data->{'type'});
-            unset($data->{'type'});
-        }
+
         if (property_exists($data, 'not') && $data->{'not'} !== null) {
             $value_2 = $data->{'not'};
             if (is_object($data->{'not'}) and isset($data->{'not'}->{'$ref'})) {
@@ -210,33 +249,13 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $object->setAdditionalProperties($value_12);
             unset($data->{'additionalProperties'});
         }
-        if (property_exists($data, 'description') && $data->{'description'} !== null) {
-            $object->setDescription($data->{'description'});
-            unset($data->{'description'});
-        }
-        if (property_exists($data, 'format') && $data->{'format'} !== null) {
-            $object->setFormat($data->{'format'});
-            unset($data->{'format'});
-        }
         if (property_exists($data, 'default') && $data->{'default'} !== null) {
             $object->setDefault($data->{'default'});
             unset($data->{'default'});
         }
-        if (property_exists($data, 'nullable') && $data->{'nullable'} !== null) {
-            $object->setNullable($data->{'nullable'});
-            unset($data->{'nullable'});
-        }
         if (property_exists($data, 'discriminator') && $data->{'discriminator'} !== null) {
             $object->setDiscriminator($this->denormalizer->denormalize($data->{'discriminator'}, 'Jane\\OpenApi\\JsonSchema\\Model\\Discriminator', 'json', $context));
             unset($data->{'discriminator'});
-        }
-        if (property_exists($data, 'readOnly') && $data->{'readOnly'} !== null) {
-            $object->setReadOnly($data->{'readOnly'});
-            unset($data->{'readOnly'});
-        }
-        if (property_exists($data, 'writeOnly') && $data->{'writeOnly'} !== null) {
-            $object->setWriteOnly($data->{'writeOnly'});
-            unset($data->{'writeOnly'});
         }
         if (property_exists($data, 'example') && $data->{'example'} !== null) {
             $object->setExample($data->{'example'});
@@ -245,10 +264,6 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (property_exists($data, 'externalDocs') && $data->{'externalDocs'} !== null) {
             $object->setExternalDocs($this->denormalizer->denormalize($data->{'externalDocs'}, 'Jane\\OpenApi\\JsonSchema\\Model\\ExternalDocumentation', 'json', $context));
             unset($data->{'externalDocs'});
-        }
-        if (property_exists($data, 'deprecated') && $data->{'deprecated'} !== null) {
-            $object->setDeprecated($data->{'deprecated'});
-            unset($data->{'deprecated'});
         }
         if (property_exists($data, 'xml') && $data->{'xml'} !== null) {
             $object->setXml($this->denormalizer->denormalize($data->{'xml'}, 'Jane\\OpenApi\\JsonSchema\\Model\\XML', 'json', $context));

--- a/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Model/Review.php
+++ b/src/OpenApi/Tests/fixtures/api-platform-demo/expected/Model/Review.php
@@ -37,7 +37,7 @@ class Review
      */
     protected $publicationDate;
     /**
-     * A book.
+     * The item that is being reviewed/rated
      *
      * @var Book
      */
@@ -152,7 +152,7 @@ class Review
         return $this;
     }
     /**
-     * A book.
+     * The item that is being reviewed/rated
      *
      * @return Book
      */
@@ -161,7 +161,7 @@ class Review
         return $this->book;
     }
     /**
-     * A book.
+     * The item that is being reviewed/rated
      *
      * @param Book $book
      *

--- a/src/OpenApi/Tests/fixtures/references-override-in-properties/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/references-override-in-properties/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi3.yaml',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Client.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+            $plugins = array();
+            $uri = \Http\Discovery\UriFactoryDiscovery::find()->createUri('https://acme.localhost/v1');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Model/Child.php
+++ b/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Model/Child.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Child
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $id;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getId() : string
+    {
+        return $this->id;
+    }
+    /**
+     * 
+     *
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id) : self
+    {
+        $this->id = $id;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Model/Parents.php
+++ b/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Model/Parents.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class Parents
+{
+    /**
+     * 
+     *
+     * @var Child|null
+     */
+    protected $currency;
+    /**
+     * 
+     *
+     * @return Child|null
+     */
+    public function getCurrency() : ?Child
+    {
+        return $this->currency;
+    }
+    /**
+     * 
+     *
+     * @param Child|null $currency
+     *
+     * @return self
+     */
+    public function setCurrency(?Child $currency) : self
+    {
+        $this->currency = $currency;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Normalizer/ChildNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Normalizer/ChildNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ChildNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Child';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Child';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Child();
+        if (property_exists($data, 'id')) {
+            $object->setId($data->{'id'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getId()) {
+            $data->{'id'} = $object->getId();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    protected $normalizers = array('Jane\\OpenApi\\Tests\\Expected\\Model\\Parents' => 'Jane\\OpenApi\\Tests\\Expected\\Normalizer\\ParentsNormalizer', 'Jane\\OpenApi\\Tests\\Expected\\Model\\Child' => 'Jane\\OpenApi\\Tests\\Expected\\Normalizer\\ChildNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+@trigger_error('The "NormalizerFactory" class is deprecated since Jane 5.3, use "JaneObjectNormalizer" instead.', E_USER_DEPRECATED);
+/**
+ * @deprecated The "NormalizerFactory" class is deprecated since Jane 5.3, use "JaneObjectNormalizer" instead.
+ */
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new \Jane\OpenApi\Tests\Expected\Normalizer\JaneObjectNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Normalizer/ParentsNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/references-override-in-properties/expected/Normalizer/ParentsNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ParentsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Parents';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\Parents';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\Parents();
+        if (property_exists($data, 'currency') && $data->{'currency'} !== null) {
+            $object->setCurrency($this->denormalizer->denormalize($data->{'currency'}, 'Jane\\OpenApi\\Tests\\Expected\\Model\\Child', 'json', $context));
+        }
+        elseif (property_exists($data, 'currency') && $data->{'currency'} === null) {
+            $object->setCurrency(null);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getCurrency()) {
+            $data->{'currency'} = $this->normalizer->normalize($object->getCurrency(), 'json', $context);
+        }
+        else {
+            $data->{'currency'} = null;
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/references-override-in-properties/openapi3.yaml
+++ b/src/OpenApi/Tests/fixtures/references-override-in-properties/openapi3.yaml
@@ -1,0 +1,35 @@
+openapi: '3.0.0'
+info:
+  version: 1.0.0
+  title: References override fields when used in properties
+servers:
+  - url: https://acme.localhost/v1/
+
+paths:
+  "parents":
+    get:
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/parents'
+components:
+  schemas:
+    parents:
+      type: object
+      properties:
+        currency:
+          nullable: true
+          $ref: '#/components/schemas/child'
+    child:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid


### PR DESCRIPTION
In the test given situation where a reference is used to describe a field's type but the field in the parent schema object is not required and therefore nullable. This is currently not possible in jane.

I added the overriding of multiple scalar attributes of a field. In my case only nullable is needed and the rest is just a thought of expecting this to be needed as well.