### PR TITLE
Fixing issue where class names could contains dots

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "symfony/property-access": "^3.1 || ^4.0 || ^5.0",
         "symfony/property-info": "^3.4 || ^4.0 || ^5.0",
         "symfony/serializer": "^4.2 || ^5.0",
+        "symfony/string": "^5.0",
         "symfony/yaml": "^3.1 || ^4.0 || ^5.0"
     },
     "replace": {

--- a/src/OpenApiCommon/Naming/OperationIdNaming.php
+++ b/src/OpenApiCommon/Naming/OperationIdNaming.php
@@ -4,9 +4,19 @@ namespace Jane\OpenApiCommon\Naming;
 
 use Doctrine\Common\Inflector\Inflector;
 use Jane\OpenApiCommon\Operation\Operation;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\String\Slugger\SluggerInterface;
 
 class OperationIdNaming implements OperationNamingInterface
 {
+    /** @var SluggerInterface */
+    private $slugger;
+
+    public function __construct()
+    {
+        $this->slugger = new AsciiSlugger();
+    }
+
     public function getFunctionName(Operation $operation): string
     {
         return Inflector::camelize((string) $operation->getOperation()->getOperationId());
@@ -14,6 +24,9 @@ class OperationIdNaming implements OperationNamingInterface
 
     public function getEndpointName(Operation $operation): string
     {
-        return Inflector::classify((string) $operation->getOperation()->getOperationId());
+        $operationId = (string) $operation->getOperation()->getOperationId();
+        $operationId = $this->slugger->slug($operationId, '-');
+
+        return Inflector::classify($operationId);
     }
 }

--- a/src/OpenApiCommon/composer.json
+++ b/src/OpenApiCommon/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "jane-php/json-schema": "^5.0"
+        "jane-php/json-schema": "^5.0",
+        "symfony/string": "^5.0"
     },
     "suggest": {
         "jane-php/open-api-2": "Allow to generate OpenApi v2 clients",


### PR DESCRIPTION
Fixes #248 

I also introduced `symfony/string` to fix it, way easier that way, will probably refactor all Naming stuff with it later ~