### PR TITLE
Content-Type can be mistyped by schema

### DIFF
--- a/src/OpenApi/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/OpenApi/Generator/Parameter/NonBodyParameterGenerator.php
@@ -87,6 +87,10 @@ class NonBodyParameterGenerator extends ParameterGenerator
                     $types[] = new Expr\ArrayItem(new Scalar\String_('null'));
                 }
 
+                if (mb_stripos($parameter->getName(), 'content-type') !== false) {
+                    $types[] = new Expr\ArrayItem(new Scalar\String_('array'));
+                }
+
                 $allowedTypes[] = new Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'setAllowedTypes', [
                     new Node\Arg(new Scalar\String_($parameter->getName())),
                     new Node\Arg(new Expr\Array_($types)),

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/.jane-openapi
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.yaml',
+    'namespace' => 'Jane\OpenApi2\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Client.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function testReferenceResponse(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi2\Tests\Expected\Endpoint\TestReferenceResponse(), $fetch);
+    }
+    /**
+     * 
+     *
+     * @param \Jane\OpenApi2\Tests\Expected\Model\TestQueryPostBody $requestBody 
+     * @param array $headerParameters {
+     *     @var string $Content-Type 
+     * }
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Jane\OpenApi2\Tests\Expected\Model\TestQueryPostResponse201|\Psr\Http\Message\ResponseInterface
+     */
+    public function postQuery(\Jane\OpenApi2\Tests\Expected\Model\TestQueryPostBody $requestBody, array $headerParameters = array(), string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi2\Tests\Expected\Endpoint\PostQuery($requestBody, $headerParameters), $fetch);
+    }
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Endpoint/PostQuery.php
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Endpoint/PostQuery.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Endpoint;
+
+class PostQuery extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    /**
+     * 
+     *
+     * @param \Jane\OpenApi2\Tests\Expected\Model\TestQueryPostBody $requestBody 
+     * @param array $headerParameters {
+     *     @var string $Content-Type 
+     * }
+     */
+    public function __construct(\Jane\OpenApi2\Tests\Expected\Model\TestQueryPostBody $requestBody, array $headerParameters = array())
+    {
+        $this->body = $requestBody;
+        $this->headerParameters = $headerParameters;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'POST';
+    }
+    public function getUri() : string
+    {
+        return '/test-query';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        if ($this->body instanceof \Jane\OpenApi2\Tests\Expected\Model\TestQueryPostBody) {
+            return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));
+        }
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getHeadersOptionsResolver();
+        $optionsResolver->setDefined(array('Content-Type'));
+        $optionsResolver->setRequired(array('Content-Type'));
+        $optionsResolver->setDefaults(array());
+        $optionsResolver->setAllowedTypes('Content-Type', array('string', 'array'));
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\OpenApi2\Tests\Expected\Model\TestQueryPostResponse201
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (201 === $status && mb_strpos($contentType, 'application/json') !== false) {
+            return $serializer->deserialize($body, 'Jane\\OpenApi2\\Tests\\Expected\\Model\\TestQueryPostResponse201', 'json');
+        }
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Endpoint/TestReferenceResponse.php
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Endpoint/TestReferenceResponse.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Endpoint;
+
+class TestReferenceResponse extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/test-query';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status) {
+            return null;
+        }
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Model/TestQueryPostBody.php
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Model/TestQueryPostBody.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Model;
+
+class TestQueryPostBody
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getName() : string
+    {
+        return $this->name;
+    }
+    /**
+     * 
+     *
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name) : self
+    {
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Model/TestQueryPostResponse201.php
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Model/TestQueryPostResponse201.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Model;
+
+class TestQueryPostResponse201
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $id;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getId() : string
+    {
+        return $this->id;
+    }
+    /**
+     * 
+     *
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id) : self
+    {
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getName() : string
+    {
+        return $this->name;
+    }
+    /**
+     * 
+     *
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name) : self
+    {
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    protected $normalizers = array('Jane\\OpenApi2\\Tests\\Expected\\Model\\TestQueryPostBody' => 'Jane\\OpenApi2\\Tests\\Expected\\Normalizer\\TestQueryPostBodyNormalizer', 'Jane\\OpenApi2\\Tests\\Expected\\Model\\TestQueryPostResponse201' => 'Jane\\OpenApi2\\Tests\\Expected\\Normalizer\\TestQueryPostResponse201Normalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Normalizer;
+
+@trigger_error('The "NormalizerFactory" class is deprecated since Jane 5.3, use "JaneObjectNormalizer" instead.', E_USER_DEPRECATED);
+/**
+ * @deprecated The "NormalizerFactory" class is deprecated since Jane 5.3, use "JaneObjectNormalizer" instead.
+ */
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new \Jane\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Normalizer/TestQueryPostBodyNormalizer.php
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Normalizer/TestQueryPostBodyNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class TestQueryPostBodyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi2\\Tests\\Expected\\Model\\TestQueryPostBody';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi2\\Tests\\Expected\\Model\\TestQueryPostBody';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
+        }
+        $object = new \Jane\OpenApi2\Tests\Expected\Model\TestQueryPostBody();
+        if (property_exists($data, 'name')) {
+            $object->setName($data->{'name'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Normalizer/TestQueryPostResponse201Normalizer.php
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/expected/Normalizer/TestQueryPostResponse201Normalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class TestQueryPostResponse201Normalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi2\\Tests\\Expected\\Model\\TestQueryPostResponse201';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi2\\Tests\\Expected\\Model\\TestQueryPostResponse201';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
+        }
+        $object = new \Jane\OpenApi2\Tests\Expected\Model\TestQueryPostResponse201();
+        if (property_exists($data, 'id')) {
+            $object->setId($data->{'id'});
+        }
+        if (property_exists($data, 'name')) {
+            $object->setName($data->{'name'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getId()) {
+            $data->{'id'} = $object->getId();
+        }
+        if (null !== $object->getName()) {
+            $data->{'name'} = $object->getName();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/content-type-explicit-required/swagger.yaml
+++ b/src/OpenApi2/Tests/fixtures/content-type-explicit-required/swagger.yaml
@@ -1,0 +1,47 @@
+openapi: '3.0.0'
+info:
+  version: 1.0.0
+paths:
+  "/test-query":
+    get:
+      operationId: Test Reference Response
+      responses:
+        '200':
+          description: no error
+      tags:
+      - Test
+    post:
+      operationId: post query
+      parameters:
+        contentType:
+          name: Content-Type
+          in: header
+          schema:
+            type: string
+          required: true
+      requestBody:
+        $ref: '#/components/requests/item'
+      responses:
+        201:
+          description: A new item has been succesfully created
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  name:
+                    type: string
+      tags:
+        - Test
+components:
+  requests:
+    item:
+      required: true
+      content:
+        application/json:
+          schema:
+            properties:
+              name:
+                type: string

--- a/src/OpenApiRuntime/Client/BaseEndpoint.php
+++ b/src/OpenApiRuntime/Client/BaseEndpoint.php
@@ -35,7 +35,7 @@ abstract class BaseEndpoint implements Endpoint
 
     public function getHeaders(array $baseHeaders = []): array
     {
-        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+        return array_merge($this->getExtraHeaders(), $this->getHeadersOptionsResolver()->resolve(array_merge($baseHeaders, $this->headerParameters)));
     }
 
     protected function getQueryOptionsResolver(): OptionsResolver


### PR DESCRIPTION
When a schema file provides a required header `Content-Type` it will influence the type check for the header that is auto generated by jane. This later conflicts with the options resolver as it expects it to be the type of the schema and not the auto generated array. This change will ensure it is at least of type array.

Regarding the options resolver and content types I rearranged the passed headers as the generated `Content-Type` header is marked defined and required but the headers that are checked by the options resolver do not include the auto generated `Content-Type` header and therefore fail due to being "non-"existing.