### PR TITLE
Fix OpenAPI v2 null support

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -39,6 +39,12 @@ Lastly, if you want to contribute there is some details about :doc:`/contributin
 
 .. toctree::
    :hidden:
+   :caption: Tips
+
+   How to manage nullable properties <tips/nullable>
+
+.. toctree::
+   :hidden:
    :caption: Contributing
 
    Backwards compatibility <contributing/bc>

--- a/documentation/tips/nullable.rst
+++ b/documentation/tips/nullable.rst
@@ -1,0 +1,54 @@
+How to manage nullable properties
+=================================
+
+Most of the time, the schema you get from vendor have issues about nullability of their properties.
+
+Here Jane has an option called ``strict`` mode, by default we will follow strictly your schema types. But you can
+switch to non-strict mode (by having the option set to false in your Jane configuration file: ``"strict" => false``).
+By doing this, any property of your schema will be considered nullable.
+
+You can also try to fix your schema, here are some tips depending on which schema you are using
+
+JSON Schema
+-----------
+
+Jane is actually supporting JSON Schema draft 2019-09. Which support ``null`` type, you just have to add it to your
+type field as follows:
+
+.. code-block:: yaml
+
+    type:
+      - 'null'   # Note the quotes around 'null'
+      - string
+
+OpenAPI v2 / Swagger
+--------------------
+
+OpenAPI v2 does not support ``null`` type. Instead, most libraries does support ``x-nullable`` field in order to fake
+``null`` support. You can use it as follows:
+
+.. code-block:: yaml
+
+    type: string
+    x-nullable: true
+
+If you are using OpenAPI v2, consider migrating to OpenAPI v3 to get proper nullability support.
+
+OpenAPI v3.0.x
+--------------
+
+OpenAPI v3 still does not support ``null`` type but added a ``nullable`` field in order to say that property is
+nullable or not. By default this field is set to ``false``. You can use it as follows:
+
+.. code-block:: yaml
+
+    type: string
+    nullable: true
+
+OpenAPI v3.1.x
+--------------
+
+This new OpenAPI version will be compatible with JSON Schema. So everything will be the same as JSON Schema. You still
+can use ``nullable`` field but it will be deprecated in favor of JSON Schema ``null`` type.
+
+As of 25/04/2020, this version is not yet released.

--- a/src/JsonSchema/Generator/Model/PropertyGenerator.php
+++ b/src/JsonSchema/Generator/Model/PropertyGenerator.php
@@ -21,7 +21,7 @@ trait PropertyGenerator
      */
     abstract protected function getParser(): Parser;
 
-    protected function createProperty(Property $property, string $namespace, $default = null, bool $required = false): Stmt
+    protected function createProperty(Property $property, string $namespace, $default = null, bool $strict = true): Stmt
     {
         $propertyName = $this->getNaming()->getPropertyName($property->getPhpName());
         $propertyStmt = new Stmt\PropertyProperty($propertyName);
@@ -37,14 +37,14 @@ trait PropertyGenerator
         return new Stmt\Property(Stmt\Class_::MODIFIER_PROTECTED, [
             $propertyStmt,
         ], [
-            'comments' => [$this->createPropertyDoc($property, $namespace, $required)],
+            'comments' => [$this->createPropertyDoc($property, $namespace, $strict)],
         ]);
     }
 
-    protected function createPropertyDoc(Property $property, $namespace, bool $required): Doc
+    protected function createPropertyDoc(Property $property, $namespace, bool $strict): Doc
     {
         $docTypeHint = $property->getType()->getDocTypeHint($namespace);
-        if (!$required && strpos($docTypeHint, 'null') === false) {
+        if ((!$strict || $property->isNullable()) && strpos($docTypeHint, 'null') === false) {
             $docTypeHint .= '|null';
         }
 

--- a/src/JsonSchema/Generator/ModelGenerator.php
+++ b/src/JsonSchema/Generator/ModelGenerator.php
@@ -71,9 +71,8 @@ class ModelGenerator implements GeneratorInterface
 
             /** @var Property $property */
             foreach ($class->getProperties() as $property) {
-                $required = !$property->isNullable() && $context->isStrict();
-                $properties[] = $this->createProperty($property, $namespace, null, $required);
-                $methods = array_merge($methods, $this->doCreateClassMethods($class, $property, $namespace, $required));
+                $properties[] = $this->createProperty($property, $namespace, null, $context->isStrict());
+                $methods = array_merge($methods, $this->doCreateClassMethods($class, $property, $namespace, $context->isStrict()));
             }
 
             $model = $this->doCreateModel($class, $properties, $methods);
@@ -83,11 +82,11 @@ class ModelGenerator implements GeneratorInterface
         }
     }
 
-    protected function doCreateClassMethods(ClassGuess $classGuess, Property $property, string $namespace, bool $required): array
+    protected function doCreateClassMethods(ClassGuess $classGuess, Property $property, string $namespace, bool $strict): array
     {
         $methods = [];
-        $methods[] = $this->createGetter($property, $namespace, $required);
-        $methods[] = $this->createSetter($property, $namespace, $required);
+        $methods[] = $this->createGetter($property, $namespace, $strict);
+        $methods[] = $this->createSetter($property, $namespace, $strict);
 
         return $methods;
     }

--- a/src/JsonSchema/Guesser/Guess/MultipleType.php
+++ b/src/JsonSchema/Guesser/Guess/MultipleType.php
@@ -83,6 +83,12 @@ class MultipleType extends Type
      */
     public function getTypeHint(string $namespace)
     {
+        if (1 === \count($this->types)) {
+            $type = current($this->types);
+
+            return $type->getTypeHint($namespace);
+        }
+
         // We have exactly two types: one null and an object
         if (2 === \count($this->types)) {
             list($type1, $type2) = $this->types;

--- a/src/JsonSchema/Guesser/JsonSchema/MultipleGuesser.php
+++ b/src/JsonSchema/Guesser/JsonSchema/MultipleGuesser.php
@@ -13,6 +13,8 @@ use Jane\JsonSchema\Registry;
 
 class MultipleGuesser implements GuesserInterface, TypeGuesserInterface, ChainGuesserAwareInterface
 {
+    protected $bannedTypes = [];
+
     use ChainGuesserAwareTrait;
 
     /**
@@ -39,6 +41,10 @@ class MultipleGuesser implements GuesserInterface, TypeGuesserInterface, ChainGu
         $fakeSchema = clone $object;
 
         foreach ($object->getType() as $type) {
+            if (\in_array($type, $this->bannedTypes)) {
+                continue;
+            }
+
             $fakeSchema->setType($type);
             $typeGuess->addType($this->chainGuesser->guessType($fakeSchema, $name, $reference, $registry));
         }

--- a/src/OpenApi2/Guesser/OpenApiSchema/MultipleGuesser.php
+++ b/src/OpenApi2/Guesser/OpenApiSchema/MultipleGuesser.php
@@ -7,6 +7,8 @@ use Jane\OpenApi2\JsonSchema\Model\Schema;
 
 class MultipleGuesser extends BaseMultipleGuesser
 {
+    protected $bannedTypes = ['null'];
+
     protected function getSchemaClass(): string
     {
         return Schema::class;

--- a/src/OpenApi2/Guesser/OpenApiSchema/SchemaGuesser.php
+++ b/src/OpenApi2/Guesser/OpenApiSchema/SchemaGuesser.php
@@ -19,6 +19,14 @@ class SchemaGuesser extends ObjectGuesser
     }
 
     /**
+     * @param Schema $property
+     */
+    protected function isPropertyNullable($property): bool
+    {
+        return $property->offsetExists('x-nullable') && \is_bool($property->offsetGet('x-nullable')) && $property->offsetGet('x-nullable');
+    }
+
+    /**
      * @param Schema $object
      */
     protected function createClassGuess($object, string $reference, string $name, array $extensions): BaseClassGuess

--- a/src/OpenApi2/Guesser/OpenApiSchema/SimpleTypeGuesser.php
+++ b/src/OpenApi2/Guesser/OpenApiSchema/SimpleTypeGuesser.php
@@ -7,6 +7,13 @@ use Jane\OpenApi2\JsonSchema\Model\Schema;
 
 class SimpleTypeGuesser extends BaseSimpleTypeGuesser
 {
+    protected $typesSupported = [
+        'boolean',
+        'integer',
+        'number',
+        'string',
+    ];
+
     protected function getSchemaClass(): string
     {
         return Schema::class;

--- a/src/OpenApi2/Tests/fixtures/nullable-check/.jane-openapi
+++ b/src/OpenApi2/Tests/fixtures/nullable-check/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ .  '/swagger.json',
+    'namespace' => 'Jane\OpenApi2\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi2/Tests/fixtures/nullable-check/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/nullable-check/expected/Client.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
+{
+    public static function create($httpClient = null, array $additionalPlugins = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins[] = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/nullable-check/expected/Model/Foo.php
+++ b/src/OpenApi2/Tests/fixtures/nullable-check/expected/Model/Foo.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Model;
+
+class Foo
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $foo;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $bar;
+    /**
+     * 
+     *
+     * @var string|null
+     */
+    protected $baz;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+    /**
+     * 
+     *
+     * @param string $foo
+     *
+     * @return self
+     */
+    public function setFoo(string $foo) : self
+    {
+        $this->foo = $foo;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getBar() : string
+    {
+        return $this->bar;
+    }
+    /**
+     * 
+     *
+     * @param string $bar
+     *
+     * @return self
+     */
+    public function setBar(string $bar) : self
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string|null
+     */
+    public function getBaz() : ?string
+    {
+        return $this->baz;
+    }
+    /**
+     * 
+     *
+     * @param string|null $baz
+     *
+     * @return self
+     */
+    public function setBaz(?string $baz) : self
+    {
+        $this->baz = $baz;
+        return $this;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/nullable-check/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi2/Tests/fixtures/nullable-check/expected/Normalizer/FooNormalizer.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FooNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi2\\Tests\\Expected\\Model\\Foo';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi2\\Tests\\Expected\\Model\\Foo';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\OpenApi2\Tests\Expected\Model\Foo();
+        if (\array_key_exists('foo', $data)) {
+            $object->setFoo($data['foo']);
+        }
+        if (\array_key_exists('bar', $data)) {
+            $value = $data['bar'];
+            if (is_string($data['bar'])) {
+                $value = $data['bar'];
+            }
+            $object->setBar($value);
+        }
+        if (\array_key_exists('baz', $data) && $data['baz'] !== null) {
+            $object->setBaz($data['baz']);
+        }
+        elseif (\array_key_exists('baz', $data) && $data['baz'] === null) {
+            $object->setBaz(null);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getFoo()) {
+            $data['foo'] = $object->getFoo();
+        }
+        if (null !== $object->getBar()) {
+            $value = $object->getBar();
+            if (is_string($object->getBar())) {
+                $value = $object->getBar();
+            }
+            $data['bar'] = $value;
+        }
+        $data['baz'] = $object->getBaz();
+        return $data;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/nullable-check/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi2/Tests/fixtures/nullable-check/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('Jane\\OpenApi2\\Tests\\Expected\\Model\\Foo' => 'Jane\\OpenApi2\\Tests\\Expected\\Normalizer\\FooNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchemaRuntime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/nullable-check/swagger.json
+++ b/src/OpenApi2/Tests/fixtures/nullable-check/swagger.json
@@ -1,0 +1,18 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Swagger",
+        "version": "0.0.0"
+    },
+    "definitions": {
+        "Foo": {
+            "type": "object",
+            "properties": {
+                "foo": {"type": "string"},
+                "bar": {"type": ["string", "null"]},
+                "baz": {"type": "string", "x-nullable": true}
+            }
+        }
+    },
+    "paths": {}
+}

--- a/src/OpenApiCommon/JaneOpenApi.php
+++ b/src/OpenApiCommon/JaneOpenApi.php
@@ -90,7 +90,6 @@ abstract class JaneOpenApi extends ChainGenerator
                     }
 
                     $names[] = strtolower($property->getPhpName());
-
                     $property->setType($this->chainGuesser->guessType($property->getObject(), $property->getName(), $property->getReference(), $registry));
                 }
 


### PR DESCRIPTION
Fixes #297

OpenAPI v2 does not support `null` type. We should use custom field such as `x-nullable`. See https://stackoverflow.com/a/48114322 for more details.

- [x] Remove null support in OpenAPI v2
- [x] Add `x-nullable` support
- [x] Documentation about nullable support in all libraries