### PR TITLE
Add an option to override some classes FQCN

### DIFF
--- a/src/JsonSchema/Console/Loader/ConfigLoader.php
+++ b/src/JsonSchema/Console/Loader/ConfigLoader.php
@@ -66,6 +66,7 @@ class ConfigLoader implements ConfigLoaderInterface
             'clean-generated' => true,
             'use-cacheable-supports-method' => null,
             'skip-null-values' => true,
+            'override-model-fqcn' => null,
         ];
     }
 }

--- a/src/JsonSchema/Console/Loader/SchemaLoader.php
+++ b/src/JsonSchema/Console/Loader/SchemaLoader.php
@@ -39,6 +39,7 @@ class SchemaLoader implements SchemaLoaderInterface
             'clean-generated',
             'use-cacheable-supports-method',
             'skip-null-values',
+            'override-model-fqcn',
         ];
     }
 

--- a/src/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/NormalizerGenerator.php
@@ -46,18 +46,24 @@ class NormalizerGenerator implements GeneratorInterface
     protected $skipNullValues;
 
     /**
+     * @var array A list of model FQCN which should be overrided when generating the normalizer
+     */
+    protected $overrideModelFqcns;
+
+    /**
      * @param Naming $naming       Naming Service
      * @param Parser $parser       PHP Parser
      * @param bool   $useReference Whether to generate the JSON Reference system
      * @param bool   $useCache     Whether to use the CacheableSupportsMethodInterface interface, for >sf 4.1
      */
-    public function __construct(Naming $naming, Parser $parser, bool $useReference = true, bool $useCacheableSupportsMethod = null, bool $skipNullValues = true)
+    public function __construct(Naming $naming, Parser $parser, bool $useReference = true, bool $useCacheableSupportsMethod = null, bool $skipNullValues = true, array $overrideModelFqcns = [])
     {
         $this->naming = $naming;
         $this->parser = $parser;
         $this->useReference = $useReference;
         $this->useCacheableSupportsMethod = $this->canUseCacheableSupportsMethod($useCacheableSupportsMethod);
         $this->skipNullValues = $skipNullValues;
+        $this->overrideModelFqcns = $overrideModelFqcns;
     }
 
     /**
@@ -77,6 +83,10 @@ class NormalizerGenerator implements GeneratorInterface
 
         foreach ($schema->getClasses() as $class) {
             $modelFqdn = $schema->getNamespace() . '\\Model\\' . $class->getName();
+
+            if (isset($this->overrideModelFqcns[$modelFqdn])) {
+                $modelFqdn = $this->overrideModelFqcns[$modelFqdn];
+            }
 
             $methods = [];
             $methods[] = $this->createSupportsDenormalizationMethod($modelFqdn);

--- a/src/JsonSchema/Jane.php
+++ b/src/JsonSchema/Jane.php
@@ -102,7 +102,7 @@ class Jane extends ChainGenerator
         $naming = new Naming();
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
         $modelGenerator = new ModelGenerator($naming, $parser);
-        $normGenerator = new NormalizerGenerator($naming, $parser, $options['reference'], $options['use-cacheable-supports-method'] ?? false, $options['skip-null-values'] ?? true);
+        $normGenerator = new NormalizerGenerator($naming, $parser, $options['reference'], $options['use-cacheable-supports-method'] ?? false, $options['skip-null-values'] ?? true, $options['override-model-fqcn'] ?? []);
 
         $self = new self($serializer, $chainGuesser, $naming, $options['strict']);
         $self->addGenerator($modelGenerator);

--- a/src/JsonSchema/Tests/fixtures/overrided-model-fqdn/.jane
+++ b/src/JsonSchema/Tests/fixtures/overrided-model-fqdn/.jane
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'json-schema-file' => __DIR__ . '/schema.json',
+    'root-class' => 'Test',
+    'namespace' => 'Jane\JsonSchema\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'override-model-fqcn' => [
+        'Jane\JsonSchema\Tests\Expected\Model\Foo' => 'Custom\Model\Foo',
+    ],
+];

--- a/src/JsonSchema/Tests/fixtures/overrided-model-fqdn/expected/Model/Foo.php
+++ b/src/JsonSchema/Tests/fixtures/overrided-model-fqdn/expected/Model/Foo.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Model;
+
+/**
+ *
+ * @deprecated
+ */
+class Foo
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $email;
+    /**
+     * 
+     *
+     * @deprecated
+     *
+     * @var string
+     */
+    protected $foo;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getEmail() : string
+    {
+        return $this->email;
+    }
+    /**
+     * 
+     *
+     * @param string $email
+     *
+     * @return self
+     */
+    public function setEmail(string $email) : self
+    {
+        $this->email = $email;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @deprecated
+     *
+     * @return string
+     */
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+    /**
+     * 
+     *
+     * @param string $foo
+     *
+     * @deprecated
+     *
+     * @return self
+     */
+    public function setFoo(string $foo) : self
+    {
+        $this->foo = $foo;
+        return $this;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/overrided-model-fqdn/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/overrided-model-fqdn/expected/Normalizer/FooNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FooNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Custom\\Model\\Foo';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Custom\Model\Foo;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Custom\Model\Foo();
+        if (\array_key_exists('email', $data)) {
+            $object->setEmail($data['email']);
+        }
+        if (\array_key_exists('foo', $data)) {
+            $object->setFoo($data['foo']);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getEmail()) {
+            $data['email'] = $object->getEmail();
+        }
+        if (null !== $object->getFoo()) {
+            $data['foo'] = $object->getFoo();
+        }
+        return $data;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/overrided-model-fqdn/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/overrided-model-fqdn/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('Custom\\Model\\Foo' => 'Jane\\JsonSchema\\Tests\\Expected\\Normalizer\\FooNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchemaRuntime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/overrided-model-fqdn/schema.json
+++ b/src/JsonSchema/Tests/fixtures/overrided-model-fqdn/schema.json
@@ -1,0 +1,18 @@
+{
+    "type": "object",
+    "definitions": {
+        "Foo": {
+            "type": "object",
+            "deprecated": true,
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "foo": {
+                    "type": "string",
+                    "deprecated": true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
One of my main concern when using Jane is the impossibility to update a generated Model (to add custom methods for example).

This new option allow to override the FQCN used by the normalizer.
I should now be able to create a custom model class (which inherit from the model generated by Jane) to add some custom logic.

WDYT about this option?