### PR TITLE
Fix 6.x dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "symfony/serializer": "^4.4 || ^5.0",
         "symfony/string": "^5.0",
         "symfony/translation-contracts": "^2.0",
-        "symfony/var-dumper": "^5.0",
         "symfony/yaml": "^4.4 || ^5.0"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,15 @@
         "php-jsonpointer/php-jsonpointer": "^3.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "symfony/console": "^4.4 || ^5.0",
-        "symfony/filesystem": "^4.4 || ^5.0",
-        "symfony/options-resolver": "^4.4 || ^5.0",
-        "symfony/property-info": "~5.1",
-        "symfony/serializer": "^4.4 || ^5.0",
-        "symfony/string": "^5.0",
+        "symfony/console": "^4.4 || 5.0.*",
+        "symfony/filesystem": "^4.4 || 5.0.*",
+        "symfony/options-resolver": "^4.4 || 5.0.*",
+        "symfony/property-info": "^4.4 || 5.0.*",
+        "symfony/serializer": "^4.4 || 5.0.*",
+        "symfony/string": "5.0.*",
         "symfony/translation-contracts": "^2.0",
-        "symfony/yaml": "^4.4 || ^5.0"
+        "symfony/var-dumper": "^4.4 || 5.0.*",
+        "symfony/yaml": "^4.4 || 5.0.*"
     },
     "replace": {
         "jane-php/automapper": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
         "symfony/console": "^4.4 || 5.0.*",
         "symfony/filesystem": "^4.4 || 5.0.*",
         "symfony/options-resolver": "^4.4 || 5.0.*",
-        "symfony/property-info": "^4.4 || 5.0.*",
+        "symfony/property-info": "~5.1",
         "symfony/serializer": "^4.4 || 5.0.*",
-        "symfony/string": "5.0.*",
+        "symfony/string": "^5.0",
         "symfony/translation-contracts": "^2.0",
         "symfony/var-dumper": "^4.4 || 5.0.*",
         "symfony/yaml": "^4.4 || 5.0.*"

--- a/src/AutoMapper/composer.json
+++ b/src/AutoMapper/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "doctrine/annotations": "~1.0",
         "phpdocumentor/reflection-docblock": "^3.0 || ^4.0",
-        "symfony/serializer": "^4.2 || ^5.0"
+        "symfony/serializer": "^4.2 || 5.0.*"
     },
     "suggest": {
         "symfony/serializer": "Allow to bridge mappers to normalizer and denormalizer"

--- a/src/JsonSchema/composer.json
+++ b/src/JsonSchema/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "symfony/finder": "^5.0"
+        "symfony/finder": "^4.4 || ^5.0"
     },
     "suggest": {
         "friendsofphp/php-cs-fixer": "Allow to automatically fix cs on generated code for better visualisation"

--- a/src/JsonSchema/composer.json
+++ b/src/JsonSchema/composer.json
@@ -26,16 +26,16 @@
         "doctrine/inflector": "^1.4",
         "jane-php/json-schema-runtime": "^6.0",
         "nikic/php-parser": "^4.0",
-        "symfony/console": "^4.4 || ^5.0",
-        "symfony/filesystem": "^4.4 || ^5.0",
-        "symfony/options-resolver": "^4.4 || ^5.0",
-        "symfony/serializer": "^4.4 || ^5.0",
-        "symfony/var-dumper": "^4.4 || ^5.0",
-        "symfony/yaml": "^4.4 || ^5.0"
+        "symfony/console": "^4.4 || 5.0.*",
+        "symfony/filesystem": "^4.4 || 5.0.*",
+        "symfony/options-resolver": "^4.4 || 5.0.*",
+        "symfony/serializer": "^4.4 || 5.0.*",
+        "symfony/var-dumper": "^4.4 || 5.0.*",
+        "symfony/yaml": "^4.4 || 5.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "symfony/finder": "^4.4 || ^5.0"
+        "symfony/finder": "^4.4 || 5.0.*"
     },
     "suggest": {
         "friendsofphp/php-cs-fixer": "Allow to automatically fix cs on generated code for better visualisation"

--- a/src/JsonSchemaRuntime/composer.json
+++ b/src/JsonSchemaRuntime/composer.json
@@ -26,8 +26,8 @@
         "ext-json": "*",
         "league/uri": "^6.0",
         "php-jsonpointer/php-jsonpointer": "^3.0",
-        "symfony/serializer": "^4.4 || ^5.0",
-        "symfony/yaml": "^4.4 || ^5.0"
+        "symfony/serializer": "^4.4 || 5.0.*",
+        "symfony/yaml": "^4.4 || 5.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"

--- a/src/OpenApi2/composer.json
+++ b/src/OpenApi2/composer.json
@@ -32,12 +32,12 @@
         "jane-php/json-schema": "^6.0",
         "jane-php/open-api-common": "^6.0",
         "nikic/php-parser": "^4.0",
-        "symfony/serializer": "^4.4 || ^5.0",
-        "symfony/yaml": "^4.4 || ^5.0"
+        "symfony/serializer": "^4.4 || 5.0.*",
+        "symfony/yaml": "^4.4 || 5.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "symfony/finder": "^4.4 || ^5.0"
+        "symfony/finder": "^4.4 || 5.0.*"
     },
     "suggest": {
         "friendsofphp/php-cs-fixer": "To have a nice formatting of the generated files"

--- a/src/OpenApi2/composer.json
+++ b/src/OpenApi2/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "symfony/finder": "^5.0"
+        "symfony/finder": "^4.4 || ^5.0"
     },
     "suggest": {
         "friendsofphp/php-cs-fixer": "To have a nice formatting of the generated files"

--- a/src/OpenApi3/composer.json
+++ b/src/OpenApi3/composer.json
@@ -32,12 +32,12 @@
         "jane-php/json-schema": "^6.0",
         "jane-php/open-api-common": "^6.0",
         "nikic/php-parser": "^4.0",
-        "symfony/serializer": "^4.4 || ^5.0",
-        "symfony/yaml": "^4.4 || ^5.0"
+        "symfony/serializer": "^4.4 || 5.0.*",
+        "symfony/yaml": "^4.4 || 5.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "symfony/finder": "^4.4 || ^5.0"
+        "symfony/finder": "^4.4 || 5.0.*"
     },
     "suggest": {
         "friendsofphp/php-cs-fixer": "To have a nice formatting of the generated files"

--- a/src/OpenApi3/composer.json
+++ b/src/OpenApi3/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "symfony/finder": "^5.0"
+        "symfony/finder": "^4.4 || ^5.0"
     },
     "suggest": {
         "friendsofphp/php-cs-fixer": "To have a nice formatting of the generated files"

--- a/src/OpenApiCommon/composer.json
+++ b/src/OpenApiCommon/composer.json
@@ -29,11 +29,11 @@
         "ext-json": "*",
         "jane-php/json-schema": "^6.0",
         "jane-php/open-api-runtime": "^6.0",
-        "symfony/console": "^4.4 || ^5.0",
-        "symfony/filesystem": "^4.4 || ^5.0",
-        "symfony/string": "^5.0",
+        "symfony/console": "^4.4 || 5.0.*",
+        "symfony/filesystem": "^4.4 || 5.0.*",
+        "symfony/string": "5.0.*",
         "symfony/translation-contracts": "^2.0",
-        "symfony/var-dumper": "^4.4 || ^5.0"
+        "symfony/var-dumper": "^4.4 || 5.0.*"
     },
     "extra": {
         "branch-alias": {

--- a/src/OpenApiCommon/composer.json
+++ b/src/OpenApiCommon/composer.json
@@ -31,7 +31,7 @@
         "jane-php/open-api-runtime": "^6.0",
         "symfony/console": "^4.4 || 5.0.*",
         "symfony/filesystem": "^4.4 || 5.0.*",
-        "symfony/string": "5.0.*",
+        "symfony/string": "^5.0",
         "symfony/translation-contracts": "^2.0",
         "symfony/var-dumper": "^4.4 || 5.0.*"
     },

--- a/src/OpenApiCommon/composer.json
+++ b/src/OpenApiCommon/composer.json
@@ -32,7 +32,8 @@
         "symfony/console": "^4.4 || ^5.0",
         "symfony/filesystem": "^4.4 || ^5.0",
         "symfony/string": "^5.0",
-        "symfony/var-dumper": "^5.0"
+        "symfony/translation-contracts": "^2.0",
+        "symfony/var-dumper": "^4.4 || ^5.0"
     },
     "extra": {
         "branch-alias": {

--- a/src/OpenApiRuntime/composer.json
+++ b/src/OpenApiRuntime/composer.json
@@ -28,11 +28,12 @@
         "php-http/multipart-stream-builder": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "symfony/options-resolver": "^4.4 || ^5.0"
+        "symfony/options-resolver": "^4.4 || ^5.0",
+        "jane-php/json-schema-runtime": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "symfony/serializer": "^5.0"
+        "symfony/serializer": "^4.4 || ^5.0"
     },
     "extra": {
         "branch-alias": {

--- a/src/OpenApiRuntime/composer.json
+++ b/src/OpenApiRuntime/composer.json
@@ -28,12 +28,12 @@
         "php-http/multipart-stream-builder": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "symfony/options-resolver": "^4.4 || ^5.0",
+        "symfony/options-resolver": "^4.4 || 5.0.*",
         "jane-php/json-schema-runtime": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "symfony/serializer": "^4.4 || ^5.0"
+        "symfony/serializer": "^4.4 || 5.0.*"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Same as #327 but for `master` branch

> Fixes #323 
> 
> I didn't changed `symfony/string`, it's a new component since Symfony 5.x and it doesn't require any other Symfony component so it shouln'd be an issue.
> 
> I also restricted Symfony to `5.0.*` (instead of `^5.0`), because we have an issue with Serializer container definition in `5.1` (see for more details https://github.com/symfony/symfony/pull/37058)