### PR TITLE
Fix when no operationId is given on path with a dot

### DIFF
--- a/src/OpenApi/Naming/OperationUrlNaming.php
+++ b/src/OpenApi/Naming/OperationUrlNaming.php
@@ -10,6 +10,12 @@ use Jane\OpenApiCommon\Operation\Operation;
 
 class OperationUrlNaming extends CommonOperationUrlNaming
 {
+    const POSSIBLE_EXTENSIONS = [
+        '.json',
+        '.php',
+        '.asp',
+    ];
+
     protected function getUniqueName(Operation $operation): string
     {
         $prefix = strtolower($operation->getMethod());
@@ -28,13 +34,14 @@ class OperationUrlNaming extends CommonOperationUrlNaming
             }
         }
 
-        preg_match_all('/(?P<separator>[^a-zA-Z0-9_{}])+(?P<part>[a-zA-Z0-9_{}]*)/', $operation->getPath(), $matches);
+        $matches = [];
+        preg_match_all('/(?<separator>[^a-zA-Z0-9_{}])+(?<part>[a-zA-Z0-9_{}]*)/', $operation->getPath(), $matches);
 
         $methodNameParts = [];
         $lastNonParameterPartIndex = 0;
 
         foreach ($matches[0] as $index => $match) {
-            if ($matches['separator'][$index] === '.') {
+            if ($matches['separator'][$index] === '.' && \in_array(mb_strtolower($match), self::POSSIBLE_EXTENSIONS)) {
                 continue;
             }
 

--- a/src/OpenApi/Naming/OperationUrlNaming.php
+++ b/src/OpenApi/Naming/OperationUrlNaming.php
@@ -10,7 +10,7 @@ use Jane\OpenApiCommon\Operation\Operation;
 
 class OperationUrlNaming extends CommonOperationUrlNaming
 {
-    const POSSIBLE_EXTENSIONS = [
+    const FORBIDDEN_EXTENSIONS = [
         '.json',
         '.php',
         '.asp',
@@ -41,7 +41,7 @@ class OperationUrlNaming extends CommonOperationUrlNaming
         $lastNonParameterPartIndex = 0;
 
         foreach ($matches[0] as $index => $match) {
-            if ($matches['separator'][$index] === '.' && \in_array(mb_strtolower($match), self::POSSIBLE_EXTENSIONS)) {
+            if ($matches['separator'][$index] === '.' && \in_array(mb_strtolower($match), self::FORBIDDEN_EXTENSIONS)) {
                 continue;
             }
 

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/.jane-openapi
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.yaml',
+    'namespace' => 'Jane\OpenApi\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Client.php
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Client.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr7HttplugClient
+{
+    /**
+     * 
+     *
+     * @param \Jane\OpenApi\Tests\Expected\Model\MessageM700PostBody $requestBody 
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function postMessageM700(\Jane\OpenApi\Tests\Expected\Model\MessageM700PostBody $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Endpoint\PostMessageM700($requestBody), $fetch);
+    }
+    /**
+     * 
+     *
+     * @param \Jane\OpenApi\Tests\Expected\Model\MessageM70047PostBody $requestBody 
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function postMessageM70047(\Jane\OpenApi\Tests\Expected\Model\MessageM70047PostBody $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi\Tests\Expected\Endpoint\PostMessageM70047($requestBody), $fetch);
+    }
+    public static function create($httpClient = null)
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\HttpClientDiscovery::find();
+        }
+        $messageFactory = \Http\Discovery\MessageFactoryDiscovery::find();
+        $streamFactory = \Http\Discovery\StreamFactoryDiscovery::find();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode())));
+        return new static($httpClient, $messageFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Endpoint/PostMessageM700.php
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Endpoint/PostMessageM700.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Endpoint;
+
+class PostMessageM700 extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    /**
+     * 
+     *
+     * @param \Jane\OpenApi\Tests\Expected\Model\MessageM700PostBody $requestBody 
+     */
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\MessageM700PostBody $requestBody)
+    {
+        $this->body = $requestBody;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'POST';
+    }
+    public function getUri() : string
+    {
+        return '/message/M700';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        if ($this->body instanceof \Jane\OpenApi\Tests\Expected\Model\MessageM700PostBody) {
+            return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));
+        }
+        return array(array(), null);
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        return null;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Endpoint/PostMessageM70047.php
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Endpoint/PostMessageM70047.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Endpoint;
+
+class PostMessageM70047 extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    /**
+     * 
+     *
+     * @param \Jane\OpenApi\Tests\Expected\Model\MessageM70047PostBody $requestBody 
+     */
+    public function __construct(\Jane\OpenApi\Tests\Expected\Model\MessageM70047PostBody $requestBody)
+    {
+        $this->body = $requestBody;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'POST';
+    }
+    public function getUri() : string
+    {
+        return '/message/M700.47';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        if ($this->body instanceof \Jane\OpenApi\Tests\Expected\Model\MessageM70047PostBody) {
+            return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));
+        }
+        return array(array(), null);
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        return null;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Model/MessageM70047PostBody.php
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Model/MessageM70047PostBody.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class MessageM70047PostBody
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $bar;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getBar() : string
+    {
+        return $this->bar;
+    }
+    /**
+     * 
+     *
+     * @param string $bar
+     *
+     * @return self
+     */
+    public function setBar(string $bar) : self
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Model/MessageM700PostBody.php
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Model/MessageM700PostBody.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Model;
+
+class MessageM700PostBody
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $bar;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getBar() : string
+    {
+        return $this->bar;
+    }
+    /**
+     * 
+     *
+     * @param string $bar
+     *
+     * @return self
+     */
+    public function setBar(string $bar) : self
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    protected $normalizers = array('Jane\\OpenApi\\Tests\\Expected\\Model\\MessageM700PostBody' => 'Jane\\OpenApi\\Tests\\Expected\\Normalizer\\MessageM700PostBodyNormalizer', 'Jane\\OpenApi\\Tests\\Expected\\Model\\MessageM70047PostBody' => 'Jane\\OpenApi\\Tests\\Expected\\Normalizer\\MessageM70047PostBodyNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Normalizer/MessageM70047PostBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Normalizer/MessageM70047PostBodyNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class MessageM70047PostBodyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\MessageM70047PostBody';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\MessageM70047PostBody';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\MessageM70047PostBody();
+        if (property_exists($data, 'bar')) {
+            $object->setBar($data->{'bar'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Normalizer/MessageM700PostBodyNormalizer.php
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Normalizer/MessageM700PostBodyNormalizer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class MessageM700PostBodyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi\\Tests\\Expected\\Model\\MessageM700PostBody';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi\\Tests\\Expected\\Model\\MessageM700PostBody';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (!is_object($data)) {
+            throw new InvalidArgumentException(sprintf('Given $data is not an object (%s given). We need an object in order to continue denormalize method.', gettype($data)));
+        }
+        $object = new \Jane\OpenApi\Tests\Expected\Model\MessageM700PostBody();
+        if (property_exists($data, 'bar')) {
+            $object->setBar($data->{'bar'});
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = new \stdClass();
+        if (null !== $object->getBar()) {
+            $data->{'bar'} = $object->getBar();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Normalizer/NormalizerFactory.php
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/expected/Normalizer/NormalizerFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Jane\OpenApi\Tests\Expected\Normalizer;
+
+@trigger_error('The "NormalizerFactory" class is deprecated since Jane 5.3, use "JaneObjectNormalizer" instead.', E_USER_DEPRECATED);
+/**
+ * @deprecated The "NormalizerFactory" class is deprecated since Jane 5.3, use "JaneObjectNormalizer" instead.
+ */
+class NormalizerFactory
+{
+    public static function create()
+    {
+        $normalizers = array();
+        $normalizers[] = new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer();
+        $normalizers[] = new \Jane\OpenApi\Tests\Expected\Normalizer\JaneObjectNormalizer();
+        return $normalizers;
+    }
+}

--- a/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/swagger.yaml
+++ b/src/OpenApi/Tests/fixtures/no-operation-id-with-dot-path/swagger.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+paths:
+    /message/M700:
+        post:
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                              bar:
+                                type: string
+                required: true
+            responses:
+                default:
+                    description: Default response
+    /message/M700.47:
+      post:
+        requestBody:
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  bar:
+                    type: string
+          required: true
+        responses:
+          default:
+            description: Default response
+info:
+    version: ''
+    title: ''
+components:
+    schemas: {}


### PR DESCRIPTION
Given the following schema:
```yaml
openapi: 3.0.0
paths:
    /message/M700:
        post:
            requestBody:
                content:
                    application/json:
                        schema:
                            type: object
                            properties:
                              bar:
                                type: string
                required: true
            responses:
                default:
                    description: Default response
    /message/M700.47:
      post:
        requestBody:
          content:
            application/json:
              schema:
                type: object
                properties:
                  bar:
                    type: string
          required: true
        responses:
          default:
            description: Default response
info:
    version: ''
    title: ''
components:
    schemas: {}
```

We need to have the `47` in generated `operationId`, before we were ignoring any word starting by `.`, now we restrict this to know possible extensions (`.php`, `.json`, `.asp`)