### PR TITLE
fix docs

### DIFF
--- a/documentation/components/OpenAPI.rst
+++ b/documentation/components/OpenAPI.rst
@@ -143,11 +143,11 @@ Other options are available to customize the generated code:
  * ``skip-null-values``: When having nullable properties, you can enforce normalization to skip theses
    properties even if they are nullable. This option allows you to not have theses properties when they're not set
    (``null``). By default it is enabled.
+ * ``endpoint-generator``: Generator Class (extending `\Jane\OpenApi3\Generator\EndpointGenerator`) which can
+   specify custom endpoint interface & corresponding trait.
  * ``whitelisted-paths``: This option allows you to generate only needed endpoints and related models. Be carefull,
    that option will filter models used by whitelisted endpoints and generate model & normalizer only for them. Here is
    some examples about how to use it::
- * ``endpoint-generator``: Generator Class (extending `\Jane\OpenApi3\Generator\EndpointGenerator`) which can
-   specify custom endpoint interface & corresponding trait.
 
     <?php
 


### PR DESCRIPTION
Hi, when I introduced this endpoint-generator feature I put the docs on wrong place, so whitelisted paths documentation was messed up. Here is fix, that should solve it