### PR TITLE
Do not try to create an instance of an interface

### DIFF
--- a/src/AutoMapper/Tests/Transformer/StringToDateTimeTransformerTest.php
+++ b/src/AutoMapper/Tests/Transformer/StringToDateTimeTransformerTest.php
@@ -40,4 +40,14 @@ class StringToDateTimeTransformerTest extends TestCase
 
         self::assertInstanceOf(\DateTimeImmutable::class, $output);
     }
+
+    public function testDateTimeTransformerInterface()
+    {
+        $transformer = new StringToDateTimeTransformer(\DateTimeInterface::class);
+
+        $date = new \DateTime();
+        $output = $this->evalTransformer($transformer, $date->format(\DateTime::RFC3339));
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $output);
+    }
 }

--- a/src/AutoMapper/Transformer/StringToDateTimeTransformer.php
+++ b/src/AutoMapper/Transformer/StringToDateTimeTransformer.php
@@ -31,7 +31,9 @@ final class StringToDateTimeTransformer implements TransformerInterface
      */
     public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
-        return [new Expr\StaticCall(new Name\FullyQualified($this->className), 'createFromFormat', [
+        $className = \DateTimeInterface::class === $this->className ? \DateTimeImmutable::class : $this->className;
+
+        return [new Expr\StaticCall(new Name\FullyQualified($className), 'createFromFormat', [
             new Arg(new String_($this->format)),
             new Arg($input),
         ]), []];


### PR DESCRIPTION
When a `setter` is casted with a `DateTimeInterface`, the automapper try to create an instanceof `DateTimeInterface`.

When `DateTimeInterface` is given as class name, we fallback on a `DateTimeImmutable` instead.