### PR TITLE
Use copy transformer for sibling arrays

### DIFF
--- a/src/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/AutoMapper/Tests/AutoMapperTest.php
@@ -627,4 +627,16 @@ class AutoMapperTest extends AutoMapperBaseTest
         $automapper = AutoMapper::create(false, null, null, 'Mapper_', true, false);
         $automapper->getMapper(Fixtures\User::class, Fixtures\UserDTO::class);
     }
+
+    public function testWithMixedArray(): void
+    {
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $user->setProperties(['foo' => 'bar']);
+
+        /** @var Fixtures\UserDTOProperties $dto */
+        $dto = $this->autoMapper->map($user, Fixtures\UserDTOProperties::class);
+
+        self::assertInstanceOf(Fixtures\UserDTOProperties::class, $dto);
+        self::assertSame(['foo' => 'bar'], $dto->getProperties());
+    }
 }

--- a/src/AutoMapper/Tests/Fixtures/User.php
+++ b/src/AutoMapper/Tests/Fixtures/User.php
@@ -49,6 +49,11 @@ class User
      */
     public $languages;
 
+    /**
+     * @var mixed[]
+     */
+    protected $properties = [];
+
     public function __construct($id, $name, $age)
     {
         $this->id = $id;
@@ -66,5 +71,15 @@ class User
     public function getId()
     {
         return $this->id;
+    }
+
+    public function getProperties(): iterable
+    {
+        return $this->properties;
+    }
+
+    public function setProperties(iterable $properties): void
+    {
+        $this->properties = $properties;
     }
 }

--- a/src/AutoMapper/Tests/Fixtures/UserDTOProperties.php
+++ b/src/AutoMapper/Tests/Fixtures/UserDTOProperties.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jane\AutoMapper\Tests\Fixtures;
+
+class UserDTOProperties
+{
+    /**
+     * @var mixed[]
+     */
+    protected $properties = [];
+
+    public function getProperties(): iterable
+    {
+        return $this->properties;
+    }
+
+    public function setProperties(iterable $properties): void
+    {
+        $this->properties = $properties;
+    }
+}

--- a/src/AutoMapper/Tests/Transformer/ArrayTransformerFactoryTest.php
+++ b/src/AutoMapper/Tests/Transformer/ArrayTransformerFactoryTest.php
@@ -3,9 +3,9 @@
 namespace Jane\AutoMapper\Tests\Transformer;
 
 use Jane\AutoMapper\MapperMetadata;
-use Jane\AutoMapper\Transformer\ArrayTransformer;
 use Jane\AutoMapper\Transformer\ArrayTransformerFactory;
 use Jane\AutoMapper\Transformer\ChainTransformerFactory;
+use Jane\AutoMapper\Transformer\CopyTransformer;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -19,7 +19,7 @@ class ArrayTransformerFactoryTest extends TestCase
 
         $transformer = $factory->getTransformer([new Type('array', false, null, true)], [new Type('array', false, null, true)], $mapperMetadata);
 
-        self::assertInstanceOf(ArrayTransformer::class, $transformer);
+        self::assertInstanceOf(CopyTransformer::class, $transformer);
     }
 
     public function testNoTransformerTargetNoCollection(): void

--- a/src/AutoMapper/Transformer/ArrayTransformerFactory.php
+++ b/src/AutoMapper/Transformer/ArrayTransformerFactory.php
@@ -33,10 +33,10 @@ final class ArrayTransformerFactory extends AbstractUniqueTypeTransformerFactory
         }
 
         if (null === $sourceType->getCollectionValueType() || null === $targetType->getCollectionValueType()) {
-            $subItemTransformer = new CopyTransformer();
-        } else {
-            $subItemTransformer = $this->chainTransformerFactory->getTransformer([$sourceType->getCollectionValueType()], [$targetType->getCollectionValueType()], $mapperMetadata);
+            return new CopyTransformer();
         }
+
+        $subItemTransformer = $this->chainTransformerFactory->getTransformer([$sourceType->getCollectionValueType()], [$targetType->getCollectionValueType()], $mapperMetadata);
 
         if (null !== $subItemTransformer) {
             return new ArrayTransformer($subItemTransformer);


### PR DESCRIPTION
When source & target are equals, directly use a `CopyTransformer` instead of a `ArrayTransformer` containing a `CopyTransformer` which don't preserve keys.