### PR TITLE
Improvement & fix on whitelisted path feature

### DIFF
--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/.jane-openapi
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/.jane-openapi
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.yaml',
+    'namespace' => 'Jane\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'whitelisted-paths' => [
+        '\/foo$',
+    ],
+];

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Client.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\OpenApi3\Tests\Expected\Exception\GetFooUnauthorizedException
+     *
+     * @return null|\Jane\OpenApi3\Tests\Expected\Model\Foo|\Psr\Http\Message\ResponseInterface
+     */
+    public function getFoo(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi3\Tests\Expected\Endpoint\GetFoo(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Endpoint/GetFoo.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Endpoint/GetFoo.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Endpoint;
+
+class GetFoo extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/foo';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\OpenApi3\Tests\Expected\Exception\GetFooUnauthorizedException
+     *
+     * @return null|\Jane\OpenApi3\Tests\Expected\Model\Foo
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status && mb_strpos($contentType, 'application/json') !== false) {
+            return $serializer->deserialize($body, 'Jane\\OpenApi3\\Tests\\Expected\\Model\\Foo', 'json');
+        }
+        if (401 === $status) {
+            throw new \Jane\OpenApi3\Tests\Expected\Exception\GetFooUnauthorizedException();
+        }
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Exception/ApiException.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Exception/ClientException.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Exception/GetFooUnauthorizedException.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Exception/GetFooUnauthorizedException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Exception;
+
+class GetFooUnauthorizedException extends \RuntimeException implements ClientException
+{
+    public function __construct()
+    {
+        parent::__construct('User must be identified to access this resource', 401);
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Exception/ServerException.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Model/Foo.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Model/Foo.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Model;
+
+class Foo
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $label;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getLabel() : string
+    {
+        return $this->label;
+    }
+    /**
+     * 
+     *
+     * @param string $label
+     *
+     * @return self
+     */
+    public function setLabel(string $label) : self
+    {
+        $this->label = $label;
+        return $this;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Normalizer/FooNormalizer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FooNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi3\\Tests\\Expected\\Model\\Foo';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi3\\Tests\\Expected\\Model\\Foo';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\OpenApi3\Tests\Expected\Model\Foo();
+        if (\array_key_exists('label', $data)) {
+            $object->setLabel($data['label']);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getLabel()) {
+            $data['label'] = $object->getLabel();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('Jane\\OpenApi3\\Tests\\Expected\\Model\\Foo' => 'Jane\\OpenApi3\\Tests\\Expected\\Normalizer\\FooNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchemaRuntime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/openapi.yaml
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/openapi.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Whitelist - Response without content
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      summary: Get foo entity
+      responses:
+        '200':
+          description: Foo item
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Foo'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+
+components:
+  schemas:
+    Foo:
+      type: object
+      properties:
+        label:
+          type: string
+  responses:
+    401Unauthorized:
+      description: User must be identified to access this resource

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/.jane-openapi
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/.jane-openapi
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.yaml',
+    'namespace' => 'Jane\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'whitelisted-paths' => [
+        '\/foo$',
+    ],
+];

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Client.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
+{
+    /**
+     * 
+     *
+     * @param \Jane\OpenApi3\Tests\Expected\Model\FooPayload $requestBody 
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function postFoo(\Jane\OpenApi3\Tests\Expected\Model\FooPayload $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi3\Tests\Expected\Endpoint\PostFoo($requestBody), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Endpoint/PostFoo.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Endpoint/PostFoo.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Endpoint;
+
+class PostFoo extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    /**
+     * 
+     *
+     * @param \Jane\OpenApi3\Tests\Expected\Model\FooPayload $requestBody 
+     */
+    public function __construct(\Jane\OpenApi3\Tests\Expected\Model\FooPayload $requestBody)
+    {
+        $this->body = $requestBody;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'POST';
+    }
+    public function getUri() : string
+    {
+        return '/foo';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        if ($this->body instanceof \Jane\OpenApi3\Tests\Expected\Model\FooPayload) {
+            return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));
+        }
+        return array(array(), null);
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status) {
+            return null;
+        }
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Model/FooPayload.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Model/FooPayload.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Model;
+
+class FooPayload
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $label;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getLabel() : string
+    {
+        return $this->label;
+    }
+    /**
+     * 
+     *
+     * @param string $label
+     *
+     * @return self
+     */
+    public function setLabel(string $label) : self
+    {
+        $this->label = $label;
+        return $this;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Normalizer/FooPayloadNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Normalizer/FooPayloadNormalizer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FooPayloadNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi3\\Tests\\Expected\\Model\\FooPayload';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi3\\Tests\\Expected\\Model\\FooPayload';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\OpenApi3\Tests\Expected\Model\FooPayload();
+        if (\array_key_exists('label', $data)) {
+            $object->setLabel($data['label']);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getLabel()) {
+            $data['label'] = $object->getLabel();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('Jane\\OpenApi3\\Tests\\Expected\\Model\\FooPayload' => 'Jane\\OpenApi3\\Tests\\Expected\\Normalizer\\FooPayloadNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchemaRuntime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/openapi.yaml
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/openapi.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Whitelist - Request body processing
+  version: 1.0.0
+paths:
+  /foo:
+    post:
+      summary: Add foo entity
+      requestBody:
+        description: Foo item to add
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FooPayload'
+      responses:
+        '200':
+          description: Foo item created
+
+components:
+  schemas:
+    FooPayload:
+      type: object
+      properties:
+        label:
+          type: string
+

--- a/src/OpenApi3/WhitelistedSchema.php
+++ b/src/OpenApi3/WhitelistedSchema.php
@@ -45,6 +45,10 @@ class WhitelistedSchema implements WhitelistFetchInterface
         $responses = $operationGuess->getOperation()->getResponses();
         if (null !== $responses && \count($responses) > 0) {
             foreach ($responses as $response) {
+                if (!($response instanceof Response)) {
+                    continue;
+                }
+
                 if (null === $response->getContent()) {
                     $classGuess = $this->guessClass->guessClass(null, $operationGuess->getReference(), $registry, $this->denormalizer);
                     if (null !== $classGuess) {


### PR DESCRIPTION
**Bug fix:**
When you want to generate an endpoint who has a referenced response without content (simple 401/403 responses for example), the `Jane\OpenApi3\WhitelistedSchema` class throw an exception because `Jane\OpenApi3\JsonSchema\Model\Reference` object has no `getContent()` method. 

**Improvement:**
In POST endpoint, `requestBody` object/reference is not processing by `Jane\OpenApi3\WhitelistedSchema::addOperationRelations` method and referenced Model is not added to relations array. 