### PR TITLE
Fixed array items with mixed types

### DIFF
--- a/src/JsonSchema/Guesser/JsonSchema/ArrayGuesser.php
+++ b/src/JsonSchema/Guesser/JsonSchema/ArrayGuesser.php
@@ -43,7 +43,7 @@ class ArrayGuesser implements GuesserInterface, TypeGuesserInterface, ChainGuess
     {
         $items = $object->getItems();
 
-        if (null === $items) {
+        if (null === $items || (\is_array($items) && 0 === \count($items))) {
             return new ArrayType($object, new Type($object, 'mixed'));
         }
 


### PR DESCRIPTION
When having a schema as following:
```json
{
  "schema": {
    "properties": {
      "comments": {
        "items": {},
        "type": "array"
      }
    }
  }
}
```

We had an empty array which was not matched as empty, this PR fix it and permit to be recognize as `mixed` type for this array.