### PR TITLE
Compatibility with other old dependencies for league/uri

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=7.2",
         "ext-json": "*",
         "doctrine/inflector": "^1.3",
-        "league/uri": "^6.0",
+        "league/uri": "^6.0 || ^5.0",
         "nikic/php-parser": "^4.0",
         "php-http/client-common": "^2.0",
         "php-http/message-factory": "^1.0.2",


### PR DESCRIPTION
I use a dependency call Payum which is not compatible with this package because of league/uri upgrade on version 6. Is it possible to use an old version without BC ?