### PR TITLE
Move Query & Header resolve while sending the request

### DIFF
--- a/src/OpenApi3/Generator/EndpointGenerator.php
+++ b/src/OpenApi3/Generator/EndpointGenerator.php
@@ -344,7 +344,7 @@ EOD
         $optionsResolverVariable = new Expr\Variable('optionsResolver');
 
         return new Stmt\ClassMethod($methodName, [
-            'type' => Stmt\Class_::MODIFIER_PROTECTED,
+            'type' => Stmt\Class_::MODIFIER_PUBLIC,
             'stmts' => array_merge(
                 [
                     new Stmt\Expression(new Expr\Assign($optionsResolverVariable, new Expr\StaticCall(new Name('parent'), $methodName))),

--- a/src/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiBooksReviewsGetSubresource.php
+++ b/src/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiBooksReviewsGetSubresource.php
@@ -39,7 +39,7 @@ class ApiBooksReviewsGetSubresource extends \Jane\OpenApiRuntime\Client\BaseEndp
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('order[id]', 'order[publicationDate]', 'book', 'book[]', 'page'));

--- a/src/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetBookCollection.php
+++ b/src/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetBookCollection.php
@@ -40,7 +40,7 @@ class GetBookCollection extends \Jane\OpenApiRuntime\Client\BaseEndpoint impleme
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('properties[]', 'order[id]', 'order[title]', 'order[author]', 'order[isbn]', 'order[publicationDate]', 'title', 'author', 'page'));

--- a/src/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetParchmentCollection.php
+++ b/src/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetParchmentCollection.php
@@ -32,7 +32,7 @@ class GetParchmentCollection extends \Jane\OpenApiRuntime\Client\BaseEndpoint im
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('page'));

--- a/src/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetReviewCollection.php
+++ b/src/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetReviewCollection.php
@@ -36,7 +36,7 @@ class GetReviewCollection extends \Jane\OpenApiRuntime\Client\BaseEndpoint imple
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('order[id]', 'order[publicationDate]', 'book', 'book[]', 'page'));

--- a/src/OpenApi3/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
+++ b/src/OpenApi3/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
@@ -32,7 +32,7 @@ class ListPets extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('limit'));

--- a/src/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Endpoint/Foo.php
+++ b/src/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Endpoint/Foo.php
@@ -28,7 +28,7 @@ class Foo extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\Open
     {
         return array(array(), null);
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('bar'));

--- a/src/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestGetWithPathParameters.php
+++ b/src/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestGetWithPathParameters.php
@@ -35,7 +35,7 @@ class TestGetWithPathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint
     {
         return array(array(), null);
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('testQuery'));
@@ -44,7 +44,7 @@ class TestGetWithPathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint
         $optionsResolver->setAllowedTypes('testQuery', array('string'));
         return $optionsResolver;
     }
-    protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getHeadersOptionsResolver();
         $optionsResolver->setDefined(array('testHeader'));

--- a/src/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
+++ b/src/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
@@ -33,7 +33,7 @@ class TestHeaderParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint impl
     {
         return array(array(), null);
     }
-    protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getHeadersOptionsResolver();
         $optionsResolver->setDefined(array('testString', 'testInteger', 'testFloat', 'testArray', 'testRequired', 'testDefault'));

--- a/src/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestPostWithPathParameters.php
+++ b/src/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestPostWithPathParameters.php
@@ -35,7 +35,7 @@ class TestPostWithPathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoin
     {
         return array(array(), null);
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('testQuery'));
@@ -44,7 +44,7 @@ class TestPostWithPathParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoin
         $optionsResolver->setAllowedTypes('testQuery', array('string'));
         return $optionsResolver;
     }
-    protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getHeadersOptionsResolver();
         $optionsResolver->setDefined(array('testHeader'));

--- a/src/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
+++ b/src/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
@@ -33,7 +33,7 @@ class TestQueryParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoint imple
     {
         return array(array(), null);
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('testString', 'testInteger', 'testFloat', 'testArray', 'testRequired', 'testDefault'));

--- a/src/OpenApi3/Tests/fixtures/skip-null-values/expected/Endpoint/TestNullableQueryParameters.php
+++ b/src/OpenApi3/Tests/fixtures/skip-null-values/expected/Endpoint/TestNullableQueryParameters.php
@@ -28,7 +28,7 @@ class TestNullableQueryParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoi
     {
         return array(array(), null);
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('testNullableInteger'));

