### PR TITLE
Fix null parameter to empty string transformation to keep zero value

### DIFF
--- a/src/OpenApiRuntime/Client/BaseEndpoint.php
+++ b/src/OpenApiRuntime/Client/BaseEndpoint.php
@@ -28,7 +28,7 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(function ($value) { return $value ?: ''; }, $optionsResolved);
+        $optionsResolved = array_map(function ($value) { return null !== $value ? $value : ''; }, $optionsResolved);
 
         return http_build_query($optionsResolved, null, '&', PHP_QUERY_RFC3986);
     }


### PR DESCRIPTION
When i call an API endpoint with query string contains a ```0``` value, Jane convert it to empty string. Jane must only convert ```null``` values to empty string.

Example:

Endpoint ```https://monapi.dev/get_items``` called with ```limit=20``` and ```offset=0```

Today, Jane convert ```offset``` query parameter to empty string:
```https://monapi.dev/get_items?limit=20&offset=```

Url expected : 
```https://monapi.dev/get_items?limit=20&offset=0```

