### PR TITLE
Hotfix/fix plugins on client creation

### DIFF
--- a/src/OpenApi2/Tests/fixtures/all-of-merge/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/all-of-merge/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/array-definition/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/array-definition/expected/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/body-parameter/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/body-parameter/expected/Client.php
@@ -46,7 +46,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/content-type/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/content-type/expected/Client.php
@@ -31,7 +31,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/discriminator/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/discriminator/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
+++ b/src/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
+++ b/src/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/exceptions/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/exceptions/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/from-url/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/from-url/expected/Client.php
@@ -48,7 +48,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/host/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/host/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/model-in-response/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/model-in-response/expected/Client.php
@@ -62,7 +62,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/multi-resources/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/multi-resources/expected/Client.php
@@ -28,7 +28,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Client.php
+++ b/src/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Client.php
+++ b/src/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/no-reference-body/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/no-reference-body/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/no-reference-response/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/no-reference-response/expected/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/nullable-check/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/nullable-check/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/operations/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/operations/expected/Client.php
@@ -154,7 +154,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/parameters/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/parameters/expected/Client.php
@@ -155,7 +155,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/response-reference/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/response-reference/expected/Client.php
@@ -28,7 +28,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Client.php
@@ -42,7 +42,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi2/Tests/fixtures/yaml/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/yaml/expected/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/all-of-merge/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/all-of-merge/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/api-platform-demo/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/api-platform-demo/expected/Client.php
@@ -294,7 +294,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/array-definition/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/array-definition/expected/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/body-parameter/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/body-parameter/expected/Client.php
@@ -46,7 +46,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/content-type/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/content-type/expected/Client.php
@@ -31,7 +31,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/deprecated/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/deprecated/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/discriminator/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/discriminator/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
+++ b/src/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
+++ b/src/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Client.php
@@ -20,7 +20,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/exceptions/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/exceptions/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/from-url/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/from-url/expected/Client.php
@@ -48,7 +48,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/host-with-port/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/host-with-port/expected/Client.php
@@ -21,7 +21,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUrlFactory()->createUri('http://www.foo-host.com:8024');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/host/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/host/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/model-in-response/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/model-in-response/expected/Client.php
@@ -53,7 +53,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/model-type-reference/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/model-type-reference/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/multi-resources/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/multi-resources/expected/Client.php
@@ -28,7 +28,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Client.php
+++ b/src/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Client.php
+++ b/src/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/no-reference-body/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/no-reference-body/expected/Client.php
@@ -34,7 +34,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/no-reference-response/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/no-reference-response/expected/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/operations/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/operations/expected/Client.php
@@ -154,7 +154,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Client.php
@@ -24,7 +24,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/parameters/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/parameters/expected/Client.php
@@ -146,7 +146,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/read-only-properties/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/read-only-properties/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Client.php
@@ -40,7 +40,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/response-reference/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/response-reference/expected/Client.php
@@ -28,7 +28,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/response-type-reference/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/response-type-reference/expected/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/skip-null-values/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/skip-null-values/expected/Client.php
@@ -24,7 +24,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/test-nullable-array/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/test-nullable-array/expected/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/test-nullable/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/test-nullable/expected/Client.php
@@ -24,7 +24,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/twitter/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/twitter/expected/Client.php
@@ -169,7 +169,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUrlFactory()->createUri('https://api.twitter.com');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Client.php
@@ -22,7 +22,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Client.php
@@ -10,7 +10,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php
@@ -46,7 +46,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUrlFactory()->createUri('https://api.twitter.com');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApi3/Tests/fixtures/yaml/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/yaml/expected/Client.php
@@ -19,7 +19,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = array();
             if (count($additionalPlugins) > 0) {
-                $plugins[] = array_merge($plugins, $additionalPlugins);
+                $plugins = array_merge($plugins, $additionalPlugins);
             }
             $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }

--- a/src/OpenApiCommon/Generator/Client/HttpClientCreateGenerator.php
+++ b/src/OpenApiCommon/Generator/Client/HttpClientCreateGenerator.php
@@ -52,7 +52,7 @@ trait HttpClientCreateGenerator
             [
                 'stmts' => [
                     new Stmt\Expression(new Expr\Assign(
-                        new Expr\ArrayDimFetch(new Expr\Variable('plugins')),
+                        new Expr\Variable('plugins'),
                         new Expr\FuncCall(new Name('array_merge'), [
                             new Node\Arg(new Expr\Variable('plugins')),
                             new Node\Arg(new Expr\Variable('additionalPlugins')),


### PR DESCRIPTION
This PR fixes the issue where the additionalPlugins variable. was not being merged but added into the $plugins variable in the client.
```php
$client = Client::create(null, [new BasicAuthAuthentication('user', 'pass')]);
````

A simple change as suggested here: https://github.com/janephp/janephp/pull/289 where `$plugins[]` could be replaced `$plugins` fixes this problem. 