--- a/src/OpenApi3/Tests/fixtures/test-nullable/expected/Endpoint/TestNullableQueryParameters.php
+++ b/src/OpenApi3/Tests/fixtures/test-nullable/expected/Endpoint/TestNullableQueryParameters.php
@@ -28,7 +28,7 @@ class TestNullableQueryParameters extends \Jane\OpenApiRuntime\Client\BaseEndpoi
     {
         return array(array(), null);
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('testNullableInteger'));

--- a/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/AddOrDeleteRules.php
+++ b/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/AddOrDeleteRules.php
@@ -37,7 +37,7 @@ class AddOrDeleteRules extends \Jane\OpenApiRuntime\Client\BaseEndpoint implemen
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('dry_run'));

--- a/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindPrivateTweetMetricsById.php
+++ b/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindPrivateTweetMetricsById.php
@@ -32,7 +32,7 @@ class FindPrivateTweetMetricsById extends \Jane\OpenApiRuntime\Client\BaseEndpoi
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('ids'));

--- a/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindTweetsById.php
+++ b/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindTweetsById.php
@@ -37,7 +37,7 @@ class FindTweetsById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('ids', 'format', 'tweet.format', 'user.format', 'place.format', 'expansions'));

--- a/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindUsersByIdOrUsername.php
+++ b/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindUsersByIdOrUsername.php
@@ -38,7 +38,7 @@ class FindUsersByIdOrUsername extends \Jane\OpenApiRuntime\Client\BaseEndpoint i
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('ids', 'usernames', 'format', 'tweet.format', 'user.format', 'place.format', 'expansions'));

--- a/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/GetRules.php
+++ b/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/GetRules.php
@@ -32,7 +32,7 @@ class GetRules extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('ids'));

--- a/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamFilter.php
+++ b/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamFilter.php
@@ -32,7 +32,7 @@ class StreamFilter extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('expansions'));

--- a/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamSample.php
+++ b/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamSample.php
@@ -32,7 +32,7 @@ class StreamSample extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('expansions'));

--- a/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/TweetsRecentSearch.php
+++ b/src/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/TweetsRecentSearch.php
@@ -43,7 +43,7 @@ class TweetsRecentSearch extends \Jane\OpenApiRuntime\Client\BaseEndpoint implem
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('query', 'start_time', 'end_time', 'since_id', 'until_id', 'max_results', 'next_token', 'format', 'tweet.format', 'user.format', 'place.format', 'expansions'));

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/AddOrDeleteRules.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/AddOrDeleteRules.php
@@ -37,7 +37,7 @@ class AddOrDeleteRules extends \Jane\OpenApiRuntime\Client\BaseEndpoint implemen
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('dry_run'));

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/FindTweetsById.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/FindTweetsById.php
@@ -37,7 +37,7 @@ class FindTweetsById extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements
     {
         return array('Accept' => array('application/json'));
     }
-    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    public function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
         $optionsResolver->setDefined(array('ids', 'format', 'tweet.format', 'user.format', 'place.format', 'expansions'));

--- a/src/OpenApiRuntime/Client/BaseEndpoint.php
+++ b/src/OpenApiRuntime/Client/BaseEndpoint.php
@@ -27,23 +27,22 @@ abstract class BaseEndpoint implements Endpoint
 
     public function getQueryString(): string
     {
-        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(function ($value) { return null !== $value ? $value : ''; }, $optionsResolved);
+        $optionsResolved = array_map(function ($value) { return null !== $value ? $value : ''; }, $this->queryParameters);
 
         return http_build_query($optionsResolved, null, '&', PHP_QUERY_RFC3986);
     }
 
     public function getHeaders(array $baseHeaders = []): array
     {
-        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->headerParameters);
     }
 
-    protected function getQueryOptionsResolver(): OptionsResolver
+    public function getQueryOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
     }
 
-    protected function getHeadersOptionsResolver(): OptionsResolver
+    public function getHeadersOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
     }

--- a/src/OpenApiRuntime/Client/Endpoint.php
+++ b/src/OpenApiRuntime/Client/Endpoint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Jane\OpenApiRuntime\Client;
 
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Serializer\SerializerInterface;
 
 interface Endpoint
@@ -35,4 +36,14 @@ interface Endpoint
      * Get the headers of an endpoint.
      */
     public function getHeaders(array $baseHeaders = []): array;
