### PR TITLE
Allow date_time_format override from bundle

### DIFF
--- a/documentation/components/AutoMapper.rst
+++ b/documentation/components/AutoMapper.rst
@@ -164,6 +164,7 @@ Then configure the bundle to your needs, for example:
 
     jane_auto_mapper:
       autoregister: true
+      date_time_format: !php/const \DateTimeInterface::RFC3339_EXTENDED
       mappings:
         - source: Jane\AutoMapper\Bundle\Tests\Fixtures\User
           target: Jane\AutoMapper\Tests\Fixtures\UserDTO
@@ -174,6 +175,7 @@ Possible fields:
 * ``normalizer`` (default: ``false``):  A boolean which indicate if we inject the AutoMapperNormalizer;
 * ``cache_dir`` (default: ``%kernel.cache_dir%/automapper``): This settings allows you to customize the output directory for generated mappers;
 * ``mappings``: This option allows you to customize Mapper metadata, you have to specify ``source`` and ``target`` data types and related configuration using ``pass`` field. This configuration should implements ``Jane\AutoMapper\Bundle\Configuration\ConfigurationPassInterface``.
+* ``date_time_format``: This option allows you to change the date time format used to transform strings to ``\DateTimeInterface`` (default: ``\DateTimeInterface::RFC3339``).
 
 Normalizer Bridge
 -----------------

--- a/src/AutoMapper/Bundle/DependencyInjection/Configuration.php
+++ b/src/AutoMapper/Bundle/DependencyInjection/Configuration.php
@@ -16,6 +16,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('normalizer')->defaultFalse()->end()
                 ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/automapper')->end()
+                ->scalarNode('date_time_format')->defaultValue(\DateTime::RFC3339)->end()
                 ->arrayNode('mappings')
                     ->prototype('array')
                     ->children()

--- a/src/AutoMapper/Bundle/DependencyInjection/JaneAutoMapperExtension.php
+++ b/src/AutoMapper/Bundle/DependencyInjection/JaneAutoMapperExtension.php
@@ -29,6 +29,8 @@ class JaneAutoMapperExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
 
+        $container->getDefinition(MapperGeneratorMetadataFactory::class)->replaceArgument(5, $config['date_time_format']);
+
         foreach ($config['mappings'] as $mapping) {
             $this->createMapperConfigurationDefinition($container, $mapping);
         }

--- a/src/AutoMapper/Bundle/Resources/config/services.xml
+++ b/src/AutoMapper/Bundle/Resources/config/services.xml
@@ -38,6 +38,8 @@
             <argument type="service" id="Jane\AutoMapper\Extractor\FromSourceMappingExtractor" />
             <argument type="service" id="Jane\AutoMapper\Extractor\FromTargetMappingExtractor" />
             <argument>Symfony_Mapper_</argument>
+            <argument>true</argument>
+            <argument></argument> <!-- Date time format -->
         </service>
         <service id="Jane\AutoMapper\MapperGeneratorMetadataFactoryInterface" alias="Jane\AutoMapper\MapperGeneratorMetadataFactory" />
 

--- a/src/AutoMapper/MapperGeneratorMetadataFactory.php
+++ b/src/AutoMapper/MapperGeneratorMetadataFactory.php
@@ -18,19 +18,22 @@ final class MapperGeneratorMetadataFactory implements MapperGeneratorMetadataFac
     private $fromTargetPropertiesMappingExtractor;
     private $classPrefix;
     private $attributeChecking;
+    private $dateTimeFormat;
 
     public function __construct(
         SourceTargetMappingExtractor $sourceTargetPropertiesMappingExtractor,
         FromSourceMappingExtractor $fromSourcePropertiesMappingExtractor,
         FromTargetMappingExtractor $fromTargetPropertiesMappingExtractor,
         string $classPrefix = 'Mapper_',
-        bool $attributeChecking = true
+        bool $attributeChecking = true,
+        string $dateTimeFormat = \DateTime::RFC3339
     ) {
         $this->sourceTargetPropertiesMappingExtractor = $sourceTargetPropertiesMappingExtractor;
         $this->fromSourcePropertiesMappingExtractor = $fromSourcePropertiesMappingExtractor;
         $this->fromTargetPropertiesMappingExtractor = $fromTargetPropertiesMappingExtractor;
         $this->classPrefix = $classPrefix;
         $this->attributeChecking = $attributeChecking;
+        $this->dateTimeFormat = $dateTimeFormat;
     }
 
     /**
@@ -50,6 +53,7 @@ final class MapperGeneratorMetadataFactory implements MapperGeneratorMetadataFac
 
         $mapperMetadata = new MapperMetadata($autoMapperRegister, $extractor, $source, $target, $this->classPrefix);
         $mapperMetadata->setAttributeChecking($this->attributeChecking);
+        $mapperMetadata->setDateTimeFormat($this->dateTimeFormat);
 
         return $mapperMetadata;
     }


### PR DESCRIPTION
When using the bundle it's currently not possible to use a custom date format.