### PR TITLE
Exclude tests from classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,10 @@
     "autoload": {
         "psr-4": {
             "Jane\\": "src/"
-        }
+        },
+        "exclude-from-classmap": [
+            "*/Tests/"
+        ]
     },
     "autoload-dev": {
         "classmap": [


### PR DESCRIPTION
Avoid composer warnings for almost all tests classes:
```
Deprecation Notice: Class Jane\OpenApi3\Tests\Expected\Endpoint\GetAnotherThing located in ./vendor/jane-php/jane-php/src/OpenApi3/Tests/fixtures/operations/expected/Endpoint/GetAnotherThing.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```