### PR TITLE
Use iterable instead of ArrayObject type hint

### DIFF
--- a/src/JsonSchema/Guesser/Guess/MapType.php
+++ b/src/JsonSchema/Guesser/Guess/MapType.php
@@ -20,7 +20,7 @@ class MapType extends ArrayType
      */
     public function getTypeHint(string $namespace)
     {
-        return new Name('\ArrayObject');
+        return new Name('iterable');
     }
 
     /**

--- a/src/JsonSchema/Model/JsonSchema.php
+++ b/src/JsonSchema/Model/JsonSchema.php
@@ -363,7 +363,7 @@ class JsonSchema
      *
      * @return JsonSchema[]|bool[]|null
      */
-    public function getDefinitions() : ?\ArrayObject
+    public function getDefinitions() : ?iterable
     {
         return $this->definitions;
     }
@@ -374,7 +374,7 @@ class JsonSchema
      *
      * @return self
      */
-    public function setDefinitions(?\ArrayObject $definitions) : self
+    public function setDefinitions(?iterable $definitions) : self
     {
         $this->definitions = $definitions;
         return $this;
@@ -384,7 +384,7 @@ class JsonSchema
      *
      * @return JsonSchema[]|bool[]|string[][]|null
      */
-    public function getDependencies() : ?\ArrayObject
+    public function getDependencies() : ?iterable
     {
         return $this->dependencies;
     }
@@ -395,7 +395,7 @@ class JsonSchema
      *
      * @return self
      */
-    public function setDependencies(?\ArrayObject $dependencies) : self
+    public function setDependencies(?iterable $dependencies) : self
     {
         $this->dependencies = $dependencies;
         return $this;
@@ -510,7 +510,7 @@ class JsonSchema
      *
      * @return JsonSchema[]|bool[]|null
      */
-    public function getUnevaluatedProperties() : ?\ArrayObject
+    public function getUnevaluatedProperties() : ?iterable
     {
         return $this->unevaluatedProperties;
     }
@@ -521,7 +521,7 @@ class JsonSchema
      *
      * @return self
      */
-    public function setUnevaluatedProperties(?\ArrayObject $unevaluatedProperties) : self
+    public function setUnevaluatedProperties(?iterable $unevaluatedProperties) : self
     {
         $this->unevaluatedProperties = $unevaluatedProperties;
         return $this;
@@ -531,7 +531,7 @@ class JsonSchema
      *
      * @return JsonSchema[]|bool[]|null
      */
-    public function getProperties() : ?\ArrayObject
+    public function getProperties() : ?iterable
     {
         return $this->properties;
     }
@@ -542,7 +542,7 @@ class JsonSchema
      *
      * @return self
      */
-    public function setProperties(?\ArrayObject $properties) : self
+    public function setProperties(?iterable $properties) : self
     {
         $this->properties = $properties;
         return $this;
@@ -552,7 +552,7 @@ class JsonSchema
      *
      * @return JsonSchema[]|bool[]|null
      */
-    public function getPatternProperties() : ?\ArrayObject
+    public function getPatternProperties() : ?iterable
     {
         return $this->patternProperties;
     }
@@ -563,7 +563,7 @@ class JsonSchema
      *
      * @return self
      */
-    public function setPatternProperties(?\ArrayObject $patternProperties) : self
+    public function setPatternProperties(?iterable $patternProperties) : self
     {
         $this->patternProperties = $patternProperties;
         return $this;
@@ -573,7 +573,7 @@ class JsonSchema
      *
      * @return JsonSchema[]|bool[]|null
      */
-    public function getDependentSchemas() : ?\ArrayObject
+    public function getDependentSchemas() : ?iterable
     {
         return $this->dependentSchemas;
     }
@@ -584,7 +584,7 @@ class JsonSchema
      *
      * @return self
      */
-    public function setDependentSchemas(?\ArrayObject $dependentSchemas) : self
+    public function setDependentSchemas(?iterable $dependentSchemas) : self
     {
         $this->dependentSchemas = $dependentSchemas;
         return $this;
@@ -951,7 +951,7 @@ class JsonSchema
      *
      * @return bool[]|null
      */
-    public function getDollarVocabulary() : ?\ArrayObject
+    public function getDollarVocabulary() : ?iterable
     {
         return $this->dollarVocabulary;
     }
@@ -962,7 +962,7 @@ class JsonSchema
      *
      * @return self
      */
-    public function setDollarVocabulary(?\ArrayObject $dollarVocabulary) : self
+    public function setDollarVocabulary(?iterable $dollarVocabulary) : self
     {
         $this->dollarVocabulary = $dollarVocabulary;
         return $this;
@@ -993,7 +993,7 @@ class JsonSchema
      *
      * @return JsonSchema[]|bool[]|null
      */
-    public function getDollarDefs() : ?\ArrayObject
+    public function getDollarDefs() : ?iterable
     {
         return $this->dollarDefs;
     }
@@ -1004,7 +1004,7 @@ class JsonSchema
      *
      * @return self
      */
-    public function setDollarDefs(?\ArrayObject $dollarDefs) : self
+    public function setDollarDefs(?iterable $dollarDefs) : self
     {
         $this->dollarDefs = $dollarDefs;
         return $this;
@@ -1518,7 +1518,7 @@ class JsonSchema
      *
      * @return string[][]|null
      */
-    public function getDependentRequired() : ?\ArrayObject
+    public function getDependentRequired() : ?iterable
     {
         return $this->dependentRequired;
     }
@@ -1529,7 +1529,7 @@ class JsonSchema
      *
      * @return self
      */
-    public function setDependentRequired(?\ArrayObject $dependentRequired) : self
+    public function setDependentRequired(?iterable $dependentRequired) : self
     {
         $this->dependentRequired = $dependentRequired;
         return $this;

--- a/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Model/Test.php
+++ b/src/JsonSchema/Tests/fixtures/test-not-strict/expected/Model/Test.php
@@ -96,7 +96,7 @@ class Test
      *
      * @return string[]|null
      */
-    public function getObject() : ?\ArrayObject
+    public function getObject() : ?iterable
     {
         return $this->object;
     }
@@ -107,7 +107,7 @@ class Test
      *
      * @return self
      */
-    public function setObject(?\ArrayObject $object) : self
+    public function setObject(?iterable $object) : self
     {
         $this->object = $object;
         return $this;

--- a/src/OpenApi2/JsonSchema/Model/Oauth2AccessCodeSecurity.php
+++ b/src/OpenApi2/JsonSchema/Model/Oauth2AccessCodeSecurity.php
@@ -80,7 +80,7 @@ class Oauth2AccessCodeSecurity extends \ArrayObject
     /**
      * @return string[]|null
      */
-    public function getScopes(): ?\ArrayObject
+    public function getScopes(): ?iterable
     {
         return $this->scopes;
     }
@@ -90,7 +90,7 @@ class Oauth2AccessCodeSecurity extends \ArrayObject
      *
      * @return self
      */
-    public function setScopes(?\ArrayObject $scopes): self
+    public function setScopes(?iterable $scopes): self
     {
         $this->scopes = $scopes;
 

--- a/src/OpenApi2/JsonSchema/Model/Oauth2ApplicationSecurity.php
+++ b/src/OpenApi2/JsonSchema/Model/Oauth2ApplicationSecurity.php
@@ -76,7 +76,7 @@ class Oauth2ApplicationSecurity extends \ArrayObject
     /**
      * @return string[]|null
      */
-    public function getScopes(): ?\ArrayObject
+    public function getScopes(): ?iterable
     {
         return $this->scopes;
     }
@@ -86,7 +86,7 @@ class Oauth2ApplicationSecurity extends \ArrayObject
      *
      * @return self
      */
-    public function setScopes(?\ArrayObject $scopes): self
+    public function setScopes(?iterable $scopes): self
     {
         $this->scopes = $scopes;
 

--- a/src/OpenApi2/JsonSchema/Model/Oauth2ImplicitSecurity.php
+++ b/src/OpenApi2/JsonSchema/Model/Oauth2ImplicitSecurity.php
@@ -76,7 +76,7 @@ class Oauth2ImplicitSecurity extends \ArrayObject
     /**
      * @return string[]|null
      */
-    public function getScopes(): ?\ArrayObject
+    public function getScopes(): ?iterable
     {
         return $this->scopes;
     }
@@ -86,7 +86,7 @@ class Oauth2ImplicitSecurity extends \ArrayObject
      *
      * @return self
      */
-    public function setScopes(?\ArrayObject $scopes): self
+    public function setScopes(?iterable $scopes): self
     {
         $this->scopes = $scopes;
 

--- a/src/OpenApi2/JsonSchema/Model/Oauth2PasswordSecurity.php
+++ b/src/OpenApi2/JsonSchema/Model/Oauth2PasswordSecurity.php
@@ -76,7 +76,7 @@ class Oauth2PasswordSecurity extends \ArrayObject
     /**
      * @return string[]|null
      */
-    public function getScopes(): ?\ArrayObject
+    public function getScopes(): ?iterable
     {
         return $this->scopes;
     }
@@ -86,7 +86,7 @@ class Oauth2PasswordSecurity extends \ArrayObject
      *
      * @return self
      */
-    public function setScopes(?\ArrayObject $scopes): self
+    public function setScopes(?iterable $scopes): self
     {
         $this->scopes = $scopes;
 

--- a/src/OpenApi2/JsonSchema/Model/OpenApi.php
+++ b/src/OpenApi2/JsonSchema/Model/OpenApi.php
@@ -294,7 +294,7 @@ class OpenApi extends \ArrayObject
      *
      * @return Schema[]|null
      */
-    public function getDefinitions(): ?\ArrayObject
+    public function getDefinitions(): ?iterable
     {
         return $this->definitions;
     }
@@ -306,7 +306,7 @@ class OpenApi extends \ArrayObject
      *
      * @return self
      */
-    public function setDefinitions(?\ArrayObject $definitions): self
+    public function setDefinitions(?iterable $definitions): self
     {
         $this->definitions = $definitions;
 
@@ -318,7 +318,7 @@ class OpenApi extends \ArrayObject
      *
      * @return BodyParameter[]|HeaderParameterSubSchema[]|FormDataParameterSubSchema[]|QueryParameterSubSchema[]|PathParameterSubSchema[]|null
      */
-    public function getParameters(): ?\ArrayObject
+    public function getParameters(): ?iterable
     {
         return $this->parameters;
     }
@@ -330,7 +330,7 @@ class OpenApi extends \ArrayObject
      *
      * @return self
      */
-    public function setParameters(?\ArrayObject $parameters): self
+    public function setParameters(?iterable $parameters): self
     {
         $this->parameters = $parameters;
 
@@ -342,7 +342,7 @@ class OpenApi extends \ArrayObject
      *
      * @return Response[]|null
      */
-    public function getResponses(): ?\ArrayObject
+    public function getResponses(): ?iterable
     {
         return $this->responses;
     }
@@ -354,7 +354,7 @@ class OpenApi extends \ArrayObject
      *
      * @return self
      */
-    public function setResponses(?\ArrayObject $responses): self
+    public function setResponses(?iterable $responses): self
     {
         $this->responses = $responses;
 
@@ -384,7 +384,7 @@ class OpenApi extends \ArrayObject
     /**
      * @return BasicAuthenticationSecurity[]|ApiKeySecurity[]|Oauth2ImplicitSecurity[]|Oauth2PasswordSecurity[]|Oauth2ApplicationSecurity[]|Oauth2AccessCodeSecurity[]|null
      */
-    public function getSecurityDefinitions(): ?\ArrayObject
+    public function getSecurityDefinitions(): ?iterable
     {
         return $this->securityDefinitions;
     }
@@ -394,7 +394,7 @@ class OpenApi extends \ArrayObject
      *
      * @return self
      */
-    public function setSecurityDefinitions(?\ArrayObject $securityDefinitions): self
+    public function setSecurityDefinitions(?iterable $securityDefinitions): self
     {
         $this->securityDefinitions = $securityDefinitions;
 

--- a/src/OpenApi2/JsonSchema/Model/Response.php
+++ b/src/OpenApi2/JsonSchema/Model/Response.php
@@ -72,7 +72,7 @@ class Response extends \ArrayObject
     /**
      * @return Header[]|null
      */
-    public function getHeaders(): ?\ArrayObject
+    public function getHeaders(): ?iterable
     {
         return $this->headers;
     }
@@ -82,7 +82,7 @@ class Response extends \ArrayObject
      *
      * @return self
      */
-    public function setHeaders(?\ArrayObject $headers): self
+    public function setHeaders(?iterable $headers): self
     {
         $this->headers = $headers;
 
@@ -92,7 +92,7 @@ class Response extends \ArrayObject
     /**
      * @return mixed[]|null
      */
-    public function getExamples(): ?\ArrayObject
+    public function getExamples(): ?iterable
     {
         return $this->examples;
     }
@@ -102,7 +102,7 @@ class Response extends \ArrayObject
      *
      * @return self
      */
-    public function setExamples(?\ArrayObject $examples): self
+    public function setExamples(?iterable $examples): self
     {
         $this->examples = $examples;
 

--- a/src/OpenApi2/JsonSchema/Model/Schema.php
+++ b/src/OpenApi2/JsonSchema/Model/Schema.php
@@ -618,7 +618,7 @@ class Schema extends \ArrayObject
     /**
      * @return Schema[]|null
      */
-    public function getProperties(): ?\ArrayObject
+    public function getProperties(): ?iterable
     {
         return $this->properties;
     }
@@ -628,7 +628,7 @@ class Schema extends \ArrayObject
      *
      * @return self
      */
-    public function setProperties(?\ArrayObject $properties): self
+    public function setProperties(?iterable $properties): self
     {
         $this->properties = $properties;
 

--- a/src/OpenApi2/Tests/fixtures/body-parameter/expected/Model/Schema.php
+++ b/src/OpenApi2/Tests/fixtures/body-parameter/expected/Model/Schema.php
@@ -162,7 +162,7 @@ class Schema
      *
      * @return string[]
      */
-    public function getMapProperty() : \ArrayObject
+    public function getMapProperty() : iterable
     {
         return $this->mapProperty;
     }
@@ -173,7 +173,7 @@ class Schema
      *
      * @return self
      */
-    public function setMapProperty(\ArrayObject $mapProperty) : self
+    public function setMapProperty(iterable $mapProperty) : self
     {
         $this->mapProperty = $mapProperty;
         return $this;

--- a/src/OpenApi2/Tests/fixtures/content-type/expected/Model/Schema.php
+++ b/src/OpenApi2/Tests/fixtures/content-type/expected/Model/Schema.php
@@ -162,7 +162,7 @@ class Schema
      *
      * @return string[]
      */
-    public function getMapProperty() : \ArrayObject
+    public function getMapProperty() : iterable
     {
         return $this->mapProperty;
     }
@@ -173,7 +173,7 @@ class Schema
      *
      * @return self
      */
-    public function setMapProperty(\ArrayObject $mapProperty) : self
+    public function setMapProperty(iterable $mapProperty) : self
     {
         $this->mapProperty = $mapProperty;
         return $this;

--- a/src/OpenApi2/Tests/fixtures/model-in-response/expected/Model/Schema.php
+++ b/src/OpenApi2/Tests/fixtures/model-in-response/expected/Model/Schema.php
@@ -135,7 +135,7 @@ class Schema
      *
      * @return string[]
      */
-    public function getMapProperty() : \ArrayObject
+    public function getMapProperty() : iterable
     {
         return $this->mapProperty;
     }
@@ -146,7 +146,7 @@ class Schema
      *
      * @return self
      */
-    public function setMapProperty(\ArrayObject $mapProperty) : self
+    public function setMapProperty(iterable $mapProperty) : self
     {
         $this->mapProperty = $mapProperty;
         return $this;

--- a/src/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Model/Schema.php
+++ b/src/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Model/Schema.php
@@ -162,7 +162,7 @@ class Schema
      *
      * @return string[]
      */
-    public function getMapProperty() : \ArrayObject
+    public function getMapProperty() : iterable
     {
         return $this->mapProperty;
     }
@@ -173,7 +173,7 @@ class Schema
      *
      * @return self
      */
-    public function setMapProperty(\ArrayObject $mapProperty) : self
+    public function setMapProperty(iterable $mapProperty) : self
     {
         $this->mapProperty = $mapProperty;
         return $this;

--- a/src/OpenApi3/JsonSchema/Model/AuthorizationCodeOAuthFlow.php
+++ b/src/OpenApi3/JsonSchema/Model/AuthorizationCodeOAuthFlow.php
@@ -92,7 +92,7 @@ class AuthorizationCodeOAuthFlow extends \ArrayObject
     /**
      * @return string[]|null
      */
-    public function getScopes(): ?\ArrayObject
+    public function getScopes(): ?iterable
     {
         return $this->scopes;
     }
@@ -102,7 +102,7 @@ class AuthorizationCodeOAuthFlow extends \ArrayObject
      *
      * @return self
      */
-    public function setScopes(?\ArrayObject $scopes): self
+    public function setScopes(?iterable $scopes): self
     {
         $this->scopes = $scopes;
 

--- a/src/OpenApi3/JsonSchema/Model/ClientCredentialsFlow.php
+++ b/src/OpenApi3/JsonSchema/Model/ClientCredentialsFlow.php
@@ -68,7 +68,7 @@ class ClientCredentialsFlow extends \ArrayObject
     /**
      * @return string[]|null
      */
-    public function getScopes(): ?\ArrayObject
+    public function getScopes(): ?iterable
     {
         return $this->scopes;
     }
@@ -78,7 +78,7 @@ class ClientCredentialsFlow extends \ArrayObject
      *
      * @return self
      */
-    public function setScopes(?\ArrayObject $scopes): self
+    public function setScopes(?iterable $scopes): self
     {
         $this->scopes = $scopes;
 

--- a/src/OpenApi3/JsonSchema/Model/Discriminator.php
+++ b/src/OpenApi3/JsonSchema/Model/Discriminator.php
@@ -44,7 +44,7 @@ class Discriminator
     /**
      * @return string[]|null
      */
-    public function getMapping(): ?\ArrayObject
+    public function getMapping(): ?iterable
     {
         return $this->mapping;
     }
@@ -54,7 +54,7 @@ class Discriminator
      *
      * @return self
      */
-    public function setMapping(?\ArrayObject $mapping): self
+    public function setMapping(?iterable $mapping): self
     {
         $this->mapping = $mapping;
 

--- a/src/OpenApi3/JsonSchema/Model/Encoding.php
+++ b/src/OpenApi3/JsonSchema/Model/Encoding.php
@@ -56,7 +56,7 @@ class Encoding
     /**
      * @return Header[]|null
      */
-    public function getHeaders(): ?\ArrayObject
+    public function getHeaders(): ?iterable
     {
         return $this->headers;
     }
@@ -66,7 +66,7 @@ class Encoding
      *
      * @return self
      */
-    public function setHeaders(?\ArrayObject $headers): self
+    public function setHeaders(?iterable $headers): self
     {
         $this->headers = $headers;
 

--- a/src/OpenApi3/JsonSchema/Model/Header.php
+++ b/src/OpenApi3/JsonSchema/Model/Header.php
@@ -220,7 +220,7 @@ class Header extends \ArrayObject
     /**
      * @return MediaType[]|null
      */
-    public function getContent(): ?\ArrayObject
+    public function getContent(): ?iterable
     {
         return $this->content;
     }
@@ -230,7 +230,7 @@ class Header extends \ArrayObject
      *
      * @return self
      */
-    public function setContent(?\ArrayObject $content): self
+    public function setContent(?iterable $content): self
     {
         $this->content = $content;
 
@@ -260,7 +260,7 @@ class Header extends \ArrayObject
     /**
      * @return Example[]|Reference[]|null
      */
-    public function getExamples(): ?\ArrayObject
+    public function getExamples(): ?iterable
     {
         return $this->examples;
     }
@@ -270,7 +270,7 @@ class Header extends \ArrayObject
      *
      * @return self
      */
-    public function setExamples(?\ArrayObject $examples): self
+    public function setExamples(?iterable $examples): self
     {
         $this->examples = $examples;
 

--- a/src/OpenApi3/JsonSchema/Model/ImplicitOAuthFlow.php
+++ b/src/OpenApi3/JsonSchema/Model/ImplicitOAuthFlow.php
@@ -68,7 +68,7 @@ class ImplicitOAuthFlow extends \ArrayObject
     /**
      * @return string[]|null
      */
-    public function getScopes(): ?\ArrayObject
+    public function getScopes(): ?iterable
     {
         return $this->scopes;
     }
@@ -78,7 +78,7 @@ class ImplicitOAuthFlow extends \ArrayObject
      *
      * @return self
      */
-    public function setScopes(?\ArrayObject $scopes): self
+    public function setScopes(?iterable $scopes): self
     {
         $this->scopes = $scopes;
 

--- a/src/OpenApi3/JsonSchema/Model/Link.php
+++ b/src/OpenApi3/JsonSchema/Model/Link.php
@@ -80,7 +80,7 @@ class Link extends \ArrayObject
     /**
      * @return mixed[]|null
      */
-    public function getParameters(): ?\ArrayObject
+    public function getParameters(): ?iterable
     {
         return $this->parameters;
     }
@@ -90,7 +90,7 @@ class Link extends \ArrayObject
      *
      * @return self
      */
-    public function setParameters(?\ArrayObject $parameters): self
+    public function setParameters(?iterable $parameters): self
     {
         $this->parameters = $parameters;
 

--- a/src/OpenApi3/JsonSchema/Model/MediaType.php
+++ b/src/OpenApi3/JsonSchema/Model/MediaType.php
@@ -72,7 +72,7 @@ class MediaType extends \ArrayObject
     /**
      * @return Example[]|Reference[]|null
      */
-    public function getExamples(): ?\ArrayObject
+    public function getExamples(): ?iterable
     {
         return $this->examples;
     }
@@ -82,7 +82,7 @@ class MediaType extends \ArrayObject
      *
      * @return self
      */
-    public function setExamples(?\ArrayObject $examples): self
+    public function setExamples(?iterable $examples): self
     {
         $this->examples = $examples;
 
@@ -92,7 +92,7 @@ class MediaType extends \ArrayObject
     /**
      * @return Encoding[]|null
      */
-    public function getEncoding(): ?\ArrayObject
+    public function getEncoding(): ?iterable
     {
         return $this->encoding;
     }
@@ -102,7 +102,7 @@ class MediaType extends \ArrayObject
      *
      * @return self
      */
-    public function setEncoding(?\ArrayObject $encoding): self
+    public function setEncoding(?iterable $encoding): self
     {
         $this->encoding = $encoding;
 

--- a/src/OpenApi3/JsonSchema/Model/Operation.php
+++ b/src/OpenApi3/JsonSchema/Model/Operation.php
@@ -224,7 +224,7 @@ class Operation extends \ArrayObject
     /**
      * @return mixed[][]|Reference[]|null
      */
-    public function getCallbacks(): ?\ArrayObject
+    public function getCallbacks(): ?iterable
     {
         return $this->callbacks;
     }
@@ -234,7 +234,7 @@ class Operation extends \ArrayObject
      *
      * @return self
      */
-    public function setCallbacks(?\ArrayObject $callbacks): self
+    public function setCallbacks(?iterable $callbacks): self
     {
         $this->callbacks = $callbacks;
 

--- a/src/OpenApi3/JsonSchema/Model/Parameter.php
+++ b/src/OpenApi3/JsonSchema/Model/Parameter.php
@@ -268,7 +268,7 @@ class Parameter extends \ArrayObject
     /**
      * @return MediaType[]|null
      */
-    public function getContent(): ?\ArrayObject
+    public function getContent(): ?iterable
     {
         return $this->content;
     }
@@ -278,7 +278,7 @@ class Parameter extends \ArrayObject
      *
      * @return self
      */
-    public function setContent(?\ArrayObject $content): self
+    public function setContent(?iterable $content): self
     {
         $this->content = $content;
 
@@ -308,7 +308,7 @@ class Parameter extends \ArrayObject
     /**
      * @return Example[]|Reference[]|null
      */
-    public function getExamples(): ?\ArrayObject
+    public function getExamples(): ?iterable
     {
         return $this->examples;
     }
@@ -318,7 +318,7 @@ class Parameter extends \ArrayObject
      *
      * @return self
      */
-    public function setExamples(?\ArrayObject $examples): self
+    public function setExamples(?iterable $examples): self
     {
         $this->examples = $examples;
 

--- a/src/OpenApi3/JsonSchema/Model/PasswordOAuthFlow.php
+++ b/src/OpenApi3/JsonSchema/Model/PasswordOAuthFlow.php
@@ -68,7 +68,7 @@ class PasswordOAuthFlow extends \ArrayObject
     /**
      * @return string[]|null
      */
-    public function getScopes(): ?\ArrayObject
+    public function getScopes(): ?iterable
     {
         return $this->scopes;
     }
@@ -78,7 +78,7 @@ class PasswordOAuthFlow extends \ArrayObject
      *
      * @return self
      */
-    public function setScopes(?\ArrayObject $scopes): self
+    public function setScopes(?iterable $scopes): self
     {
         $this->scopes = $scopes;
 

--- a/src/OpenApi3/JsonSchema/Model/RequestBody.php
+++ b/src/OpenApi3/JsonSchema/Model/RequestBody.php
@@ -48,7 +48,7 @@ class RequestBody extends \ArrayObject
     /**
      * @return MediaType[]|null
      */
-    public function getContent(): ?\ArrayObject
+    public function getContent(): ?iterable
     {
         return $this->content;
     }
@@ -58,7 +58,7 @@ class RequestBody extends \ArrayObject
      *
      * @return self
      */
-    public function setContent(?\ArrayObject $content): self
+    public function setContent(?iterable $content): self
     {
         $this->content = $content;
 

--- a/src/OpenApi3/JsonSchema/Model/Response.php
+++ b/src/OpenApi3/JsonSchema/Model/Response.php
@@ -52,7 +52,7 @@ class Response extends \ArrayObject
     /**
      * @return Header[]|Reference[]|null
      */
-    public function getHeaders(): ?\ArrayObject
+    public function getHeaders(): ?iterable
     {
         return $this->headers;
     }
@@ -62,7 +62,7 @@ class Response extends \ArrayObject
      *
      * @return self
      */
-    public function setHeaders(?\ArrayObject $headers): self
+    public function setHeaders(?iterable $headers): self
     {
         $this->headers = $headers;
 
@@ -72,7 +72,7 @@ class Response extends \ArrayObject
     /**
      * @return MediaType[]|null
      */
-    public function getContent(): ?\ArrayObject
+    public function getContent(): ?iterable
     {
         return $this->content;
     }
@@ -82,7 +82,7 @@ class Response extends \ArrayObject
      *
      * @return self
      */
-    public function setContent(?\ArrayObject $content): self
+    public function setContent(?iterable $content): self
     {
         $this->content = $content;
 
@@ -92,7 +92,7 @@ class Response extends \ArrayObject
     /**
      * @return Link[]|Reference[]|null
      */
-    public function getLinks(): ?\ArrayObject
+    public function getLinks(): ?iterable
     {
         return $this->links;
     }
@@ -102,7 +102,7 @@ class Response extends \ArrayObject
      *
      * @return self
      */
-    public function setLinks(?\ArrayObject $links): self
+    public function setLinks(?iterable $links): self
     {
         $this->links = $links;
 

--- a/src/OpenApi3/JsonSchema/Model/Schema.php
+++ b/src/OpenApi3/JsonSchema/Model/Schema.php
@@ -596,7 +596,7 @@ class Schema extends \ArrayObject
     /**
      * @return Schema[]|Reference[]|null
      */
-    public function getProperties(): ?\ArrayObject
+    public function getProperties(): ?iterable
     {
         return $this->properties;
     }
@@ -606,7 +606,7 @@ class Schema extends \ArrayObject
      *
      * @return self
      */
-    public function setProperties(?\ArrayObject $properties): self
+    public function setProperties(?iterable $properties): self
     {
         $this->properties = $properties;
 

--- a/src/OpenApi3/JsonSchema/Model/Server.php
+++ b/src/OpenApi3/JsonSchema/Model/Server.php
@@ -68,7 +68,7 @@ class Server extends \ArrayObject
     /**
      * @return ServerVariable[]|null
      */
-    public function getVariables(): ?\ArrayObject
+    public function getVariables(): ?iterable
     {
         return $this->variables;
     }
@@ -78,7 +78,7 @@ class Server extends \ArrayObject
      *
      * @return self
      */
-    public function setVariables(?\ArrayObject $variables): self
+    public function setVariables(?iterable $variables): self
     {
         $this->variables = $variables;
 

--- a/src/OpenApi3/Tests/fixtures/body-parameter/expected/Model/Schema.php
+++ b/src/OpenApi3/Tests/fixtures/body-parameter/expected/Model/Schema.php
@@ -162,7 +162,7 @@ class Schema
      *
      * @return string[]
      */
-    public function getMapProperty() : \ArrayObject
+    public function getMapProperty() : iterable
     {
         return $this->mapProperty;
     }
@@ -173,7 +173,7 @@ class Schema
      *
      * @return self
      */
-    public function setMapProperty(\ArrayObject $mapProperty) : self
+    public function setMapProperty(iterable $mapProperty) : self
     {
         $this->mapProperty = $mapProperty;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/content-type/expected/Model/Schema.php
+++ b/src/OpenApi3/Tests/fixtures/content-type/expected/Model/Schema.php
@@ -162,7 +162,7 @@ class Schema
      *
      * @return string[]
      */
-    public function getMapProperty() : \ArrayObject
+    public function getMapProperty() : iterable
     {
         return $this->mapProperty;
     }
@@ -173,7 +173,7 @@ class Schema
      *
      * @return self
      */
-    public function setMapProperty(\ArrayObject $mapProperty) : self
+    public function setMapProperty(iterable $mapProperty) : self
     {
         $this->mapProperty = $mapProperty;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/github/expected/Model/BaseGist.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Model/BaseGist.php
@@ -297,7 +297,7 @@ class BaseGist
      *
      * @return BaseGistFilesItem[]
      */
-    public function getFiles() : \ArrayObject
+    public function getFiles() : iterable
     {
         return $this->files;
     }
@@ -308,7 +308,7 @@ class BaseGist
      *
      * @return self
      */
-    public function setFiles(\ArrayObject $files) : self
+    public function setFiles(iterable $files) : self
     {
         $this->files = $files;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/github/expected/Model/GistFull.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Model/GistFull.php
@@ -303,7 +303,7 @@ class GistFull
      *
      * @return GistSimpleFilesItem[]
      */
-    public function getFiles() : \ArrayObject
+    public function getFiles() : iterable
     {
         return $this->files;
     }
@@ -314,7 +314,7 @@ class GistFull
      *
      * @return self
      */
-    public function setFiles(\ArrayObject $files) : self
+    public function setFiles(iterable $files) : self
     {
         $this->files = $files;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/github/expected/Model/GistFullforkOf.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Model/GistFullforkOf.php
@@ -285,7 +285,7 @@ class GistFullforkOf
      *
      * @return GistSimpleFilesItem[]
      */
-    public function getFiles() : \ArrayObject
+    public function getFiles() : iterable
     {
         return $this->files;
     }
@@ -296,7 +296,7 @@ class GistFullforkOf
      *
      * @return self
      */
-    public function setFiles(\ArrayObject $files) : self
+    public function setFiles(iterable $files) : self
     {
         $this->files = $files;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/github/expected/Model/GistSimple.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Model/GistSimple.php
@@ -285,7 +285,7 @@ class GistSimple
      *
      * @return GistSimpleFilesItem[]
      */
-    public function getFiles() : \ArrayObject
+    public function getFiles() : iterable
     {
         return $this->files;
     }
@@ -296,7 +296,7 @@ class GistSimple
      *
      * @return self
      */
-    public function setFiles(\ArrayObject $files) : self
+    public function setFiles(iterable $files) : self
     {
         $this->files = $files;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/github/expected/Model/GistsGistIdPatchBody.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Model/GistsGistIdPatchBody.php
@@ -42,7 +42,7 @@ class GistsGistIdPatchBody
      *
      * @return GistsGistIdPatchBodyFilesItem[]
      */
-    public function getFiles() : \ArrayObject
+    public function getFiles() : iterable
     {
         return $this->files;
     }
@@ -53,7 +53,7 @@ class GistsGistIdPatchBody
      *
      * @return self
      */
-    public function setFiles(\ArrayObject $files) : self
+    public function setFiles(iterable $files) : self
     {
         $this->files = $files;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/github/expected/Model/GistsPostBody.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Model/GistsPostBody.php
@@ -48,7 +48,7 @@ class GistsPostBody
      *
      * @return GistsPostBodyFilesItem[]
      */
-    public function getFiles() : \ArrayObject
+    public function getFiles() : iterable
     {
         return $this->files;
     }
@@ -59,7 +59,7 @@ class GistsPostBody
      *
      * @return self
      */
-    public function setFiles(\ArrayObject $files) : self
+    public function setFiles(iterable $files) : self
     {
         $this->files = $files;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/github/expected/Model/ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBody.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Model/ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBody.php
@@ -42,7 +42,7 @@ class ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBody
      *
      * @return string[]
      */
-    public function getInputs() : \ArrayObject
+    public function getInputs() : iterable
     {
         return $this->inputs;
     }
@@ -53,7 +53,7 @@ class ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBody
      *
      * @return self
      */
-    public function setInputs(\ArrayObject $inputs) : self
+    public function setInputs(iterable $inputs) : self
     {
         $this->inputs = $inputs;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/github/expected/Model/ReposOwnerRepoDispatchesPostBody.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Model/ReposOwnerRepoDispatchesPostBody.php
@@ -42,7 +42,7 @@ class ReposOwnerRepoDispatchesPostBody
      *
      * @return mixed[]
      */
-    public function getClientPayload() : \ArrayObject
+    public function getClientPayload() : iterable
     {
         return $this->clientPayload;
     }
@@ -53,7 +53,7 @@ class ReposOwnerRepoDispatchesPostBody
      *
      * @return self
      */
-    public function setClientPayload(\ArrayObject $clientPayload) : self
+    public function setClientPayload(iterable $clientPayload) : self
     {
         $this->clientPayload = $clientPayload;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/model-in-response/expected/Model/Schema.php
+++ b/src/OpenApi3/Tests/fixtures/model-in-response/expected/Model/Schema.php
@@ -135,7 +135,7 @@ class Schema
      *
      * @return string[]
      */
-    public function getMapProperty() : \ArrayObject
+    public function getMapProperty() : iterable
     {
         return $this->mapProperty;
     }
@@ -146,7 +146,7 @@ class Schema
      *
      * @return self
      */
-    public function setMapProperty(\ArrayObject $mapProperty) : self
+    public function setMapProperty(iterable $mapProperty) : self
     {
         $this->mapProperty = $mapProperty;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/twitter/expected/Model/InvalidRequestProblemErrorsItem.php
+++ b/src/OpenApi3/Tests/fixtures/twitter/expected/Model/InvalidRequestProblemErrorsItem.php
@@ -21,7 +21,7 @@ class InvalidRequestProblemErrorsItem
      *
      * @return string[][]
      */
-    public function getParameters() : \ArrayObject
+    public function getParameters() : iterable
     {
         return $this->parameters;
     }
@@ -32,7 +32,7 @@ class InvalidRequestProblemErrorsItem
      *
      * @return self
      */
-    public function setParameters(\ArrayObject $parameters) : self
+    public function setParameters(iterable $parameters) : self
     {
         $this->parameters = $parameters;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Model/Schema.php
+++ b/src/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Model/Schema.php
@@ -162,7 +162,7 @@ class Schema
      *
      * @return string[]
      */
-    public function getMapProperty() : \ArrayObject
+    public function getMapProperty() : iterable
     {
         return $this->mapProperty;
     }
@@ -173,7 +173,7 @@ class Schema
      *
      * @return self
      */
-    public function setMapProperty(\ArrayObject $mapProperty) : self
+    public function setMapProperty(iterable $mapProperty) : self
     {
         $this->mapProperty = $mapProperty;
         return $this;

--- a/src/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Model/InvalidRequestProblemErrorsItem.php
+++ b/src/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Model/InvalidRequestProblemErrorsItem.php
@@ -21,7 +21,7 @@ class InvalidRequestProblemErrorsItem
      *
      * @return string[][]
      */
-    public function getParameters() : \ArrayObject
+    public function getParameters() : iterable
     {
         return $this->parameters;
     }
@@ -32,7 +32,7 @@ class InvalidRequestProblemErrorsItem
      *
      * @return self
      */
-    public function setParameters(\ArrayObject $parameters) : self
+    public function setParameters(iterable $parameters) : self
     {
         $this->parameters = $parameters;
         return $this;


### PR DESCRIPTION
Use `iterable` type hint instead `\ArrayAccess` in order to allow both `array` & `\ArrayObject`.