### PR TITLE
Add new dump-config command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "doctrine/inflector": "^1.3",
         "league/uri": "^6.0",
         "nikic/php-parser": "^4.0",
-        "php-jsonpointer/php-jsonpointer": "^3.0",
         "php-http/client-common": "^2.0",
         "php-http/message-factory": "^1.0.2",
         "php-http/multipart-stream-builder": "^1.0",
+        "php-jsonpointer/php-jsonpointer": "^3.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "symfony/console": "^4.4 || ^5.0",
@@ -30,6 +30,7 @@
         "symfony/property-info": "^4.4 || ^5.0",
         "symfony/serializer": "^4.4 || ^5.0",
         "symfony/string": "^5.0",
+        "symfony/var-dumper": "^5.0",
         "symfony/yaml": "^4.4 || ^5.0"
     },
     "replace": {

--- a/src/JsonSchema/Application.php
+++ b/src/JsonSchema/Application.php
@@ -2,12 +2,14 @@
 
 namespace Jane\JsonSchema;
 
+use Jane\JsonSchema\Command\DumpConfigCommand;
 use Jane\JsonSchema\Command\GenerateCommand;
 use Symfony\Component\Console\Application as BaseApplication;
 
 class Application extends BaseApplication
 {
-    public const COMMAND_CLASS = GenerateCommand::class;
+    public const GENERATE_COMMAND = GenerateCommand::class;
+    public const DUMP_CONFIG_COMMAND = DumpConfigCommand::class;
     public const VERSION = '6.x-dev';
 
     /**
@@ -17,7 +19,10 @@ class Application extends BaseApplication
     {
         parent::__construct('Jane', self::VERSION);
 
-        $commandClass = static::COMMAND_CLASS;
-        $this->add(new $commandClass());
+        $generateCommand = static::GENERATE_COMMAND;
+        $dumpConfigCommand = static::DUMP_CONFIG_COMMAND;
+
+        $this->add(new $generateCommand());
+        $this->add(new $dumpConfigCommand());
     }
 }

--- a/src/JsonSchema/Command/ConfigLoader.php
+++ b/src/JsonSchema/Command/ConfigLoader.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\JsonSchema\Command;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+trait ConfigLoader
+{
+    public function loadConfig(string $path): array
+    {
+        if (!file_exists($path)) {
+            throw new \RuntimeException(sprintf('Config file %s does not exist', $path));
+        }
+
+        $options = require $path;
+
+        if (!\is_array($options)) {
+            throw new \RuntimeException(sprintf('Invalid config file specified or invalid return type in file %s', $path));
+        }
+
+        return $this->resolveConfiguration($options);
+    }
+
+    private function resolveConfiguration(array $options = [])
+    {
+        $optionsResolver = new OptionsResolver();
+        $optionsResolver->setDefaults([
+            'reference' => true,
+            'strict' => true,
+            'date-format' => \DateTime::RFC3339,
+            'full-date-format' => 'Y-m-d',
+            'date-prefer-interface' => null,
+            'date-input-format' => null,
+            'use-fixer' => false,
+            'fixer-config-file' => null,
+            'clean-generated' => true,
+            'use-cacheable-supports-method' => null,
+            'normalizer-force-null-when-nullable' => true,
+        ]);
+
+        if (\array_key_exists('json-schema-file', $options)) {
+            $optionsResolver->setRequired([
+                'json-schema-file',
+                'root-class',
+                'namespace',
+                'directory',
+            ]);
+        } else {
+            $optionsResolver->setRequired([
+                'mapping',
+            ]);
+        }
+
+        return $optionsResolver->resolve($options);
+    }
+}

--- a/src/JsonSchema/Command/DumpConfigCommand.php
+++ b/src/JsonSchema/Command/DumpConfigCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\JsonSchema\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\VarDumper\VarDumper;
+
+class DumpConfigCommand extends Command
+{
+    use ConfigLoader;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this->setName('dump-config');
+        $this->setDescription('Dump Jane configuration for debugging purpose');
+        $this->addOption('config-file', 'c', InputOption::VALUE_REQUIRED, 'File to use for Jane configuration', '.jane');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        VarDumper::dump($this->loadConfig($input->getOption('config-file')));
+
+        return 0;
+    }
+}

--- a/src/JsonSchema/composer.json
+++ b/src/JsonSchema/composer.json
@@ -30,6 +30,7 @@
         "symfony/filesystem": "^4.4 || ^5.0",
         "symfony/options-resolver": "^4.4 || ^5.0",
         "symfony/serializer": "^4.4 || ^5.0",
+        "symfony/var-dumper": "^4.4 || ^5.0",
         "symfony/yaml": "^4.4 || ^5.0"
     },
     "require-dev": {

--- a/src/OpenApiCommon/Application.php
+++ b/src/OpenApiCommon/Application.php
@@ -3,9 +3,11 @@
 namespace Jane\OpenApiCommon;
 
 use Jane\JsonSchema\Application as JsonSchemaApplication;
+use Jane\OpenApiCommon\Command\DumpConfigCommand;
 use Jane\OpenApiCommon\Command\GenerateCommand;
 
 class Application extends JsonSchemaApplication
 {
-    public const COMMAND_CLASS = GenerateCommand::class;
+    public const GENERATE_COMMAND = GenerateCommand::class;
+    public const DUMP_CONFIG_COMMAND = DumpConfigCommand::class;
 }

--- a/src/OpenApiCommon/Command/DumpConfigCommand.php
+++ b/src/OpenApiCommon/Command/DumpConfigCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Jane\OpenApiCommon\Command;
+
+use Jane\JsonSchema\Command\ConfigLoader;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\VarDumper\VarDumper;
+
+class DumpConfigCommand extends Command
+{
+    use ConfigLoader;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this->setName('dump-config');
+        $this->setDescription('Dump Jane OpenAPI configuration for debugging purpose');
+        $this->addOption('config-file', 'c', InputOption::VALUE_REQUIRED, 'File to use for Jane OpenAPI configuration', '.jane-openapi');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        VarDumper::dump($this->loadConfig($input->getOption('config-file')));
+
+        return 0;
+    }
+}

--- a/src/OpenApiCommon/Command/GenerateCommand.php
+++ b/src/OpenApiCommon/Command/GenerateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Jane\OpenApiCommon\Command;
 
+use Jane\JsonSchema\Command\ConfigLoader;
 use Jane\JsonSchema\Printer;
 use Jane\OpenApiCommon\Exception\CouldNotParseException;
 use Jane\OpenApiCommon\Exception\OpenApiVersionSupportException;
@@ -17,6 +18,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class GenerateCommand extends Command
 {
+    use ConfigLoader;
+
     private static $schemaParsers = [];
 
     public function configure()
@@ -28,19 +31,7 @@ class GenerateCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $configFile = $input->getOption('config-file');
-
-        if (!file_exists($configFile)) {
-            throw new \RuntimeException(sprintf('Config file %s does not exist', $configFile));
-        }
-
-        $options = require $configFile;
-
-        if (!\is_array($options)) {
-            throw new \RuntimeException(sprintf('Invalid config file specified or invalid return type in file %s', $configFile));
-        }
-
-        $options = $this->resolveConfiguration($options);
+        $options = $this->loadConfig($input->getOption('config-file'));
         $registries = [];
 
         if (\array_key_exists('openapi-file', $options)) {

--- a/src/OpenApiCommon/composer.json
+++ b/src/OpenApiCommon/composer.json
@@ -31,7 +31,8 @@
         "jane-php/open-api-runtime": "^6.0",
         "symfony/console": "^4.4 || ^5.0",
         "symfony/filesystem": "^4.4 || ^5.0",
-        "symfony/string": "^5.0"
+        "symfony/string": "^5.0",
+        "symfony/var-dumper": "^5.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Fixes #285

Add a new `dump-config` command to both JsonSchema & OpenApiCommon applications. This command allow you to dump your configuration file to know exactly what's inside (even when you have some strange logic :wink:)