### PR TITLE
Allow dictionary parameters for OpenAPI 3

### DIFF
--- a/src/OpenApi3/Tests/fixtures/parameters/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/parameters/expected/Client.php
@@ -140,6 +140,20 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
     {
         return $this->executePsr7Endpoint(new \Jane\OpenApi3\Tests\Expected\Endpoint\GetByTestInteger($testInteger), $fetch);
     }
+    /**
+     * 
+     *
+     * @param array $queryParameters {
+     *     @var string $input 
+     * }
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function testDictionary(array $queryParameters = array(), string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executePsr7Endpoint(new \Jane\OpenApi3\Tests\Expected\Endpoint\TestDictionary($queryParameters), $fetch);
+    }
     public static function create($httpClient = null, array $additionalPlugins = array())
     {
         if (null === $httpClient) {

--- a/src/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestDictionary.php
+++ b/src/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestDictionary.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Endpoint;
+
+class TestDictionary extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Psr7Endpoint
+{
+    /**
+     * 
+     *
+     * @param array $queryParameters {
+     *     @var string $input 
+     * }
+     */
+    public function __construct(array $queryParameters = array())
+    {
+        $this->queryParameters = $queryParameters;
+    }
+    use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'POST';
+    }
+    public function getUri() : string
+    {
+        return '/test-dictionary';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(array('input'));
+        $optionsResolver->setRequired(array('input'));
+        $optionsResolver->setDefaults(array());
+        $optionsResolver->setAllowedTypes('input', array('string'));
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/parameters/swagger.json
+++ b/src/OpenApi3/Tests/fixtures/parameters/swagger.json
@@ -324,6 +324,27 @@
                     "Test"
                 ]
             }
+        },
+        "/test-dictionary": {
+            "post": {
+                "tags": [
+                    "example"
+                ],
+                "operationId": "testDictionary",
+                "parameters": [
+                    {
+                        "name": "input",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }
         }
     },
     "info": {


### PR DESCRIPTION
Fixes #313 

Will allow dictionary types in parameters for OpenAPI 3 using:
```yaml
parameters:
  - name: input
    in: query
    required: true
    schema:
      type: object
      additionalProperties:
        type: string
```