### PR TITLE
Fix dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php-http/multipart-stream-builder": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
+        "symfony/console": "^4.4 || ^5.0",
         "symfony/options-resolver": "^4.4 || ^5.0",
         "symfony/property-info": "^4.4 || ^5.0",
         "symfony/serializer": "^4.4 || ^5.0",

--- a/src/OpenApiCommon/composer.json
+++ b/src/OpenApiCommon/composer.json
@@ -28,8 +28,9 @@
         "php": ">=7.2",
         "ext-json": "*",
         "jane-php/json-schema": "^6.0",
-        "jane-php/open-api-runtime": "^6.0",
-        "symfony/string": "^5.0"
+        "jane-php/open-api-runtime": "^6.0"
+        "symfony/console": "^4.4 || ^5.0",
+        "symfony/string": "^5.0",
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Missing `symfony/console` on both root repository & `open-api-common`