+
+    /**
+     * Get query definition.
+     */
+    public function getQueryOptionsResolver(): OptionsResolver;
+
+    /**
+     * Get headers definition.
+     */
+    public function getHeadersOptionsResolver(): OptionsResolver;
 }

--- a/src/OpenApiRuntime/Client/Plugin/HeaderResolver.php
+++ b/src/OpenApiRuntime/Client/Plugin/HeaderResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApiRuntime\Client\Plugin;
+
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class HeaderResolver implements Plugin
+{
+    private $optionsResolver;
+
+    public function __construct(OptionsResolver $optionsResolver)
+    {
+        $this->optionsResolver = $optionsResolver;
+    }
+
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        $requestHeaders = $request->getHeaders();
+        $resolvedHeaders = $this->optionsResolver->resolve($requestHeaders);
+
+        foreach ($requestHeaders as $name => $_) {
+            $request->withoutHeader($name);
+        }
+
+        foreach ($resolvedHeaders as $name => $value) {
+            $request->withHeader($name, $value);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/OpenApiRuntime/Client/Plugin/QueryResolver.php
+++ b/src/OpenApiRuntime/Client/Plugin/QueryResolver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Jane\OpenApiRuntime\Client\Plugin;
+
+use Http\Client\Common\Plugin;
+use Http\Promise\Promise;
+use League\Uri\Uri;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class QueryResolver implements Plugin
+{
+    private $optionsResolver;
+
+    public function __construct(OptionsResolver $optionsResolver)
+    {
+        $this->optionsResolver = $optionsResolver;
+    }
+
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): Promise
+    {
+        $uri = $request->getUri();
+
+        if (null !== $uri) {
+            $parsed = Uri::createFromUri($uri);
+            parse_str($parsed->getQuery() ?? '', $query);
+            $uri->withQuery(http_build_query($this->optionsResolver->resolve($query)));
+        }
+
+        return $next($request);
+    }
+}

--- a/src/OpenApiRuntime/Client/Psr18Client.php
+++ b/src/OpenApiRuntime/Client/Psr18Client.php
@@ -2,6 +2,9 @@
 
 namespace Jane\OpenApiRuntime\Client;
 
+use Http\Client\Common\PluginClient;
+use Jane\OpenApiRuntime\Client\Plugin\HeaderResolver;
+use Jane\OpenApiRuntime\Client\Plugin\QueryResolver;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -62,6 +65,11 @@ abstract class Psr18Client extends Client
             $request = $request->withHeader($name, $value);
         }
 
-        return $endpoint->parsePSR7Response($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        $clientWithOptionsResolvers = new PluginClient($this->httpClient, [
+            new QueryResolver($endpoint->getQueryOptionsResolver()),
+            new HeaderResolver($endpoint->getHeadersOptionsResolver()),
+        ]);
+
+        return $endpoint->parsePSR7Response($clientWithOptionsResolvers->sendRequest($request), $this->serializer, $fetch);
     }
 }

--- a/src/OpenApiRuntime/Tests/Client/Psr18ClientTest.php
+++ b/src/OpenApiRuntime/Tests/Client/Psr18ClientTest.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class Psr18ClientTest extends TestCase
@@ -53,6 +54,10 @@ class Psr18ClientTest extends TestCase
             ->method('withBody')
             ->with($streamMock)
             ->willReturn($requestMock);
+        $requestMock
+            ->expects($this->once())
+            ->method('getHeaders')
+            ->willReturn([]);
 
         $streamFactoryMock
             ->expects($this->once())
@@ -86,6 +91,14 @@ class Psr18ClientTest extends TestCase
             ->expects($this->once())
             ->method('parsePSR7Response')
             ->willReturn('foo');
+        $endpointMock
+            ->expects($this->once())
+            ->method('getQueryOptionsResolver')
+            ->willReturn(new OptionsResolver());
+        $endpointMock
+            ->expects($this->once())
+            ->method('getHeadersOptionsResolver')
+            ->willReturn(new OptionsResolver());
 
         $this->assertSame('foo', $client->executePsr7Endpoint($endpointMock));
     }


### PR DESCRIPTION
We are validating both query and header parameters in Jane.

Problem is, if you are declaring an HTTP client with one of the two already declared we will have no way to know that with the current behavior.

The idea here is to move this validation into a plugin that will be run just before sending the request. 