### PR TITLE
Supports both inflector v1 & v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "doctrine/inflector": "^2.0",
+        "doctrine/inflector": "^1.4 || ^2.0",
         "league/uri": "^6.0",
         "nikic/php-parser": "^4.0",
         "php-http/client-common": "^2.0",

--- a/src/AutoMapper/composer.json
+++ b/src/AutoMapper/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "doctrine/inflector": "^2.0",
+        "doctrine/inflector": "^1.4 || ^2.0",
         "nikic/php-parser": "^4.0",
         "symfony/property-info": "^5.1"
     },

--- a/src/JsonSchema/composer.json
+++ b/src/JsonSchema/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "doctrine/inflector": "^2.0",
+        "doctrine/inflector": "^1.4 || ^2.0",
         "jane-php/json-schema-runtime": "~6.1.0",
         "nikic/php-parser": "^4.0",
         "symfony/console": "^4.4 || ^5.0",


### PR DESCRIPTION
As `doctrine/orm` (& maybe a few others) doesn't support `doctrine/inflector` in its latest stable release yet, let's accept `doctrine/inflector` 1.x.