### PR TITLE
Nullable property handling

### DIFF
--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -4,13 +4,8 @@ namespace Jane\JsonSchema\Generator\Normalizer;
 
 use Jane\JsonSchema\Generator\Context\Context;
 use Jane\JsonSchema\Generator\Naming;
-use Jane\JsonSchema\Guesser\Guess\ArrayType;
 use Jane\JsonSchema\Guesser\Guess\ClassGuess;
-use Jane\JsonSchema\Guesser\Guess\DateTimeType;
-use Jane\JsonSchema\Guesser\Guess\MapType;
 use Jane\JsonSchema\Guesser\Guess\MultipleType;
-use Jane\JsonSchema\Guesser\Guess\ObjectType;
-use Jane\JsonSchema\Guesser\Guess\PatternMultipleType;
 use Jane\JsonSchema\Guesser\Guess\Property;
 use Jane\JsonSchema\Guesser\Guess\Type;
 use PhpParser\Node\Arg;
@@ -102,25 +97,17 @@ trait NormalizerGenerator
                 if (!$context->isStrict() || $property->isNullable() ||
                     ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) ||
                     ($property->getType()->getName() === Type::TYPE_NULL)) {
-                    if (!$context->isStrict() || ($property->getType() instanceof DateTimeType ||
-                        $property->getType() instanceof MapType ||
-                        $property->getType() instanceof ObjectType ||
-                        $property->getType() instanceof PatternMultipleType ||
-                        $property->getType() instanceof ArrayType)) {
-                        $statements[] = new Stmt\If_(
-                            new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $propertyVar),
-                            [
-                                'stmts' => $normalizationStatements,
-                            ]
-                        );
+                    $statements[] = new Stmt\If_(
+                        new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $propertyVar),
+                        [
+                            'stmts' => $normalizationStatements,
+                        ]
+                    );
 
-                        if (!$skipNullValues) {
-                            $statements[] = new Stmt\Else_(
-                                [new Stmt\Expression(new Expr\Assign(new Expr\ArrayDimFetch($dataVariable, new Scalar\String_($property->getName())), new Expr\ConstFetch(new Name('null'))))]
-                            );
-                        }
-                    } else {
-                        $statements = array_merge($statements, $normalizationStatements);
+                    if (!$skipNullValues) {
+                        $statements[] = new Stmt\Else_(
+                            [new Stmt\Expression(new Expr\Assign(new Expr\ArrayDimFetch($dataVariable, new Scalar\String_($property->getName())), new Expr\ConstFetch(new Name('null'))))]
+                        );
                     }
 
                     continue;

--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -99,15 +99,14 @@ trait NormalizerGenerator
 
                 $normalizationStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\ArrayDimFetch($dataVariable, new Scalar\String_($property->getName())), $outputVar));
 
-                if (!$context->isStrict() || $property->isNullable() || ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) || ($property->getType()->getName() === Type::TYPE_NULL)) {
-                    if (!$context->isStrict() || ($property->getType()->getName() !== Type::TYPE_NULL &&
-                        (
-                            $property->getType() instanceof DateTimeType ||
-                            $property->getType() instanceof MapType ||
-                            $property->getType() instanceof ObjectType ||
-                            $property->getType() instanceof PatternMultipleType ||
-                            $property->getType() instanceof ArrayType
-                        ))) {
+                if (!$context->isStrict() || $property->isNullable() ||
+                    ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) ||
+                    ($property->getType()->getName() === Type::TYPE_NULL)) {
+                    if (!$context->isStrict() || ($property->getType() instanceof DateTimeType ||
+                        $property->getType() instanceof MapType ||
+                        $property->getType() instanceof ObjectType ||
+                        $property->getType() instanceof PatternMultipleType ||
+                        $property->getType() instanceof ArrayType)) {
                         $statements[] = new Stmt\If_(
                             new Expr\BinaryOp\NotIdentical(new Expr\ConstFetch(new Name('null')), $propertyVar),
                             [

--- a/src/JsonSchema/Tests/fixtures/array-object-nullable/expected/Normalizer/DocumentNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/array-object-nullable/expected/Normalizer/DocumentNormalizer.php
@@ -54,17 +54,19 @@ class DocumentNormalizer implements DenormalizerInterface, NormalizerInterface, 
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $value = $object->getAttributes();
-        if (is_array($object->getAttributes())) {
-            $values = array();
-            foreach ($object->getAttributes() as $value_1) {
-                $values[] = $this->normalizer->normalize($value_1, 'json', $context);
-            }
-            $value = $values;
-        } elseif (is_null($object->getAttributes())) {
+        if (null !== $object->getAttributes()) {
             $value = $object->getAttributes();
+            if (is_array($object->getAttributes())) {
+                $values = array();
+                foreach ($object->getAttributes() as $value_1) {
+                    $values[] = $this->normalizer->normalize($value_1, 'json', $context);
+                }
+                $value = $values;
+            } elseif (is_null($object->getAttributes())) {
+                $value = $object->getAttributes();
+            }
+            $data['attributes'] = $value;
         }
-        $data['attributes'] = $value;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/date-format/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/date-format/expected/Normalizer/TestNormalizer.php
@@ -70,22 +70,26 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getDate()) {
             $data['date'] = $object->getDate()->format('d.m.Y');
         }
-        $value = $object->getDateOrNull();
-        if (is_object($object->getDateOrNull())) {
-            $value = $object->getDateOrNull()->format('d.m.Y');
-        } elseif (is_null($object->getDateOrNull())) {
+        if (null !== $object->getDateOrNull()) {
             $value = $object->getDateOrNull();
+            if (is_object($object->getDateOrNull())) {
+                $value = $object->getDateOrNull()->format('d.m.Y');
+            } elseif (is_null($object->getDateOrNull())) {
+                $value = $object->getDateOrNull();
+            }
+            $data['dateOrNull'] = $value;
         }
-        $data['dateOrNull'] = $value;
-        $value_1 = $object->getDateOrNullOrInt();
-        if (is_object($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt()->format('d.m.Y');
-        } elseif (is_null($object->getDateOrNullOrInt())) {
+        if (null !== $object->getDateOrNullOrInt()) {
             $value_1 = $object->getDateOrNullOrInt();
-        } elseif (is_int($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt();
+            if (is_object($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt()->format('d.m.Y');
+            } elseif (is_null($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            } elseif (is_int($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            }
+            $data['dateOrNullOrInt'] = $value_1;
         }
-        $data['dateOrNullOrInt'] = $value_1;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/date/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/date/expected/Normalizer/TestNormalizer.php
@@ -70,22 +70,26 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getDate()) {
             $data['date'] = $object->getDate()->format('Y-m-d');
         }
-        $value = $object->getDateOrNull();
-        if (is_object($object->getDateOrNull())) {
-            $value = $object->getDateOrNull()->format('Y-m-d');
-        } elseif (is_null($object->getDateOrNull())) {
+        if (null !== $object->getDateOrNull()) {
             $value = $object->getDateOrNull();
+            if (is_object($object->getDateOrNull())) {
+                $value = $object->getDateOrNull()->format('Y-m-d');
+            } elseif (is_null($object->getDateOrNull())) {
+                $value = $object->getDateOrNull();
+            }
+            $data['dateOrNull'] = $value;
         }
-        $data['dateOrNull'] = $value;
-        $value_1 = $object->getDateOrNullOrInt();
-        if (is_object($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt()->format('Y-m-d');
-        } elseif (is_null($object->getDateOrNullOrInt())) {
+        if (null !== $object->getDateOrNullOrInt()) {
             $value_1 = $object->getDateOrNullOrInt();
-        } elseif (is_int($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt();
+            if (is_object($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt()->format('Y-m-d');
+            } elseif (is_null($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            } elseif (is_int($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            }
+            $data['dateOrNullOrInt'] = $value_1;
         }
-        $data['dateOrNullOrInt'] = $value_1;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
@@ -70,22 +70,26 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getDate()) {
             $data['date'] = $object->getDate()->format('l, d-M-y H:i:s T');
         }
-        $value = $object->getDateOrNull();
-        if (is_object($object->getDateOrNull())) {
-            $value = $object->getDateOrNull()->format('l, d-M-y H:i:s T');
-        } elseif (is_null($object->getDateOrNull())) {
+        if (null !== $object->getDateOrNull()) {
             $value = $object->getDateOrNull();
+            if (is_object($object->getDateOrNull())) {
+                $value = $object->getDateOrNull()->format('l, d-M-y H:i:s T');
+            } elseif (is_null($object->getDateOrNull())) {
+                $value = $object->getDateOrNull();
+            }
+            $data['dateOrNull'] = $value;
         }
-        $data['dateOrNull'] = $value;
-        $value_1 = $object->getDateOrNullOrInt();
-        if (is_object($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt()->format('l, d-M-y H:i:s T');
-        } elseif (is_null($object->getDateOrNullOrInt())) {
+        if (null !== $object->getDateOrNullOrInt()) {
             $value_1 = $object->getDateOrNullOrInt();
-        } elseif (is_int($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt();
+            if (is_object($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt()->format('l, d-M-y H:i:s T');
+            } elseif (is_null($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            } elseif (is_int($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            }
+            $data['dateOrNullOrInt'] = $value_1;
         }
-        $data['dateOrNullOrInt'] = $value_1;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/datetime-interface/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime-interface/expected/Normalizer/TestNormalizer.php
@@ -70,22 +70,26 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getDate()) {
             $data['date'] = $object->getDate()->format('Y-m-d\\TH:i:sP');
         }
-        $value = $object->getDateOrNull();
-        if (is_object($object->getDateOrNull())) {
-            $value = $object->getDateOrNull()->format('Y-m-d\\TH:i:sP');
-        } elseif (is_null($object->getDateOrNull())) {
+        if (null !== $object->getDateOrNull()) {
             $value = $object->getDateOrNull();
+            if (is_object($object->getDateOrNull())) {
+                $value = $object->getDateOrNull()->format('Y-m-d\\TH:i:sP');
+            } elseif (is_null($object->getDateOrNull())) {
+                $value = $object->getDateOrNull();
+            }
+            $data['dateOrNull'] = $value;
         }
-        $data['dateOrNull'] = $value;
-        $value_1 = $object->getDateOrNullOrInt();
-        if (is_object($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt()->format('Y-m-d\\TH:i:sP');
-        } elseif (is_null($object->getDateOrNullOrInt())) {
+        if (null !== $object->getDateOrNullOrInt()) {
             $value_1 = $object->getDateOrNullOrInt();
-        } elseif (is_int($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt();
+            if (is_object($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt()->format('Y-m-d\\TH:i:sP');
+            } elseif (is_null($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            } elseif (is_int($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            }
+            $data['dateOrNullOrInt'] = $value_1;
         }
-        $data['dateOrNullOrInt'] = $value_1;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/datetime-no-format/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime-no-format/expected/Normalizer/TestNormalizer.php
@@ -70,22 +70,26 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getDate()) {
             $data['date'] = $object->getDate()->format('Y-m-d\\TH:i:sP');
         }
-        $value = $object->getDateOrNull();
-        if (is_object($object->getDateOrNull())) {
-            $value = $object->getDateOrNull()->format('Y-m-d\\TH:i:sP');
-        } elseif (is_null($object->getDateOrNull())) {
+        if (null !== $object->getDateOrNull()) {
             $value = $object->getDateOrNull();
+            if (is_object($object->getDateOrNull())) {
+                $value = $object->getDateOrNull()->format('Y-m-d\\TH:i:sP');
+            } elseif (is_null($object->getDateOrNull())) {
+                $value = $object->getDateOrNull();
+            }
+            $data['dateOrNull'] = $value;
         }
-        $data['dateOrNull'] = $value;
-        $value_1 = $object->getDateOrNullOrInt();
-        if (is_object($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt()->format('Y-m-d\\TH:i:sP');
-        } elseif (is_null($object->getDateOrNullOrInt())) {
+        if (null !== $object->getDateOrNullOrInt()) {
             $value_1 = $object->getDateOrNullOrInt();
-        } elseif (is_int($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt();
+            if (is_object($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt()->format('Y-m-d\\TH:i:sP');
+            } elseif (is_null($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            } elseif (is_int($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            }
+            $data['dateOrNullOrInt'] = $value_1;
         }
-        $data['dateOrNullOrInt'] = $value_1;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
@@ -70,22 +70,26 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getDate()) {
             $data['date'] = $object->getDate()->format('Y-m-d\\TH:i:sP');
         }
-        $value = $object->getDateOrNull();
-        if (is_object($object->getDateOrNull())) {
-            $value = $object->getDateOrNull()->format('Y-m-d\\TH:i:sP');
-        } elseif (is_null($object->getDateOrNull())) {
+        if (null !== $object->getDateOrNull()) {
             $value = $object->getDateOrNull();
+            if (is_object($object->getDateOrNull())) {
+                $value = $object->getDateOrNull()->format('Y-m-d\\TH:i:sP');
+            } elseif (is_null($object->getDateOrNull())) {
+                $value = $object->getDateOrNull();
+            }
+            $data['dateOrNull'] = $value;
         }
-        $data['dateOrNull'] = $value;
-        $value_1 = $object->getDateOrNullOrInt();
-        if (is_object($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt()->format('Y-m-d\\TH:i:sP');
-        } elseif (is_null($object->getDateOrNullOrInt())) {
+        if (null !== $object->getDateOrNullOrInt()) {
             $value_1 = $object->getDateOrNullOrInt();
-        } elseif (is_int($object->getDateOrNullOrInt())) {
-            $value_1 = $object->getDateOrNullOrInt();
+            if (is_object($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt()->format('Y-m-d\\TH:i:sP');
+            } elseif (is_null($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            } elseif (is_int($object->getDateOrNullOrInt())) {
+                $value_1 = $object->getDateOrNullOrInt();
+            }
+            $data['dateOrNullOrInt'] = $value_1;
         }
-        $data['dateOrNullOrInt'] = $value_1;
         return $data;
     }
 }

--- a/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/test-null/expected/Normalizer/TestNormalizer.php
@@ -56,14 +56,18 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['onlyNull'] = $object->getOnlyNull();
-        $value = $object->getNullOrString();
-        if (is_string($object->getNullOrString())) {
-            $value = $object->getNullOrString();
-        } elseif (is_null($object->getNullOrString())) {
-            $value = $object->getNullOrString();
+        if (null !== $object->getOnlyNull()) {
+            $data['onlyNull'] = $object->getOnlyNull();
         }
-        $data['nullOrString'] = $value;
+        if (null !== $object->getNullOrString()) {
+            $value = $object->getNullOrString();
+            if (is_string($object->getNullOrString())) {
+                $value = $object->getNullOrString();
+            } elseif (is_null($object->getNullOrString())) {
+                $value = $object->getNullOrString();
+            }
+            $data['nullOrString'] = $value;
+        }
         return $data;
     }
 }

--- a/src/OpenApi2/Tests/fixtures/nullable-check/expected/Normalizer/FooNormalizer.php
+++ b/src/OpenApi2/Tests/fixtures/nullable-check/expected/Normalizer/FooNormalizer.php
@@ -64,7 +64,9 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
             }
             $data['bar'] = $value;
         }
-        $data['baz'] = $object->getBaz();
+        if (null !== $object->getBaz()) {
+            $data['baz'] = $object->getBaz();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ActorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ActorNormalizer.php
@@ -68,7 +68,9 @@ class ActorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
         if (null !== $object->getDisplayLogin()) {
             $data['display_login'] = $object->getDisplayLogin();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/AppManifestsCodeConversionsPostResponse201Normalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/AppManifestsCodeConversionsPostResponse201Normalizer.php
@@ -114,7 +114,9 @@ class AppManifestsCodeConversionsPostResponse201Normalizer implements Denormaliz
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getExternalUrl()) {
             $data['external_url'] = $object->getExternalUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ApplicationGrantUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ApplicationGrantUserNormalizer.php
@@ -110,7 +110,9 @@ class ApplicationGrantUserNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ApplicationsClientIdTokensAccessTokenGetResponse200Normalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ApplicationsClientIdTokensAccessTokenGetResponse200Normalizer.php
@@ -124,20 +124,30 @@ class ApplicationsClientIdTokensAccessTokenGetResponse200Normalizer implements D
         if (null !== $object->getToken()) {
             $data['token'] = $object->getToken();
         }
-        $data['token_last_eight'] = $object->getTokenLastEight();
-        $data['hashed_token'] = $object->getHashedToken();
+        if (null !== $object->getTokenLastEight()) {
+            $data['token_last_eight'] = $object->getTokenLastEight();
+        }
+        if (null !== $object->getHashedToken()) {
+            $data['hashed_token'] = $object->getHashedToken();
+        }
         if (null !== $object->getApp()) {
             $data['app'] = $this->normalizer->normalize($object->getApp(), 'json', $context);
         }
-        $data['note'] = $object->getNote();
-        $data['note_url'] = $object->getNoteUrl();
+        if (null !== $object->getNote()) {
+            $data['note'] = $object->getNote();
+        }
+        if (null !== $object->getNoteUrl()) {
+            $data['note_url'] = $object->getNoteUrl();
+        }
         if (null !== $object->getUpdatedAt()) {
             $data['updated_at'] = $object->getUpdatedAt()->format('Y-m-d\\TH:i:sP');
         }
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['fingerprint'] = $object->getFingerprint();
+        if (null !== $object->getFingerprint()) {
+            $data['fingerprint'] = $object->getFingerprint();
+        }
         if (null !== $object->getUser()) {
             $data['user'] = $this->normalizer->normalize($object->getUser(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/AuthenticationTokenNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/AuthenticationTokenNormalizer.php
@@ -79,7 +79,9 @@ class AuthenticationTokenNormalizer implements DenormalizerInterface, Normalizer
             }
             $data['repositories'] = $values;
         }
-        $data['single_file'] = $object->getSingleFile();
+        if (null !== $object->getSingleFile()) {
+            $data['single_file'] = $object->getSingleFile();
+        }
         if (null !== $object->getRepositorySelection()) {
             $data['repository_selection'] = $object->getRepositorySelection();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/AuthorizationInstallationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/AuthorizationInstallationNormalizer.php
@@ -65,7 +65,9 @@ class AuthorizationInstallationNormalizer implements DenormalizerInterface, Norm
         if (null !== $object->getRepositorySelection()) {
             $data['repository_selection'] = $object->getRepositorySelection();
         }
-        $data['single_file_name'] = $object->getSingleFileName();
+        if (null !== $object->getSingleFileName()) {
+            $data['single_file_name'] = $object->getSingleFileName();
+        }
         if (null !== $object->getRepositoriesUrl()) {
             $data['repositories_url'] = $object->getRepositoriesUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/AuthorizationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/AuthorizationNormalizer.php
@@ -124,20 +124,30 @@ class AuthorizationNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getToken()) {
             $data['token'] = $object->getToken();
         }
-        $data['token_last_eight'] = $object->getTokenLastEight();
-        $data['hashed_token'] = $object->getHashedToken();
+        if (null !== $object->getTokenLastEight()) {
+            $data['token_last_eight'] = $object->getTokenLastEight();
+        }
+        if (null !== $object->getHashedToken()) {
+            $data['hashed_token'] = $object->getHashedToken();
+        }
         if (null !== $object->getApp()) {
             $data['app'] = $this->normalizer->normalize($object->getApp(), 'json', $context);
         }
-        $data['note'] = $object->getNote();
-        $data['note_url'] = $object->getNoteUrl();
+        if (null !== $object->getNote()) {
+            $data['note'] = $object->getNote();
+        }
+        if (null !== $object->getNoteUrl()) {
+            $data['note_url'] = $object->getNoteUrl();
+        }
         if (null !== $object->getUpdatedAt()) {
             $data['updated_at'] = $object->getUpdatedAt()->format('Y-m-d\\TH:i:sP');
         }
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['fingerprint'] = $object->getFingerprint();
+        if (null !== $object->getFingerprint()) {
+            $data['fingerprint'] = $object->getFingerprint();
+        }
         if (null !== $object->getUser()) {
             $data['user'] = $this->normalizer->normalize($object->getUser(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/AuthorizationUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/AuthorizationUserNormalizer.php
@@ -110,7 +110,9 @@ class AuthorizationUserNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/BaseGistNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/BaseGistNormalizer.php
@@ -159,7 +159,9 @@ class BaseGistNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (null !== $object->getUpdatedAt()) {
             $data['updated_at'] = $object->getUpdatedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getComments()) {
             $data['comments'] = $object->getComments();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/BaseGistOwnerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/BaseGistOwnerNormalizer.php
@@ -110,7 +110,9 @@ class BaseGistOwnerNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/BaseGistUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/BaseGistUserNormalizer.php
@@ -110,7 +110,9 @@ class BaseGistUserNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/BlobNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/BlobNormalizer.php
@@ -74,7 +74,9 @@ class BlobNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getSha()) {
             $data['sha'] = $object->getSha();
         }
-        $data['size'] = $object->getSize();
+        if (null !== $object->getSize()) {
+            $data['size'] = $object->getSize();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/BranchRestrictionPolicyTeamsItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/BranchRestrictionPolicyTeamsItemNormalizer.php
@@ -98,7 +98,9 @@ class BranchRestrictionPolicyTeamsItemNormalizer implements DenormalizerInterfac
         if (null !== $object->getSlug()) {
             $data['slug'] = $object->getSlug();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getPrivacy()) {
             $data['privacy'] = $object->getPrivacy();
         }
@@ -111,7 +113,9 @@ class BranchRestrictionPolicyTeamsItemNormalizer implements DenormalizerInterfac
         if (null !== $object->getRepositoriesUrl()) {
             $data['repositories_url'] = $object->getRepositoriesUrl();
         }
-        $data['parent'] = $object->getParent();
+        if (null !== $object->getParent()) {
+            $data['parent'] = $object->getParent();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckAnnotationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckAnnotationNormalizer.php
@@ -95,12 +95,24 @@ class CheckAnnotationNormalizer implements DenormalizerInterface, NormalizerInte
         if (null !== $object->getEndLine()) {
             $data['end_line'] = $object->getEndLine();
         }
-        $data['start_column'] = $object->getStartColumn();
-        $data['end_column'] = $object->getEndColumn();
-        $data['annotation_level'] = $object->getAnnotationLevel();
-        $data['title'] = $object->getTitle();
-        $data['message'] = $object->getMessage();
-        $data['raw_details'] = $object->getRawDetails();
+        if (null !== $object->getStartColumn()) {
+            $data['start_column'] = $object->getStartColumn();
+        }
+        if (null !== $object->getEndColumn()) {
+            $data['end_column'] = $object->getEndColumn();
+        }
+        if (null !== $object->getAnnotationLevel()) {
+            $data['annotation_level'] = $object->getAnnotationLevel();
+        }
+        if (null !== $object->getTitle()) {
+            $data['title'] = $object->getTitle();
+        }
+        if (null !== $object->getMessage()) {
+            $data['message'] = $object->getMessage();
+        }
+        if (null !== $object->getRawDetails()) {
+            $data['raw_details'] = $object->getRawDetails();
+        }
         if (null !== $object->getBlobHref()) {
             $data['blob_href'] = $object->getBlobHref();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckRunAppNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckRunAppNormalizer.php
@@ -114,7 +114,9 @@ class CheckRunAppNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getExternalUrl()) {
             $data['external_url'] = $object->getExternalUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckRunNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckRunNormalizer.php
@@ -119,16 +119,24 @@ class CheckRunNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }
-        $data['external_id'] = $object->getExternalId();
+        if (null !== $object->getExternalId()) {
+            $data['external_id'] = $object->getExternalId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['details_url'] = $object->getDetailsUrl();
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getDetailsUrl()) {
+            $data['details_url'] = $object->getDetailsUrl();
+        }
         if (null !== $object->getStatus()) {
             $data['status'] = $object->getStatus();
         }
-        $data['conclusion'] = $object->getConclusion();
+        if (null !== $object->getConclusion()) {
+            $data['conclusion'] = $object->getConclusion();
+        }
         if (null !== $object->getStartedAt()) {
             $data['started_at'] = $object->getStartedAt()->format('Y-m-d\\TH:i:sP');
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckRunOutputNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckRunOutputNormalizer.php
@@ -62,9 +62,15 @@ class CheckRunOutputNormalizer implements DenormalizerInterface, NormalizerInter
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['title'] = $object->getTitle();
-        $data['summary'] = $object->getSummary();
-        $data['text'] = $object->getText();
+        if (null !== $object->getTitle()) {
+            $data['title'] = $object->getTitle();
+        }
+        if (null !== $object->getSummary()) {
+            $data['summary'] = $object->getSummary();
+        }
+        if (null !== $object->getText()) {
+            $data['text'] = $object->getText();
+        }
         if (null !== $object->getAnnotationsCount()) {
             $data['annotations_count'] = $object->getAnnotationsCount();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckSuiteAppNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckSuiteAppNormalizer.php
@@ -114,7 +114,9 @@ class CheckSuiteAppNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getExternalUrl()) {
             $data['external_url'] = $object->getExternalUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckSuiteNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CheckSuiteNormalizer.php
@@ -129,15 +129,27 @@ class CheckSuiteNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }
-        $data['head_branch'] = $object->getHeadBranch();
+        if (null !== $object->getHeadBranch()) {
+            $data['head_branch'] = $object->getHeadBranch();
+        }
         if (null !== $object->getHeadSha()) {
             $data['head_sha'] = $object->getHeadSha();
         }
-        $data['status'] = $object->getStatus();
-        $data['conclusion'] = $object->getConclusion();
-        $data['url'] = $object->getUrl();
-        $data['before'] = $object->getBefore();
-        $data['after'] = $object->getAfter();
+        if (null !== $object->getStatus()) {
+            $data['status'] = $object->getStatus();
+        }
+        if (null !== $object->getConclusion()) {
+            $data['conclusion'] = $object->getConclusion();
+        }
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getBefore()) {
+            $data['before'] = $object->getBefore();
+        }
+        if (null !== $object->getAfter()) {
+            $data['after'] = $object->getAfter();
+        }
         if (null !== $object->getPullRequests()) {
             $values = array();
             foreach ($object->getPullRequests() as $value) {

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CodeOfConductNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CodeOfConductNormalizer.php
@@ -68,7 +68,9 @@ class CodeOfConductNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getBody()) {
             $data['body'] = $object->getBody();
         }
-        $data['html_url'] = $object->getHtmlUrl();
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CodeOfConductSimpleNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CodeOfConductSimpleNormalizer.php
@@ -62,7 +62,9 @@ class CodeOfConductSimpleNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['html_url'] = $object->getHtmlUrl();
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CodeScanningAlertClosedByNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CodeScanningAlertClosedByNormalizer.php
@@ -110,7 +110,9 @@ class CodeScanningAlertClosedByNormalizer implements DenormalizerInterface, Norm
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CodeScanningAlertNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CodeScanningAlertNormalizer.php
@@ -98,7 +98,9 @@ class CodeScanningAlertNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getRuleDescription()) {
             $data['rule_description'] = $object->getRuleDescription();
         }
-        $data['tool'] = $object->getTool();
+        if (null !== $object->getTool()) {
+            $data['tool'] = $object->getTool();
+        }
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt()->format('Y-m-d\\TH:i:sP');
         }
@@ -117,7 +119,9 @@ class CodeScanningAlertNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }
-        $data['closed_reason'] = $object->getClosedReason();
+        if (null !== $object->getClosedReason()) {
+            $data['closed_reason'] = $object->getClosedReason();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CodeSearchResultItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CodeSearchResultItemNormalizer.php
@@ -115,7 +115,9 @@ class CodeSearchResultItemNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getFileSize()) {
             $data['file_size'] = $object->getFileSize();
         }
-        $data['language'] = $object->getLanguage();
+        if (null !== $object->getLanguage()) {
+            $data['language'] = $object->getLanguage();
+        }
         if (null !== $object->getLastModifiedAt()) {
             $data['last_modified_at'] = $object->getLastModifiedAt()->format('Y-m-d\\TH:i:sP');
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CollaboratorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CollaboratorNormalizer.php
@@ -110,7 +110,9 @@ class CollaboratorNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitAuthorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitAuthorNormalizer.php
@@ -110,7 +110,9 @@ class CommitAuthorNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitCommentNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitCommentNormalizer.php
@@ -107,9 +107,15 @@ class CommitCommentNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getBody()) {
             $data['body'] = $object->getBody();
         }
-        $data['path'] = $object->getPath();
-        $data['position'] = $object->getPosition();
-        $data['line'] = $object->getLine();
+        if (null !== $object->getPath()) {
+            $data['path'] = $object->getPath();
+        }
+        if (null !== $object->getPosition()) {
+            $data['position'] = $object->getPosition();
+        }
+        if (null !== $object->getLine()) {
+            $data['line'] = $object->getLine();
+        }
         if (null !== $object->getCommitId()) {
             $data['commit_id'] = $object->getCommitId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitCommentUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitCommentUserNormalizer.php
@@ -110,7 +110,9 @@ class CommitCommentUserNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitCommitterNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitCommitterNormalizer.php
@@ -110,7 +110,9 @@ class CommitCommitterNormalizer implements DenormalizerInterface, NormalizerInte
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitNormalizer.php
@@ -91,8 +91,12 @@ class CommitNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['url'] = $object->getUrl();
-        $data['sha'] = $object->getSha();
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getSha()) {
+            $data['sha'] = $object->getSha();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitSearchResultItemAuthorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommitSearchResultItemAuthorNormalizer.php
@@ -110,7 +110,9 @@ class CommitSearchResultItemAuthorNormalizer implements DenormalizerInterface, N
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommunityProfileFilesCodeOfConductNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommunityProfileFilesCodeOfConductNormalizer.php
@@ -62,7 +62,9 @@ class CommunityProfileFilesCodeOfConductNormalizer implements DenormalizerInterf
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['html_url'] = $object->getHtmlUrl();
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommunityProfileFilesLicenseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommunityProfileFilesLicenseNormalizer.php
@@ -68,8 +68,12 @@ class CommunityProfileFilesLicenseNormalizer implements DenormalizerInterface, N
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['url'] = $object->getUrl();
-        $data['spdx_id'] = $object->getSpdxId();
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getSpdxId()) {
+            $data['spdx_id'] = $object->getSpdxId();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommunityProfileNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/CommunityProfileNormalizer.php
@@ -65,8 +65,12 @@ class CommunityProfileNormalizer implements DenormalizerInterface, NormalizerInt
         if (null !== $object->getHealthPercentage()) {
             $data['health_percentage'] = $object->getHealthPercentage();
         }
-        $data['description'] = $object->getDescription();
-        $data['documentation'] = $object->getDocumentation();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
+        if (null !== $object->getDocumentation()) {
+            $data['documentation'] = $object->getDocumentation();
+        }
         if (null !== $object->getFiles()) {
             $data['files'] = $this->normalizer->normalize($object->getFiles(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentDirectoryItemLinksNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentDirectoryItemLinksNormalizer.php
@@ -53,8 +53,12 @@ class ContentDirectoryItemLinksNormalizer implements DenormalizerInterface, Norm
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['git'] = $object->getGit();
-        $data['html'] = $object->getHtml();
+        if (null !== $object->getGit()) {
+            $data['git'] = $object->getGit();
+        }
+        if (null !== $object->getHtml()) {
+            $data['html'] = $object->getHtml();
+        }
         if (null !== $object->getSelf()) {
             $data['self'] = $object->getSelf();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentDirectoryItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentDirectoryItemNormalizer.php
@@ -101,9 +101,15 @@ class ContentDirectoryItemNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['git_url'] = $object->getGitUrl();
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['download_url'] = $object->getDownloadUrl();
+        if (null !== $object->getGitUrl()) {
+            $data['git_url'] = $object->getGitUrl();
+        }
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getDownloadUrl()) {
+            $data['download_url'] = $object->getDownloadUrl();
+        }
         if (null !== $object->getLinks()) {
             $data['_links'] = $this->normalizer->normalize($object->getLinks(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentFileLinksNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentFileLinksNormalizer.php
@@ -53,8 +53,12 @@ class ContentFileLinksNormalizer implements DenormalizerInterface, NormalizerInt
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['git'] = $object->getGit();
-        $data['html'] = $object->getHtml();
+        if (null !== $object->getGit()) {
+            $data['git'] = $object->getGit();
+        }
+        if (null !== $object->getHtml()) {
+            $data['html'] = $object->getHtml();
+        }
         if (null !== $object->getSelf()) {
             $data['self'] = $object->getSelf();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentFileNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentFileNormalizer.php
@@ -113,9 +113,15 @@ class ContentFileNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['git_url'] = $object->getGitUrl();
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['download_url'] = $object->getDownloadUrl();
+        if (null !== $object->getGitUrl()) {
+            $data['git_url'] = $object->getGitUrl();
+        }
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getDownloadUrl()) {
+            $data['download_url'] = $object->getDownloadUrl();
+        }
         if (null !== $object->getLinks()) {
             $data['_links'] = $this->normalizer->normalize($object->getLinks(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentSubmoduleLinksNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentSubmoduleLinksNormalizer.php
@@ -53,8 +53,12 @@ class ContentSubmoduleLinksNormalizer implements DenormalizerInterface, Normaliz
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['git'] = $object->getGit();
-        $data['html'] = $object->getHtml();
+        if (null !== $object->getGit()) {
+            $data['git'] = $object->getGit();
+        }
+        if (null !== $object->getHtml()) {
+            $data['html'] = $object->getHtml();
+        }
         if (null !== $object->getSelf()) {
             $data['self'] = $object->getSelf();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentSubmoduleNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentSubmoduleNormalizer.php
@@ -101,9 +101,15 @@ class ContentSubmoduleNormalizer implements DenormalizerInterface, NormalizerInt
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['git_url'] = $object->getGitUrl();
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['download_url'] = $object->getDownloadUrl();
+        if (null !== $object->getGitUrl()) {
+            $data['git_url'] = $object->getGitUrl();
+        }
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getDownloadUrl()) {
+            $data['download_url'] = $object->getDownloadUrl();
+        }
         if (null !== $object->getLinks()) {
             $data['_links'] = $this->normalizer->normalize($object->getLinks(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentSymlinkLinksNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentSymlinkLinksNormalizer.php
@@ -53,8 +53,12 @@ class ContentSymlinkLinksNormalizer implements DenormalizerInterface, Normalizer
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['git'] = $object->getGit();
-        $data['html'] = $object->getHtml();
+        if (null !== $object->getGit()) {
+            $data['git'] = $object->getGit();
+        }
+        if (null !== $object->getHtml()) {
+            $data['html'] = $object->getHtml();
+        }
         if (null !== $object->getSelf()) {
             $data['self'] = $object->getSelf();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentSymlinkNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentSymlinkNormalizer.php
@@ -101,9 +101,15 @@ class ContentSymlinkNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['git_url'] = $object->getGitUrl();
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['download_url'] = $object->getDownloadUrl();
+        if (null !== $object->getGitUrl()) {
+            $data['git_url'] = $object->getGitUrl();
+        }
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getDownloadUrl()) {
+            $data['download_url'] = $object->getDownloadUrl();
+        }
         if (null !== $object->getLinks()) {
             $data['_links'] = $this->normalizer->normalize($object->getLinks(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentTreeEntriesItemLinksNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentTreeEntriesItemLinksNormalizer.php
@@ -53,8 +53,12 @@ class ContentTreeEntriesItemLinksNormalizer implements DenormalizerInterface, No
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['git'] = $object->getGit();
-        $data['html'] = $object->getHtml();
+        if (null !== $object->getGit()) {
+            $data['git'] = $object->getGit();
+        }
+        if (null !== $object->getHtml()) {
+            $data['html'] = $object->getHtml();
+        }
         if (null !== $object->getSelf()) {
             $data['self'] = $object->getSelf();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentTreeEntriesItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentTreeEntriesItemNormalizer.php
@@ -101,9 +101,15 @@ class ContentTreeEntriesItemNormalizer implements DenormalizerInterface, Normali
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['git_url'] = $object->getGitUrl();
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['download_url'] = $object->getDownloadUrl();
+        if (null !== $object->getGitUrl()) {
+            $data['git_url'] = $object->getGitUrl();
+        }
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getDownloadUrl()) {
+            $data['download_url'] = $object->getDownloadUrl();
+        }
         if (null !== $object->getLinks()) {
             $data['_links'] = $this->normalizer->normalize($object->getLinks(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentTreeLinksNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentTreeLinksNormalizer.php
@@ -53,8 +53,12 @@ class ContentTreeLinksNormalizer implements DenormalizerInterface, NormalizerInt
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['git'] = $object->getGit();
-        $data['html'] = $object->getHtml();
+        if (null !== $object->getGit()) {
+            $data['git'] = $object->getGit();
+        }
+        if (null !== $object->getHtml()) {
+            $data['html'] = $object->getHtml();
+        }
         if (null !== $object->getSelf()) {
             $data['self'] = $object->getSelf();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentTreeNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContentTreeNormalizer.php
@@ -102,9 +102,15 @@ class ContentTreeNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['git_url'] = $object->getGitUrl();
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['download_url'] = $object->getDownloadUrl();
+        if (null !== $object->getGitUrl()) {
+            $data['git_url'] = $object->getGitUrl();
+        }
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getDownloadUrl()) {
+            $data['download_url'] = $object->getDownloadUrl();
+        }
         if (null !== $object->getEntries()) {
             $values = array();
             foreach ($object->getEntries() as $value) {

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContributorActivityAuthorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContributorActivityAuthorNormalizer.php
@@ -110,7 +110,9 @@ class ContributorActivityAuthorNormalizer implements DenormalizerInterface, Norm
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContributorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ContributorNormalizer.php
@@ -116,7 +116,9 @@ class ContributorNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/DeploymentCreatorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/DeploymentCreatorNormalizer.php
@@ -110,7 +110,9 @@ class DeploymentCreatorNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/DeploymentNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/DeploymentNormalizer.php
@@ -128,7 +128,9 @@ class DeploymentNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getEnvironment()) {
             $data['environment'] = $object->getEnvironment();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getCreator()) {
             $data['creator'] = $this->normalizer->normalize($object->getCreator(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/DeploymentPerformedViaGithubAppNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/DeploymentPerformedViaGithubAppNormalizer.php
@@ -114,7 +114,9 @@ class DeploymentPerformedViaGithubAppNormalizer implements DenormalizerInterface
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getExternalUrl()) {
             $data['external_url'] = $object->getExternalUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/DeploymentStatusCreatorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/DeploymentStatusCreatorNormalizer.php
@@ -110,7 +110,9 @@ class DeploymentStatusCreatorNormalizer implements DenormalizerInterface, Normal
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/DeploymentStatusPerformedViaGithubAppNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/DeploymentStatusPerformedViaGithubAppNormalizer.php
@@ -114,7 +114,9 @@ class DeploymentStatusPerformedViaGithubAppNormalizer implements DenormalizerInt
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getExternalUrl()) {
             $data['external_url'] = $object->getExternalUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/EnterpriseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/EnterpriseNormalizer.php
@@ -80,11 +80,15 @@ class EnterpriseNormalizer implements DenormalizerInterface, NormalizerInterface
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }
-        $data['website_url'] = $object->getWebsiteUrl();
+        if (null !== $object->getWebsiteUrl()) {
+            $data['website_url'] = $object->getWebsiteUrl();
+        }
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/EventNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/EventNormalizer.php
@@ -71,7 +71,9 @@ class EventNormalizer implements DenormalizerInterface, NormalizerInterface, Den
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }
-        $data['type'] = $object->getType();
+        if (null !== $object->getType()) {
+            $data['type'] = $object->getType();
+        }
         if (null !== $object->getActor()) {
             $data['actor'] = $this->normalizer->normalize($object->getActor(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/EventPayloadPagesItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/EventPayloadPagesItemNormalizer.php
@@ -65,7 +65,9 @@ class EventPayloadPagesItemNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getTitle()) {
             $data['title'] = $object->getTitle();
         }
-        $data['summary'] = $object->getSummary();
+        if (null !== $object->getSummary()) {
+            $data['summary'] = $object->getSummary();
+        }
         if (null !== $object->getAction()) {
             $data['action'] = $object->getAction();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FileCommitCommitVerificationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FileCommitCommitVerificationNormalizer.php
@@ -62,8 +62,12 @@ class FileCommitCommitVerificationNormalizer implements DenormalizerInterface, N
         if (null !== $object->getReason()) {
             $data['reason'] = $object->getReason();
         }
-        $data['signature'] = $object->getSignature();
-        $data['payload'] = $object->getPayload();
+        if (null !== $object->getSignature()) {
+            $data['signature'] = $object->getSignature();
+        }
+        if (null !== $object->getPayload()) {
+            $data['payload'] = $object->getPayload();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FullRepositoryLicenseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FullRepositoryLicenseNormalizer.php
@@ -68,8 +68,12 @@ class FullRepositoryLicenseNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['url'] = $object->getUrl();
-        $data['spdx_id'] = $object->getSpdxId();
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getSpdxId()) {
+            $data['spdx_id'] = $object->getSpdxId();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FullRepositoryNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FullRepositoryNormalizer.php
@@ -360,7 +360,9 @@ class FullRepositoryNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getFork()) {
             $data['fork'] = $object->getFork();
         }
@@ -481,15 +483,21 @@ class FullRepositoryNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getCloneUrl()) {
             $data['clone_url'] = $object->getCloneUrl();
         }
-        $data['mirror_url'] = $object->getMirrorUrl();
+        if (null !== $object->getMirrorUrl()) {
+            $data['mirror_url'] = $object->getMirrorUrl();
+        }
         if (null !== $object->getHooksUrl()) {
             $data['hooks_url'] = $object->getHooksUrl();
         }
         if (null !== $object->getSvnUrl()) {
             $data['svn_url'] = $object->getSvnUrl();
         }
-        $data['homepage'] = $object->getHomepage();
-        $data['language'] = $object->getLanguage();
+        if (null !== $object->getHomepage()) {
+            $data['homepage'] = $object->getHomepage();
+        }
+        if (null !== $object->getLanguage()) {
+            $data['language'] = $object->getLanguage();
+        }
         if (null !== $object->getForksCount()) {
             $data['forks_count'] = $object->getForksCount();
         }
@@ -560,7 +568,9 @@ class FullRepositoryNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getTemplateRepository()) {
             $data['template_repository'] = $this->normalizer->normalize($object->getTemplateRepository(), 'json', $context);
         }
-        $data['temp_clone_token'] = $object->getTempCloneToken();
+        if (null !== $object->getTempCloneToken()) {
+            $data['temp_clone_token'] = $object->getTempCloneToken();
+        }
         if (null !== $object->getAllowSquashMerge()) {
             $data['allow_squash_merge'] = $object->getAllowSquashMerge();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FullRepositoryOrganizationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FullRepositoryOrganizationNormalizer.php
@@ -110,7 +110,9 @@ class FullRepositoryOrganizationNormalizer implements DenormalizerInterface, Nor
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FullRepositoryOwnerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FullRepositoryOwnerNormalizer.php
@@ -110,7 +110,9 @@ class FullRepositoryOwnerNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FullRepositoryTemplateRepositoryNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/FullRepositoryTemplateRepositoryNormalizer.php
@@ -363,7 +363,9 @@ class FullRepositoryTemplateRepositoryNormalizer implements DenormalizerInterfac
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getFork()) {
             $data['fork'] = $object->getFork();
         }
@@ -484,15 +486,21 @@ class FullRepositoryTemplateRepositoryNormalizer implements DenormalizerInterfac
         if (null !== $object->getCloneUrl()) {
             $data['clone_url'] = $object->getCloneUrl();
         }
-        $data['mirror_url'] = $object->getMirrorUrl();
+        if (null !== $object->getMirrorUrl()) {
+            $data['mirror_url'] = $object->getMirrorUrl();
+        }
         if (null !== $object->getHooksUrl()) {
             $data['hooks_url'] = $object->getHooksUrl();
         }
         if (null !== $object->getSvnUrl()) {
             $data['svn_url'] = $object->getSvnUrl();
         }
-        $data['homepage'] = $object->getHomepage();
-        $data['language'] = $object->getLanguage();
+        if (null !== $object->getHomepage()) {
+            $data['homepage'] = $object->getHomepage();
+        }
+        if (null !== $object->getLanguage()) {
+            $data['language'] = $object->getLanguage();
+        }
         if (null !== $object->getForksCount()) {
             $data['forks_count'] = $object->getForksCount();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistCommentUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistCommentUserNormalizer.php
@@ -110,7 +110,9 @@ class GistCommentUserNormalizer implements DenormalizerInterface, NormalizerInte
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistCommitUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistCommitUserNormalizer.php
@@ -110,7 +110,9 @@ class GistCommitUserNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullNormalizer.php
@@ -165,11 +165,15 @@ class GistFullNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (null !== $object->getUpdatedAt()) {
             $data['updated_at'] = $object->getUpdatedAt();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getComments()) {
             $data['comments'] = $object->getComments();
         }
-        $data['user'] = $object->getUser();
+        if (null !== $object->getUser()) {
+            $data['user'] = $object->getUser();
+        }
         if (null !== $object->getCommentsUrl()) {
             $data['comments_url'] = $object->getCommentsUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullforkOfNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullforkOfNormalizer.php
@@ -145,11 +145,15 @@ class GistFullforkOfNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getUpdatedAt()) {
             $data['updated_at'] = $object->getUpdatedAt();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getComments()) {
             $data['comments'] = $object->getComments();
         }
-        $data['user'] = $object->getUser();
+        if (null !== $object->getUser()) {
+            $data['user'] = $object->getUser();
+        }
         if (null !== $object->getCommentsUrl()) {
             $data['comments_url'] = $object->getCommentsUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistSimpleNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistSimpleNormalizer.php
@@ -145,11 +145,15 @@ class GistSimpleNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getUpdatedAt()) {
             $data['updated_at'] = $object->getUpdatedAt();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getComments()) {
             $data['comments'] = $object->getComments();
         }
-        $data['user'] = $object->getUser();
+        if (null !== $object->getUser()) {
+            $data['user'] = $object->getUser();
+        }
         if (null !== $object->getCommentsUrl()) {
             $data['comments_url'] = $object->getCommentsUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistsGistIdPatchBodyFilesItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistsGistIdPatchBodyFilesItemNormalizer.php
@@ -50,7 +50,9 @@ class GistsGistIdPatchBodyFilesItemNormalizer implements DenormalizerInterface, 
         if (null !== $object->getContent()) {
             $data['content'] = $object->getContent();
         }
-        $data['filename'] = $object->getFilename();
+        if (null !== $object->getFilename()) {
+            $data['filename'] = $object->getFilename();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GitCommitVerificationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GitCommitVerificationNormalizer.php
@@ -62,8 +62,12 @@ class GitCommitVerificationNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getReason()) {
             $data['reason'] = $object->getReason();
         }
-        $data['signature'] = $object->getSignature();
-        $data['payload'] = $object->getPayload();
+        if (null !== $object->getSignature()) {
+            $data['signature'] = $object->getSignature();
+        }
+        if (null !== $object->getPayload()) {
+            $data['payload'] = $object->getPayload();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GpgKeyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GpgKeyNormalizer.php
@@ -97,7 +97,9 @@ class GpgKeyNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }
-        $data['primary_key_id'] = $object->getPrimaryKeyId();
+        if (null !== $object->getPrimaryKeyId()) {
+            $data['primary_key_id'] = $object->getPrimaryKeyId();
+        }
         if (null !== $object->getKeyId()) {
             $data['key_id'] = $object->getKeyId();
         }
@@ -136,7 +138,9 @@ class GpgKeyNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (null !== $object->getExpiresAt()) {
             $data['expires_at'] = $object->getExpiresAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['raw_key'] = $object->getRawKey();
+        if (null !== $object->getRawKey()) {
+            $data['raw_key'] = $object->getRawKey();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GpgKeySubkeysItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/GpgKeySubkeysItemNormalizer.php
@@ -132,8 +132,12 @@ class GpgKeySubkeysItemNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt();
         }
-        $data['expires_at'] = $object->getExpiresAt();
-        $data['raw_key'] = $object->getRawKey();
+        if (null !== $object->getExpiresAt()) {
+            $data['expires_at'] = $object->getExpiresAt();
+        }
+        if (null !== $object->getRawKey()) {
+            $data['raw_key'] = $object->getRawKey();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/HookResponseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/HookResponseNormalizer.php
@@ -56,9 +56,15 @@ class HookResponseNormalizer implements DenormalizerInterface, NormalizerInterfa
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['code'] = $object->getCode();
-        $data['status'] = $object->getStatus();
-        $data['message'] = $object->getMessage();
+        if (null !== $object->getCode()) {
+            $data['code'] = $object->getCode();
+        }
+        if (null !== $object->getStatus()) {
+            $data['status'] = $object->getStatus();
+        }
+        if (null !== $object->getMessage()) {
+            $data['message'] = $object->getMessage();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ImportNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ImportNormalizer.php
@@ -135,7 +135,9 @@ class ImportNormalizer implements DenormalizerInterface, NormalizerInterface, De
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['vcs'] = $object->getVcs();
+        if (null !== $object->getVcs()) {
+            $data['vcs'] = $object->getVcs();
+        }
         if (null !== $object->getUseLfs()) {
             $data['use_lfs'] = $object->getUseLfs();
         }
@@ -151,12 +153,24 @@ class ImportNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (null !== $object->getStatus()) {
             $data['status'] = $object->getStatus();
         }
-        $data['status_text'] = $object->getStatusText();
-        $data['failed_step'] = $object->getFailedStep();
-        $data['error_message'] = $object->getErrorMessage();
-        $data['import_percent'] = $object->getImportPercent();
-        $data['commit_count'] = $object->getCommitCount();
-        $data['push_percent'] = $object->getPushPercent();
+        if (null !== $object->getStatusText()) {
+            $data['status_text'] = $object->getStatusText();
+        }
+        if (null !== $object->getFailedStep()) {
+            $data['failed_step'] = $object->getFailedStep();
+        }
+        if (null !== $object->getErrorMessage()) {
+            $data['error_message'] = $object->getErrorMessage();
+        }
+        if (null !== $object->getImportPercent()) {
+            $data['import_percent'] = $object->getImportPercent();
+        }
+        if (null !== $object->getCommitCount()) {
+            $data['commit_count'] = $object->getCommitCount();
+        }
+        if (null !== $object->getPushPercent()) {
+            $data['push_percent'] = $object->getPushPercent();
+        }
         if (null !== $object->getHasLargeFiles()) {
             $data['has_large_files'] = $object->getHasLargeFiles();
         }
@@ -176,7 +190,9 @@ class ImportNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (null !== $object->getMessage()) {
             $data['message'] = $object->getMessage();
         }
-        $data['authors_count'] = $object->getAuthorsCount();
+        if (null !== $object->getAuthorsCount()) {
+            $data['authors_count'] = $object->getAuthorsCount();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/InstallationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/InstallationNormalizer.php
@@ -114,7 +114,9 @@ class InstallationNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }
-        $data['account'] = $object->getAccount();
+        if (null !== $object->getAccount()) {
+            $data['account'] = $object->getAccount();
+        }
         if (null !== $object->getRepositorySelection()) {
             $data['repository_selection'] = $object->getRepositorySelection();
         }
@@ -152,7 +154,9 @@ class InstallationNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getUpdatedAt()) {
             $data['updated_at'] = $object->getUpdatedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['single_file_name'] = $object->getSingleFileName();
+        if (null !== $object->getSingleFileName()) {
+            $data['single_file_name'] = $object->getSingleFileName();
+        }
         if (null !== $object->getAppSlug()) {
             $data['app_slug'] = $object->getAppSlug();
         }
@@ -162,7 +166,9 @@ class InstallationNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getSuspendedAt()) {
             $data['suspended_at'] = $object->getSuspendedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['contact_email'] = $object->getContactEmail();
+        if (null !== $object->getContactEmail()) {
+            $data['contact_email'] = $object->getContactEmail();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/InstallationSuspendedByNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/InstallationSuspendedByNormalizer.php
@@ -110,7 +110,9 @@ class InstallationSuspendedByNormalizer implements DenormalizerInterface, Normal
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IntegrationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IntegrationNormalizer.php
@@ -136,7 +136,9 @@ class IntegrationNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getExternalUrl()) {
             $data['external_url'] = $object->getExternalUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IntegrationOwnerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IntegrationOwnerNormalizer.php
@@ -110,7 +110,9 @@ class IntegrationOwnerNormalizer implements DenormalizerInterface, NormalizerInt
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueAssigneeNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueAssigneeNormalizer.php
@@ -110,7 +110,9 @@ class IssueAssigneeNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueClosedByNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueClosedByNormalizer.php
@@ -110,7 +110,9 @@ class IssueClosedByNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueCommentPerformedViaGithubAppNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueCommentPerformedViaGithubAppNormalizer.php
@@ -114,7 +114,9 @@ class IssueCommentPerformedViaGithubAppNormalizer implements DenormalizerInterfa
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getExternalUrl()) {
             $data['external_url'] = $object->getExternalUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueCommentUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueCommentUserNormalizer.php
@@ -110,7 +110,9 @@ class IssueCommentUserNormalizer implements DenormalizerInterface, NormalizerInt
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventActorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventActorNormalizer.php
@@ -110,7 +110,9 @@ class IssueEventActorNormalizer implements DenormalizerInterface, NormalizerInte
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventAssigneeNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventAssigneeNormalizer.php
@@ -110,7 +110,9 @@ class IssueEventAssigneeNormalizer implements DenormalizerInterface, NormalizerI
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventAssignerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventAssignerNormalizer.php
@@ -110,7 +110,9 @@ class IssueEventAssignerNormalizer implements DenormalizerInterface, NormalizerI
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventDismissedReviewNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventDismissedReviewNormalizer.php
@@ -62,8 +62,12 @@ class IssueEventDismissedReviewNormalizer implements DenormalizerInterface, Norm
         if (null !== $object->getReviewId()) {
             $data['review_id'] = $object->getReviewId();
         }
-        $data['dismissal_message'] = $object->getDismissalMessage();
-        $data['dismissal_commit_id'] = $object->getDismissalCommitId();
+        if (null !== $object->getDismissalMessage()) {
+            $data['dismissal_message'] = $object->getDismissalMessage();
+        }
+        if (null !== $object->getDismissalCommitId()) {
+            $data['dismissal_commit_id'] = $object->getDismissalCommitId();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventForIssueNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventForIssueNormalizer.php
@@ -125,8 +125,12 @@ class IssueEventForIssueNormalizer implements DenormalizerInterface, NormalizerI
         if (null !== $object->getEvent()) {
             $data['event'] = $object->getEvent();
         }
-        $data['commit_id'] = $object->getCommitId();
-        $data['commit_url'] = $object->getCommitUrl();
+        if (null !== $object->getCommitId()) {
+            $data['commit_id'] = $object->getCommitId();
+        }
+        if (null !== $object->getCommitUrl()) {
+            $data['commit_url'] = $object->getCommitUrl();
+        }
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventLabelNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventLabelNormalizer.php
@@ -50,8 +50,12 @@ class IssueEventLabelNormalizer implements DenormalizerInterface, NormalizerInte
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['name'] = $object->getName();
-        $data['color'] = $object->getColor();
+        if (null !== $object->getName()) {
+            $data['name'] = $object->getName();
+        }
+        if (null !== $object->getColor()) {
+            $data['color'] = $object->getColor();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventNormalizer.php
@@ -140,8 +140,12 @@ class IssueEventNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getEvent()) {
             $data['event'] = $object->getEvent();
         }
-        $data['commit_id'] = $object->getCommitId();
-        $data['commit_url'] = $object->getCommitUrl();
+        if (null !== $object->getCommitId()) {
+            $data['commit_id'] = $object->getCommitId();
+        }
+        if (null !== $object->getCommitUrl()) {
+            $data['commit_url'] = $object->getCommitUrl();
+        }
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt()->format('Y-m-d\\TH:i:sP');
         }
@@ -181,7 +185,9 @@ class IssueEventNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getAuthorAssociation()) {
             $data['author_association'] = $object->getAuthorAssociation();
         }
-        $data['lock_reason'] = $object->getLockReason();
+        if (null !== $object->getLockReason()) {
+            $data['lock_reason'] = $object->getLockReason();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventRequestedReviewerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventRequestedReviewerNormalizer.php
@@ -110,7 +110,9 @@ class IssueEventRequestedReviewerNormalizer implements DenormalizerInterface, No
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventReviewRequesterNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueEventReviewRequesterNormalizer.php
@@ -110,7 +110,9 @@ class IssueEventReviewRequesterNormalizer implements DenormalizerInterface, Norm
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueMilestoneNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueMilestoneNormalizer.php
@@ -122,7 +122,9 @@ class IssueMilestoneNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getTitle()) {
             $data['title'] = $object->getTitle();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getCreator()) {
             $data['creator'] = $this->normalizer->normalize($object->getCreator(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueNormalizer.php
@@ -228,7 +228,9 @@ class IssueNormalizer implements DenormalizerInterface, NormalizerInterface, Den
         if (null !== $object->getLocked()) {
             $data['locked'] = $object->getLocked();
         }
-        $data['active_lock_reason'] = $object->getActiveLockReason();
+        if (null !== $object->getActiveLockReason()) {
+            $data['active_lock_reason'] = $object->getActiveLockReason();
+        }
         if (null !== $object->getComments()) {
             $data['comments'] = $object->getComments();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssuePerformedViaGithubAppNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssuePerformedViaGithubAppNormalizer.php
@@ -114,7 +114,9 @@ class IssuePerformedViaGithubAppNormalizer implements DenormalizerInterface, Nor
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getExternalUrl()) {
             $data['external_url'] = $object->getExternalUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssuePullRequestNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssuePullRequestNormalizer.php
@@ -71,10 +71,18 @@ class IssuePullRequestNormalizer implements DenormalizerInterface, NormalizerInt
         if (null !== $object->getMergedAt()) {
             $data['merged_at'] = $object->getMergedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['diff_url'] = $object->getDiffUrl();
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['patch_url'] = $object->getPatchUrl();
-        $data['url'] = $object->getUrl();
+        if (null !== $object->getDiffUrl()) {
+            $data['diff_url'] = $object->getDiffUrl();
+        }
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getPatchUrl()) {
+            $data['patch_url'] = $object->getPatchUrl();
+        }
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemAssigneeNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemAssigneeNormalizer.php
@@ -110,7 +110,9 @@ class IssueSearchResultItemAssigneeNormalizer implements DenormalizerInterface, 
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemLabelsItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemLabelsItemNormalizer.php
@@ -80,7 +80,9 @@ class IssueSearchResultItemLabelsItemNormalizer implements DenormalizerInterface
         if (null !== $object->getDefault()) {
             $data['default'] = $object->getDefault();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemMilestoneNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemMilestoneNormalizer.php
@@ -122,7 +122,9 @@ class IssueSearchResultItemMilestoneNormalizer implements DenormalizerInterface,
         if (null !== $object->getTitle()) {
             $data['title'] = $object->getTitle();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getCreator()) {
             $data['creator'] = $this->normalizer->normalize($object->getCreator(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemNormalizer.php
@@ -203,7 +203,9 @@ class IssueSearchResultItemNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getLocked()) {
             $data['locked'] = $object->getLocked();
         }
-        $data['active_lock_reason'] = $object->getActiveLockReason();
+        if (null !== $object->getActiveLockReason()) {
+            $data['active_lock_reason'] = $object->getActiveLockReason();
+        }
         if (null !== $object->getAssignees()) {
             $values = array();
             foreach ($object->getAssignees() as $value) {

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemPerformedViaGithubAppNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemPerformedViaGithubAppNormalizer.php
@@ -114,7 +114,9 @@ class IssueSearchResultItemPerformedViaGithubAppNormalizer implements Denormaliz
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getExternalUrl()) {
             $data['external_url'] = $object->getExternalUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemPullRequestNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemPullRequestNormalizer.php
@@ -71,10 +71,18 @@ class IssueSearchResultItemPullRequestNormalizer implements DenormalizerInterfac
         if (null !== $object->getMergedAt()) {
             $data['merged_at'] = $object->getMergedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['diff_url'] = $object->getDiffUrl();
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['patch_url'] = $object->getPatchUrl();
-        $data['url'] = $object->getUrl();
+        if (null !== $object->getDiffUrl()) {
+            $data['diff_url'] = $object->getDiffUrl();
+        }
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getPatchUrl()) {
+            $data['patch_url'] = $object->getPatchUrl();
+        }
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSearchResultItemUserNormalizer.php
@@ -110,7 +110,9 @@ class IssueSearchResultItemUserNormalizer implements DenormalizerInterface, Norm
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimpleAssigneeNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimpleAssigneeNormalizer.php
@@ -110,7 +110,9 @@ class IssueSimpleAssigneeNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimpleLabelsItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimpleLabelsItemNormalizer.php
@@ -74,7 +74,9 @@ class IssueSimpleLabelsItemNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getColor()) {
             $data['color'] = $object->getColor();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimpleMilestoneNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimpleMilestoneNormalizer.php
@@ -122,7 +122,9 @@ class IssueSimpleMilestoneNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getTitle()) {
             $data['title'] = $object->getTitle();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getCreator()) {
             $data['creator'] = $this->normalizer->normalize($object->getCreator(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimpleNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimpleNormalizer.php
@@ -219,7 +219,9 @@ class IssueSimpleNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getLocked()) {
             $data['locked'] = $object->getLocked();
         }
-        $data['active_lock_reason'] = $object->getActiveLockReason();
+        if (null !== $object->getActiveLockReason()) {
+            $data['active_lock_reason'] = $object->getActiveLockReason();
+        }
         if (null !== $object->getComments()) {
             $data['comments'] = $object->getComments();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimplePerformedViaGithubAppNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimplePerformedViaGithubAppNormalizer.php
@@ -114,7 +114,9 @@ class IssueSimplePerformedViaGithubAppNormalizer implements DenormalizerInterfac
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getExternalUrl()) {
             $data['external_url'] = $object->getExternalUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimplePullRequestNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimplePullRequestNormalizer.php
@@ -71,10 +71,18 @@ class IssueSimplePullRequestNormalizer implements DenormalizerInterface, Normali
         if (null !== $object->getMergedAt()) {
             $data['merged_at'] = $object->getMergedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['diff_url'] = $object->getDiffUrl();
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['patch_url'] = $object->getPatchUrl();
-        $data['url'] = $object->getUrl();
+        if (null !== $object->getDiffUrl()) {
+            $data['diff_url'] = $object->getDiffUrl();
+        }
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getPatchUrl()) {
+            $data['patch_url'] = $object->getPatchUrl();
+        }
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimpleUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueSimpleUserNormalizer.php
@@ -110,7 +110,9 @@ class IssueSimpleUserNormalizer implements DenormalizerInterface, NormalizerInte
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/IssueUserNormalizer.php
@@ -110,7 +110,9 @@ class IssueUserNormalizer implements DenormalizerInterface, NormalizerInterface,
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/JobNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/JobNormalizer.php
@@ -111,11 +111,15 @@ class JobNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['html_url'] = $object->getHtmlUrl();
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
         if (null !== $object->getStatus()) {
             $data['status'] = $object->getStatus();
         }
-        $data['conclusion'] = $object->getConclusion();
+        if (null !== $object->getConclusion()) {
+            $data['conclusion'] = $object->getConclusion();
+        }
         if (null !== $object->getStartedAt()) {
             $data['started_at'] = $object->getStartedAt()->format('Y-m-d\\TH:i:sP');
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/JobStepsItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/JobStepsItemNormalizer.php
@@ -68,7 +68,9 @@ class JobStepsItemNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getStatus()) {
             $data['status'] = $object->getStatus();
         }
-        $data['conclusion'] = $object->getConclusion();
+        if (null !== $object->getConclusion()) {
+            $data['conclusion'] = $object->getConclusion();
+        }
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LabelNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LabelNormalizer.php
@@ -74,7 +74,9 @@ class LabelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getColor()) {
             $data['color'] = $object->getColor();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LabelSearchResultItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LabelSearchResultItemNormalizer.php
@@ -90,7 +90,9 @@ class LabelSearchResultItemNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getDefault()) {
             $data['default'] = $object->getDefault();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getScore()) {
             $data['score'] = $object->getScore();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LicenseContentLicenseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LicenseContentLicenseNormalizer.php
@@ -68,8 +68,12 @@ class LicenseContentLicenseNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['url'] = $object->getUrl();
-        $data['spdx_id'] = $object->getSpdxId();
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getSpdxId()) {
+            $data['spdx_id'] = $object->getSpdxId();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LicenseContentLinksNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LicenseContentLinksNormalizer.php
@@ -53,8 +53,12 @@ class LicenseContentLinksNormalizer implements DenormalizerInterface, Normalizer
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['git'] = $object->getGit();
-        $data['html'] = $object->getHtml();
+        if (null !== $object->getGit()) {
+            $data['git'] = $object->getGit();
+        }
+        if (null !== $object->getHtml()) {
+            $data['html'] = $object->getHtml();
+        }
         if (null !== $object->getSelf()) {
             $data['self'] = $object->getSelf();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LicenseContentNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LicenseContentNormalizer.php
@@ -104,9 +104,15 @@ class LicenseContentNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['html_url'] = $object->getHtmlUrl();
-        $data['git_url'] = $object->getGitUrl();
-        $data['download_url'] = $object->getDownloadUrl();
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
+        if (null !== $object->getGitUrl()) {
+            $data['git_url'] = $object->getGitUrl();
+        }
+        if (null !== $object->getDownloadUrl()) {
+            $data['download_url'] = $object->getDownloadUrl();
+        }
         if (null !== $object->getType()) {
             $data['type'] = $object->getType();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LicenseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LicenseNormalizer.php
@@ -101,8 +101,12 @@ class LicenseNormalizer implements DenormalizerInterface, NormalizerInterface, D
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['spdx_id'] = $object->getSpdxId();
-        $data['url'] = $object->getUrl();
+        if (null !== $object->getSpdxId()) {
+            $data['spdx_id'] = $object->getSpdxId();
+        }
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LicenseSimpleNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/LicenseSimpleNormalizer.php
@@ -68,8 +68,12 @@ class LicenseSimpleNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['url'] = $object->getUrl();
-        $data['spdx_id'] = $object->getSpdxId();
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getSpdxId()) {
+            $data['spdx_id'] = $object->getSpdxId();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MarketplaceAccountNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MarketplaceAccountNormalizer.php
@@ -80,8 +80,12 @@ class MarketplaceAccountNormalizer implements DenormalizerInterface, NormalizerI
         if (null !== $object->getLogin()) {
             $data['login'] = $object->getLogin();
         }
-        $data['email'] = $object->getEmail();
-        $data['organization_billing_email'] = $object->getOrganizationBillingEmail();
+        if (null !== $object->getEmail()) {
+            $data['email'] = $object->getEmail();
+        }
+        if (null !== $object->getOrganizationBillingEmail()) {
+            $data['organization_billing_email'] = $object->getOrganizationBillingEmail();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MarketplaceListingPlanNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MarketplaceListingPlanNormalizer.php
@@ -114,7 +114,9 @@ class MarketplaceListingPlanNormalizer implements DenormalizerInterface, Normali
         if (null !== $object->getHasFreeTrial()) {
             $data['has_free_trial'] = $object->getHasFreeTrial();
         }
-        $data['unit_name'] = $object->getUnitName();
+        if (null !== $object->getUnitName()) {
+            $data['unit_name'] = $object->getUnitName();
+        }
         if (null !== $object->getState()) {
             $data['state'] = $object->getState();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MarketplacePurchaseMarketplacePendingChangeNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MarketplacePurchaseMarketplacePendingChangeNormalizer.php
@@ -62,7 +62,9 @@ class MarketplacePurchaseMarketplacePendingChangeNormalizer implements Denormali
         if (null !== $object->getEffectiveDate()) {
             $data['effective_date'] = $object->getEffectiveDate();
         }
-        $data['unit_count'] = $object->getUnitCount();
+        if (null !== $object->getUnitCount()) {
+            $data['unit_count'] = $object->getUnitCount();
+        }
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MarketplacePurchaseMarketplacePurchaseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MarketplacePurchaseMarketplacePurchaseNormalizer.php
@@ -74,15 +74,21 @@ class MarketplacePurchaseMarketplacePurchaseNormalizer implements DenormalizerIn
         if (null !== $object->getBillingCycle()) {
             $data['billing_cycle'] = $object->getBillingCycle();
         }
-        $data['next_billing_date'] = $object->getNextBillingDate();
+        if (null !== $object->getNextBillingDate()) {
+            $data['next_billing_date'] = $object->getNextBillingDate();
+        }
         if (null !== $object->getIsInstalled()) {
             $data['is_installed'] = $object->getIsInstalled();
         }
-        $data['unit_count'] = $object->getUnitCount();
+        if (null !== $object->getUnitCount()) {
+            $data['unit_count'] = $object->getUnitCount();
+        }
         if (null !== $object->getOnFreeTrial()) {
             $data['on_free_trial'] = $object->getOnFreeTrial();
         }
-        $data['free_trial_ends_on'] = $object->getFreeTrialEndsOn();
+        if (null !== $object->getFreeTrialEndsOn()) {
+            $data['free_trial_ends_on'] = $object->getFreeTrialEndsOn();
+        }
         if (null !== $object->getUpdatedAt()) {
             $data['updated_at'] = $object->getUpdatedAt();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MigrationOwnerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MigrationOwnerNormalizer.php
@@ -110,7 +110,9 @@ class MigrationOwnerNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MilestoneCreatorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MilestoneCreatorNormalizer.php
@@ -110,7 +110,9 @@ class MilestoneCreatorNormalizer implements DenormalizerInterface, NormalizerInt
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MilestoneNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MilestoneNormalizer.php
@@ -122,7 +122,9 @@ class MilestoneNormalizer implements DenormalizerInterface, NormalizerInterface,
         if (null !== $object->getTitle()) {
             $data['title'] = $object->getTitle();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getCreator()) {
             $data['creator'] = $this->normalizer->normalize($object->getCreator(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MinimalRepositoryNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MinimalRepositoryNormalizer.php
@@ -336,7 +336,9 @@ class MinimalRepositoryNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getFork()) {
             $data['fork'] = $object->getFork();
         }
@@ -457,15 +459,21 @@ class MinimalRepositoryNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getCloneUrl()) {
             $data['clone_url'] = $object->getCloneUrl();
         }
-        $data['mirror_url'] = $object->getMirrorUrl();
+        if (null !== $object->getMirrorUrl()) {
+            $data['mirror_url'] = $object->getMirrorUrl();
+        }
         if (null !== $object->getHooksUrl()) {
             $data['hooks_url'] = $object->getHooksUrl();
         }
         if (null !== $object->getSvnUrl()) {
             $data['svn_url'] = $object->getSvnUrl();
         }
-        $data['homepage'] = $object->getHomepage();
-        $data['language'] = $object->getLanguage();
+        if (null !== $object->getHomepage()) {
+            $data['homepage'] = $object->getHomepage();
+        }
+        if (null !== $object->getLanguage()) {
+            $data['language'] = $object->getLanguage();
+        }
         if (null !== $object->getForksCount()) {
             $data['forks_count'] = $object->getForksCount();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MinimalRepositoryOwnerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/MinimalRepositoryOwnerNormalizer.php
@@ -110,7 +110,9 @@ class MinimalRepositoryOwnerNormalizer implements DenormalizerInterface, Normali
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/OrgMembershipUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/OrgMembershipUserNormalizer.php
@@ -110,7 +110,9 @@ class OrgMembershipUserNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/OrganizationFullNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/OrganizationFullNormalizer.php
@@ -227,7 +227,9 @@ class OrganizationFullNormalizer implements DenormalizerInterface, NormalizerInt
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
@@ -243,7 +245,9 @@ class OrganizationFullNormalizer implements DenormalizerInterface, NormalizerInt
         if (null !== $object->getEmail()) {
             $data['email'] = $object->getEmail();
         }
-        $data['twitter_username'] = $object->getTwitterUsername();
+        if (null !== $object->getTwitterUsername()) {
+            $data['twitter_username'] = $object->getTwitterUsername();
+        }
         if (null !== $object->getIsVerified()) {
             $data['is_verified'] = $object->getIsVerified();
         }
@@ -280,16 +284,30 @@ class OrganizationFullNormalizer implements DenormalizerInterface, NormalizerInt
         if (null !== $object->getOwnedPrivateRepos()) {
             $data['owned_private_repos'] = $object->getOwnedPrivateRepos();
         }
-        $data['private_gists'] = $object->getPrivateGists();
-        $data['disk_usage'] = $object->getDiskUsage();
-        $data['collaborators'] = $object->getCollaborators();
-        $data['billing_email'] = $object->getBillingEmail();
+        if (null !== $object->getPrivateGists()) {
+            $data['private_gists'] = $object->getPrivateGists();
+        }
+        if (null !== $object->getDiskUsage()) {
+            $data['disk_usage'] = $object->getDiskUsage();
+        }
+        if (null !== $object->getCollaborators()) {
+            $data['collaborators'] = $object->getCollaborators();
+        }
+        if (null !== $object->getBillingEmail()) {
+            $data['billing_email'] = $object->getBillingEmail();
+        }
         if (null !== $object->getPlan()) {
             $data['plan'] = $this->normalizer->normalize($object->getPlan(), 'json', $context);
         }
-        $data['default_repository_permission'] = $object->getDefaultRepositoryPermission();
-        $data['members_can_create_repositories'] = $object->getMembersCanCreateRepositories();
-        $data['two_factor_requirement_enabled'] = $object->getTwoFactorRequirementEnabled();
+        if (null !== $object->getDefaultRepositoryPermission()) {
+            $data['default_repository_permission'] = $object->getDefaultRepositoryPermission();
+        }
+        if (null !== $object->getMembersCanCreateRepositories()) {
+            $data['members_can_create_repositories'] = $object->getMembersCanCreateRepositories();
+        }
+        if (null !== $object->getTwoFactorRequirementEnabled()) {
+            $data['two_factor_requirement_enabled'] = $object->getTwoFactorRequirementEnabled();
+        }
         if (null !== $object->getMembersAllowedRepositoryCreationType()) {
             $data['members_allowed_repository_creation_type'] = $object->getMembersAllowedRepositoryCreationType();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/OrganizationInvitationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/OrganizationInvitationNormalizer.php
@@ -80,8 +80,12 @@ class OrganizationInvitationNormalizer implements DenormalizerInterface, Normali
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }
-        $data['login'] = $object->getLogin();
-        $data['email'] = $object->getEmail();
+        if (null !== $object->getLogin()) {
+            $data['login'] = $object->getLogin();
+        }
+        if (null !== $object->getEmail()) {
+            $data['email'] = $object->getEmail();
+        }
         if (null !== $object->getRole()) {
             $data['role'] = $object->getRole();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/OrganizationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/OrganizationNormalizer.php
@@ -161,7 +161,9 @@ class OrganizationNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getBlog()) {
             $data['blog'] = $object->getBlog();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/OrganizationSimpleNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/OrganizationSimpleNormalizer.php
@@ -110,7 +110,9 @@ class OrganizationSimpleNormalizer implements DenormalizerInterface, NormalizerI
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PageBuildErrorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PageBuildErrorNormalizer.php
@@ -44,7 +44,9 @@ class PageBuildErrorNormalizer implements DenormalizerInterface, NormalizerInter
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['message'] = $object->getMessage();
+        if (null !== $object->getMessage()) {
+            $data['message'] = $object->getMessage();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PageBuildPusherNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PageBuildPusherNormalizer.php
@@ -110,7 +110,9 @@ class PageBuildPusherNormalizer implements DenormalizerInterface, NormalizerInte
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PageNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PageNormalizer.php
@@ -65,8 +65,12 @@ class PageNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['status'] = $object->getStatus();
-        $data['cname'] = $object->getCname();
+        if (null !== $object->getStatus()) {
+            $data['status'] = $object->getStatus();
+        }
+        if (null !== $object->getCname()) {
+            $data['cname'] = $object->getCname();
+        }
         if (null !== $object->getCustom404()) {
             $data['custom_404'] = $object->getCustom404();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PrivateUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PrivateUserNormalizer.php
@@ -206,7 +206,9 @@ class PrivateUserNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
@@ -246,14 +248,30 @@ class PrivateUserNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getSiteAdmin()) {
             $data['site_admin'] = $object->getSiteAdmin();
         }
-        $data['name'] = $object->getName();
-        $data['company'] = $object->getCompany();
-        $data['blog'] = $object->getBlog();
-        $data['location'] = $object->getLocation();
-        $data['email'] = $object->getEmail();
-        $data['hireable'] = $object->getHireable();
-        $data['bio'] = $object->getBio();
-        $data['twitter_username'] = $object->getTwitterUsername();
+        if (null !== $object->getName()) {
+            $data['name'] = $object->getName();
+        }
+        if (null !== $object->getCompany()) {
+            $data['company'] = $object->getCompany();
+        }
+        if (null !== $object->getBlog()) {
+            $data['blog'] = $object->getBlog();
+        }
+        if (null !== $object->getLocation()) {
+            $data['location'] = $object->getLocation();
+        }
+        if (null !== $object->getEmail()) {
+            $data['email'] = $object->getEmail();
+        }
+        if (null !== $object->getHireable()) {
+            $data['hireable'] = $object->getHireable();
+        }
+        if (null !== $object->getBio()) {
+            $data['bio'] = $object->getBio();
+        }
+        if (null !== $object->getTwitterUsername()) {
+            $data['twitter_username'] = $object->getTwitterUsername();
+        }
         if (null !== $object->getPublicRepos()) {
             $data['public_repos'] = $object->getPublicRepos();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectCardCreatorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectCardCreatorNormalizer.php
@@ -110,7 +110,9 @@ class ProjectCardCreatorNormalizer implements DenormalizerInterface, NormalizerI
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectCardNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectCardNormalizer.php
@@ -86,7 +86,9 @@ class ProjectCardNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }
-        $data['note'] = $object->getNote();
+        if (null !== $object->getNote()) {
+            $data['note'] = $object->getNote();
+        }
         if (null !== $object->getCreator()) {
             $data['creator'] = $this->normalizer->normalize($object->getCreator(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectCreatorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectCreatorNormalizer.php
@@ -110,7 +110,9 @@ class ProjectCreatorNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectNormalizer.php
@@ -116,7 +116,9 @@ class ProjectNormalizer implements DenormalizerInterface, NormalizerInterface, D
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['body'] = $object->getBody();
+        if (null !== $object->getBody()) {
+            $data['body'] = $object->getBody();
+        }
         if (null !== $object->getNumber()) {
             $data['number'] = $object->getNumber();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectsColumnsCardsCardIdPatchBodyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectsColumnsCardsCardIdPatchBodyNormalizer.php
@@ -47,7 +47,9 @@ class ProjectsColumnsCardsCardIdPatchBodyNormalizer implements DenormalizerInter
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['note'] = $object->getNote();
+        if (null !== $object->getNote()) {
+            $data['note'] = $object->getNote();
+        }
         if (null !== $object->getArchived()) {
             $data['archived'] = $object->getArchived();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectsProjectIdPatchBodyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ProjectsProjectIdPatchBodyNormalizer.php
@@ -59,7 +59,9 @@ class ProjectsProjectIdPatchBodyNormalizer implements DenormalizerInterface, Nor
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['body'] = $object->getBody();
+        if (null !== $object->getBody()) {
+            $data['body'] = $object->getBody();
+        }
         if (null !== $object->getState()) {
             $data['state'] = $object->getState();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PublicUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PublicUserNormalizer.php
@@ -197,7 +197,9 @@ class PublicUserNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
@@ -237,14 +239,30 @@ class PublicUserNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getSiteAdmin()) {
             $data['site_admin'] = $object->getSiteAdmin();
         }
-        $data['name'] = $object->getName();
-        $data['company'] = $object->getCompany();
-        $data['blog'] = $object->getBlog();
-        $data['location'] = $object->getLocation();
-        $data['email'] = $object->getEmail();
-        $data['hireable'] = $object->getHireable();
-        $data['bio'] = $object->getBio();
-        $data['twitter_username'] = $object->getTwitterUsername();
+        if (null !== $object->getName()) {
+            $data['name'] = $object->getName();
+        }
+        if (null !== $object->getCompany()) {
+            $data['company'] = $object->getCompany();
+        }
+        if (null !== $object->getBlog()) {
+            $data['blog'] = $object->getBlog();
+        }
+        if (null !== $object->getLocation()) {
+            $data['location'] = $object->getLocation();
+        }
+        if (null !== $object->getEmail()) {
+            $data['email'] = $object->getEmail();
+        }
+        if (null !== $object->getHireable()) {
+            $data['hireable'] = $object->getHireable();
+        }
+        if (null !== $object->getBio()) {
+            $data['bio'] = $object->getBio();
+        }
+        if (null !== $object->getTwitterUsername()) {
+            $data['twitter_username'] = $object->getTwitterUsername();
+        }
         if (null !== $object->getPublicRepos()) {
             $data['public_repos'] = $object->getPublicRepos();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestAssigneeNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestAssigneeNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestAssigneeNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestBaseRepoLicenseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestBaseRepoLicenseNormalizer.php
@@ -68,8 +68,12 @@ class PullRequestBaseRepoLicenseNormalizer implements DenormalizerInterface, Nor
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['url'] = $object->getUrl();
-        $data['spdx_id'] = $object->getSpdxId();
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getSpdxId()) {
+            $data['spdx_id'] = $object->getSpdxId();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestBaseRepoNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestBaseRepoNormalizer.php
@@ -330,7 +330,9 @@ class PullRequestBaseRepoNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getDeploymentsUrl()) {
             $data['deployments_url'] = $object->getDeploymentsUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getDownloadsUrl()) {
             $data['downloads_url'] = $object->getDownloadsUrl();
         }
@@ -463,8 +465,12 @@ class PullRequestBaseRepoNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getHasPages()) {
             $data['has_pages'] = $object->getHasPages();
         }
-        $data['homepage'] = $object->getHomepage();
-        $data['language'] = $object->getLanguage();
+        if (null !== $object->getHomepage()) {
+            $data['homepage'] = $object->getHomepage();
+        }
+        if (null !== $object->getLanguage()) {
+            $data['language'] = $object->getLanguage();
+        }
         if (null !== $object->getMasterBranch()) {
             $data['master_branch'] = $object->getMasterBranch();
         }
@@ -474,7 +480,9 @@ class PullRequestBaseRepoNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getDisabled()) {
             $data['disabled'] = $object->getDisabled();
         }
-        $data['mirror_url'] = $object->getMirrorUrl();
+        if (null !== $object->getMirrorUrl()) {
+            $data['mirror_url'] = $object->getMirrorUrl();
+        }
         if (null !== $object->getOpenIssues()) {
             $data['open_issues'] = $object->getOpenIssues();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestBaseRepoOwnerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestBaseRepoOwnerNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestBaseRepoOwnerNormalizer implements DenormalizerInterface, Norma
         if (null !== $object->getGistsUrl()) {
             $data['gists_url'] = $object->getGistsUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestBaseUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestBaseUserNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestBaseUserNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getGistsUrl()) {
             $data['gists_url'] = $object->getGistsUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestHeadRepoLicenseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestHeadRepoLicenseNormalizer.php
@@ -65,8 +65,12 @@ class PullRequestHeadRepoLicenseNormalizer implements DenormalizerInterface, Nor
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['url'] = $object->getUrl();
-        $data['spdx_id'] = $object->getSpdxId();
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getSpdxId()) {
+            $data['spdx_id'] = $object->getSpdxId();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestHeadRepoNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestHeadRepoNormalizer.php
@@ -330,7 +330,9 @@ class PullRequestHeadRepoNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getDeploymentsUrl()) {
             $data['deployments_url'] = $object->getDeploymentsUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getDownloadsUrl()) {
             $data['downloads_url'] = $object->getDownloadsUrl();
         }
@@ -463,8 +465,12 @@ class PullRequestHeadRepoNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getHasPages()) {
             $data['has_pages'] = $object->getHasPages();
         }
-        $data['homepage'] = $object->getHomepage();
-        $data['language'] = $object->getLanguage();
+        if (null !== $object->getHomepage()) {
+            $data['homepage'] = $object->getHomepage();
+        }
+        if (null !== $object->getLanguage()) {
+            $data['language'] = $object->getLanguage();
+        }
         if (null !== $object->getMasterBranch()) {
             $data['master_branch'] = $object->getMasterBranch();
         }
@@ -474,7 +480,9 @@ class PullRequestHeadRepoNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getDisabled()) {
             $data['disabled'] = $object->getDisabled();
         }
-        $data['mirror_url'] = $object->getMirrorUrl();
+        if (null !== $object->getMirrorUrl()) {
+            $data['mirror_url'] = $object->getMirrorUrl();
+        }
         if (null !== $object->getOpenIssues()) {
             $data['open_issues'] = $object->getOpenIssues();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestHeadRepoOwnerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestHeadRepoOwnerNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestHeadRepoOwnerNormalizer implements DenormalizerInterface, Norma
         if (null !== $object->getGistsUrl()) {
             $data['gists_url'] = $object->getGistsUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestHeadUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestHeadUserNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestHeadUserNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getGistsUrl()) {
             $data['gists_url'] = $object->getGistsUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestLabelsItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestLabelsItemNormalizer.php
@@ -74,7 +74,9 @@ class PullRequestLabelsItemNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getColor()) {
             $data['color'] = $object->getColor();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestMergedByNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestMergedByNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestMergedByNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestMilestoneNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestMilestoneNormalizer.php
@@ -122,7 +122,9 @@ class PullRequestMilestoneNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getTitle()) {
             $data['title'] = $object->getTitle();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getCreator()) {
             $data['creator'] = $this->normalizer->normalize($object->getCreator(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestNormalizer.php
@@ -288,7 +288,9 @@ class PullRequestNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getUser()) {
             $data['user'] = $this->normalizer->normalize($object->getUser(), 'json', $context);
         }
-        $data['body'] = $object->getBody();
+        if (null !== $object->getBody()) {
+            $data['body'] = $object->getBody();
+        }
         if (null !== $object->getLabels()) {
             $values = array();
             foreach ($object->getLabels() as $value) {
@@ -299,7 +301,9 @@ class PullRequestNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getMilestone()) {
             $data['milestone'] = $this->normalizer->normalize($object->getMilestone(), 'json', $context);
         }
-        $data['active_lock_reason'] = $object->getActiveLockReason();
+        if (null !== $object->getActiveLockReason()) {
+            $data['active_lock_reason'] = $object->getActiveLockReason();
+        }
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt()->format('Y-m-d\\TH:i:sP');
         }
@@ -312,7 +316,9 @@ class PullRequestNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getMergedAt()) {
             $data['merged_at'] = $object->getMergedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['merge_commit_sha'] = $object->getMergeCommitSha();
+        if (null !== $object->getMergeCommitSha()) {
+            $data['merge_commit_sha'] = $object->getMergeCommitSha();
+        }
         if (null !== $object->getAssignee()) {
             $data['assignee'] = $this->normalizer->normalize($object->getAssignee(), 'json', $context);
         }
@@ -355,8 +361,12 @@ class PullRequestNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getMerged()) {
             $data['merged'] = $object->getMerged();
         }
-        $data['mergeable'] = $object->getMergeable();
-        $data['rebaseable'] = $object->getRebaseable();
+        if (null !== $object->getMergeable()) {
+            $data['mergeable'] = $object->getMergeable();
+        }
+        if (null !== $object->getRebaseable()) {
+            $data['rebaseable'] = $object->getRebaseable();
+        }
         if (null !== $object->getMergeableState()) {
             $data['mergeable_state'] = $object->getMergeableState();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestReviewCommentNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestReviewCommentNormalizer.php
@@ -140,7 +140,9 @@ class PullRequestReviewCommentNormalizer implements DenormalizerInterface, Norma
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['pull_request_review_id'] = $object->getPullRequestReviewId();
+        if (null !== $object->getPullRequestReviewId()) {
+            $data['pull_request_review_id'] = $object->getPullRequestReviewId();
+        }
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }
@@ -192,9 +194,15 @@ class PullRequestReviewCommentNormalizer implements DenormalizerInterface, Norma
         if (null !== $object->getLinks()) {
             $data['_links'] = $this->normalizer->normalize($object->getLinks(), 'json', $context);
         }
-        $data['start_line'] = $object->getStartLine();
-        $data['original_start_line'] = $object->getOriginalStartLine();
-        $data['start_side'] = $object->getStartSide();
+        if (null !== $object->getStartLine()) {
+            $data['start_line'] = $object->getStartLine();
+        }
+        if (null !== $object->getOriginalStartLine()) {
+            $data['original_start_line'] = $object->getOriginalStartLine();
+        }
+        if (null !== $object->getStartSide()) {
+            $data['start_side'] = $object->getStartSide();
+        }
         if (null !== $object->getLine()) {
             $data['line'] = $object->getLine();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestReviewRequestTeamsItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestReviewRequestTeamsItemNormalizer.php
@@ -98,7 +98,9 @@ class PullRequestReviewRequestTeamsItemNormalizer implements DenormalizerInterfa
         if (null !== $object->getSlug()) {
             $data['slug'] = $object->getSlug();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getPrivacy()) {
             $data['privacy'] = $object->getPrivacy();
         }
@@ -111,7 +113,9 @@ class PullRequestReviewRequestTeamsItemNormalizer implements DenormalizerInterfa
         if (null !== $object->getRepositoriesUrl()) {
             $data['repositories_url'] = $object->getRepositoriesUrl();
         }
-        $data['parent'] = $object->getParent();
+        if (null !== $object->getParent()) {
+            $data['parent'] = $object->getParent();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestReviewUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestReviewUserNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestReviewUserNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleAssigneeNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleAssigneeNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestSimpleAssigneeNormalizer implements DenormalizerInterface, Norm
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleBaseUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleBaseUserNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestSimpleBaseUserNormalizer implements DenormalizerInterface, Norm
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleHeadUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleHeadUserNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestSimpleHeadUserNormalizer implements DenormalizerInterface, Norm
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleMilestoneNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleMilestoneNormalizer.php
@@ -122,7 +122,9 @@ class PullRequestSimpleMilestoneNormalizer implements DenormalizerInterface, Nor
         if (null !== $object->getTitle()) {
             $data['title'] = $object->getTitle();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getCreator()) {
             $data['creator'] = $this->normalizer->normalize($object->getCreator(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleNormalizer.php
@@ -243,7 +243,9 @@ class PullRequestSimpleNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getUser()) {
             $data['user'] = $this->normalizer->normalize($object->getUser(), 'json', $context);
         }
-        $data['body'] = $object->getBody();
+        if (null !== $object->getBody()) {
+            $data['body'] = $object->getBody();
+        }
         if (null !== $object->getLabels()) {
             $values = array();
             foreach ($object->getLabels() as $value) {
@@ -254,7 +256,9 @@ class PullRequestSimpleNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getMilestone()) {
             $data['milestone'] = $this->normalizer->normalize($object->getMilestone(), 'json', $context);
         }
-        $data['active_lock_reason'] = $object->getActiveLockReason();
+        if (null !== $object->getActiveLockReason()) {
+            $data['active_lock_reason'] = $object->getActiveLockReason();
+        }
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt()->format('Y-m-d\\TH:i:sP');
         }
@@ -267,7 +271,9 @@ class PullRequestSimpleNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getMergedAt()) {
             $data['merged_at'] = $object->getMergedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['merge_commit_sha'] = $object->getMergeCommitSha();
+        if (null !== $object->getMergeCommitSha()) {
+            $data['merge_commit_sha'] = $object->getMergeCommitSha();
+        }
         if (null !== $object->getAssignee()) {
             $data['assignee'] = $this->normalizer->normalize($object->getAssignee(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestSimpleUserNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestSimpleUserNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/PullRequestUserNormalizer.php
@@ -110,7 +110,9 @@ class PullRequestUserNormalizer implements DenormalizerInterface, NormalizerInte
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReactionUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReactionUserNormalizer.php
@@ -110,7 +110,9 @@ class ReactionUserNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReleaseAssetNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReleaseAssetNormalizer.php
@@ -98,7 +98,9 @@ class ReleaseAssetNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['label'] = $object->getLabel();
+        if (null !== $object->getLabel()) {
+            $data['label'] = $object->getLabel();
+        }
         if (null !== $object->getState()) {
             $data['state'] = $object->getState();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReleaseAssetUploaderNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReleaseAssetUploaderNormalizer.php
@@ -110,7 +110,9 @@ class ReleaseAssetUploaderNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReleaseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReleaseNormalizer.php
@@ -132,8 +132,12 @@ class ReleaseNormalizer implements DenormalizerInterface, NormalizerInterface, D
         if (null !== $object->getUploadUrl()) {
             $data['upload_url'] = $object->getUploadUrl();
         }
-        $data['tarball_url'] = $object->getTarballUrl();
-        $data['zipball_url'] = $object->getZipballUrl();
+        if (null !== $object->getTarballUrl()) {
+            $data['tarball_url'] = $object->getTarballUrl();
+        }
+        if (null !== $object->getZipballUrl()) {
+            $data['zipball_url'] = $object->getZipballUrl();
+        }
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }
@@ -146,8 +150,12 @@ class ReleaseNormalizer implements DenormalizerInterface, NormalizerInterface, D
         if (null !== $object->getTargetCommitish()) {
             $data['target_commitish'] = $object->getTargetCommitish();
         }
-        $data['name'] = $object->getName();
-        $data['body'] = $object->getBody();
+        if (null !== $object->getName()) {
+            $data['name'] = $object->getName();
+        }
+        if (null !== $object->getBody()) {
+            $data['body'] = $object->getBody();
+        }
         if (null !== $object->getDraft()) {
             $data['draft'] = $object->getDraft();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepoSearchResultItemLicenseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepoSearchResultItemLicenseNormalizer.php
@@ -68,8 +68,12 @@ class RepoSearchResultItemLicenseNormalizer implements DenormalizerInterface, No
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['url'] = $object->getUrl();
-        $data['spdx_id'] = $object->getSpdxId();
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getSpdxId()) {
+            $data['spdx_id'] = $object->getSpdxId();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepoSearchResultItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepoSearchResultItemNormalizer.php
@@ -334,7 +334,9 @@ class RepoSearchResultItemNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getFork()) {
             $data['fork'] = $object->getFork();
         }
@@ -350,7 +352,9 @@ class RepoSearchResultItemNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getPushedAt()) {
             $data['pushed_at'] = $object->getPushedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['homepage'] = $object->getHomepage();
+        if (null !== $object->getHomepage()) {
+            $data['homepage'] = $object->getHomepage();
+        }
         if (null !== $object->getSize()) {
             $data['size'] = $object->getSize();
         }
@@ -360,7 +364,9 @@ class RepoSearchResultItemNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getWatchersCount()) {
             $data['watchers_count'] = $object->getWatchersCount();
         }
-        $data['language'] = $object->getLanguage();
+        if (null !== $object->getLanguage()) {
+            $data['language'] = $object->getLanguage();
+        }
         if (null !== $object->getForksCount()) {
             $data['forks_count'] = $object->getForksCount();
         }
@@ -512,7 +518,9 @@ class RepoSearchResultItemNormalizer implements DenormalizerInterface, Normalize
             }
             $data['topics'] = $values;
         }
-        $data['mirror_url'] = $object->getMirrorUrl();
+        if (null !== $object->getMirrorUrl()) {
+            $data['mirror_url'] = $object->getMirrorUrl();
+        }
         if (null !== $object->getHasIssues()) {
             $data['has_issues'] = $object->getHasIssues();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepoSearchResultItemOwnerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepoSearchResultItemOwnerNormalizer.php
@@ -110,7 +110,9 @@ class RepoSearchResultItemOwnerNormalizer implements DenormalizerInterface, Norm
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoBranchesBranchProtectionPutBodyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoBranchesBranchProtectionPutBodyNormalizer.php
@@ -77,7 +77,9 @@ class ReposOwnerRepoBranchesBranchProtectionPutBodyNormalizer implements Denorma
         if (null !== $object->getRequiredStatusChecks()) {
             $data['required_status_checks'] = $this->normalizer->normalize($object->getRequiredStatusChecks(), 'json', $context);
         }
-        $data['enforce_admins'] = $object->getEnforceAdmins();
+        if (null !== $object->getEnforceAdmins()) {
+            $data['enforce_admins'] = $object->getEnforceAdmins();
+        }
         if (null !== $object->getRequiredPullRequestReviews()) {
             $data['required_pull_request_reviews'] = $this->normalizer->normalize($object->getRequiredPullRequestReviews(), 'json', $context);
         }
@@ -87,7 +89,9 @@ class ReposOwnerRepoBranchesBranchProtectionPutBodyNormalizer implements Denorma
         if (null !== $object->getRequiredLinearHistory()) {
             $data['required_linear_history'] = $object->getRequiredLinearHistory();
         }
-        $data['allow_force_pushes'] = $object->getAllowForcePushes();
+        if (null !== $object->getAllowForcePushes()) {
+            $data['allow_force_pushes'] = $object->getAllowForcePushes();
+        }
         if (null !== $object->getAllowDeletions()) {
             $data['allow_deletions'] = $object->getAllowDeletions();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoDeploymentsPostBodyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoDeploymentsPostBodyNormalizer.php
@@ -97,7 +97,9 @@ class ReposOwnerRepoDeploymentsPostBodyNormalizer implements DenormalizerInterfa
         if (null !== $object->getEnvironment()) {
             $data['environment'] = $object->getEnvironment();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getTransientEnvironment()) {
             $data['transient_environment'] = $object->getTransientEnvironment();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoGitTreesPostBodyTreeItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoGitTreesPostBodyTreeItemNormalizer.php
@@ -65,7 +65,9 @@ class ReposOwnerRepoGitTreesPostBodyTreeItemNormalizer implements DenormalizerIn
         if (null !== $object->getType()) {
             $data['type'] = $object->getType();
         }
-        $data['sha'] = $object->getSha();
+        if (null !== $object->getSha()) {
+            $data['sha'] = $object->getSha();
+        }
         if (null !== $object->getContent()) {
             $data['content'] = $object->getContent();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoIssuesIssueNumberPatchBodyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoIssuesIssueNumberPatchBodyNormalizer.php
@@ -82,7 +82,9 @@ class ReposOwnerRepoIssuesIssueNumberPatchBodyNormalizer implements Denormalizer
         if (null !== $object->getState()) {
             $data['state'] = $object->getState();
         }
-        $data['milestone'] = $object->getMilestone();
+        if (null !== $object->getMilestone()) {
+            $data['milestone'] = $object->getMilestone();
+        }
         if (null !== $object->getLabels()) {
             $values = array();
             foreach ($object->getLabels() as $value) {

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoIssuesPostBodyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoIssuesPostBodyNormalizer.php
@@ -76,8 +76,12 @@ class ReposOwnerRepoIssuesPostBodyNormalizer implements DenormalizerInterface, N
         if (null !== $object->getBody()) {
             $data['body'] = $object->getBody();
         }
-        $data['assignee'] = $object->getAssignee();
-        $data['milestone'] = $object->getMilestone();
+        if (null !== $object->getAssignee()) {
+            $data['assignee'] = $object->getAssignee();
+        }
+        if (null !== $object->getMilestone()) {
+            $data['milestone'] = $object->getMilestone();
+        }
         if (null !== $object->getLabels()) {
             $values = array();
             foreach ($object->getLabels() as $value) {

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoPagesPutBodyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReposOwnerRepoPagesPutBodyNormalizer.php
@@ -47,7 +47,9 @@ class ReposOwnerRepoPagesPutBodyNormalizer implements DenormalizerInterface, Nor
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['cname'] = $object->getCname();
+        if (null !== $object->getCname()) {
+            $data['cname'] = $object->getCname();
+        }
         if (null !== $object->getSource()) {
             $data['source'] = $object->getSource();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryCollaboratorPermissionUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryCollaboratorPermissionUserNormalizer.php
@@ -110,7 +110,9 @@ class RepositoryCollaboratorPermissionUserNormalizer implements DenormalizerInte
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryInvitationInviteeNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryInvitationInviteeNormalizer.php
@@ -110,7 +110,9 @@ class RepositoryInvitationInviteeNormalizer implements DenormalizerInterface, No
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryInvitationInviterNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryInvitationInviterNormalizer.php
@@ -110,7 +110,9 @@ class RepositoryInvitationInviterNormalizer implements DenormalizerInterface, No
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryLicenseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryLicenseNormalizer.php
@@ -68,8 +68,12 @@ class RepositoryLicenseNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['url'] = $object->getUrl();
-        $data['spdx_id'] = $object->getSpdxId();
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getSpdxId()) {
+            $data['spdx_id'] = $object->getSpdxId();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryNormalizer.php
@@ -363,7 +363,9 @@ class RepositoryNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getFork()) {
             $data['fork'] = $object->getFork();
         }
@@ -484,15 +486,21 @@ class RepositoryNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getCloneUrl()) {
             $data['clone_url'] = $object->getCloneUrl();
         }
-        $data['mirror_url'] = $object->getMirrorUrl();
+        if (null !== $object->getMirrorUrl()) {
+            $data['mirror_url'] = $object->getMirrorUrl();
+        }
         if (null !== $object->getHooksUrl()) {
             $data['hooks_url'] = $object->getHooksUrl();
         }
         if (null !== $object->getSvnUrl()) {
             $data['svn_url'] = $object->getSvnUrl();
         }
-        $data['homepage'] = $object->getHomepage();
-        $data['language'] = $object->getLanguage();
+        if (null !== $object->getHomepage()) {
+            $data['homepage'] = $object->getHomepage();
+        }
+        if (null !== $object->getLanguage()) {
+            $data['language'] = $object->getLanguage();
+        }
         if (null !== $object->getForksCount()) {
             $data['forks_count'] = $object->getForksCount();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryOwnerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositoryOwnerNormalizer.php
@@ -110,7 +110,9 @@ class RepositoryOwnerNormalizer implements DenormalizerInterface, NormalizerInte
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositorySubscriptionNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/RepositorySubscriptionNormalizer.php
@@ -65,7 +65,9 @@ class RepositorySubscriptionNormalizer implements DenormalizerInterface, Normali
         if (null !== $object->getIgnored()) {
             $data['ignored'] = $object->getIgnored();
         }
-        $data['reason'] = $object->getReason();
+        if (null !== $object->getReason()) {
+            $data['reason'] = $object->getReason();
+        }
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt()->format('Y-m-d\\TH:i:sP');
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ResponseForbiddenGistBlockNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ResponseForbiddenGistBlockNormalizer.php
@@ -56,7 +56,9 @@ class ResponseForbiddenGistBlockNormalizer implements DenormalizerInterface, Nor
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt();
         }
-        $data['html_url'] = $object->getHtmlUrl();
+        if (null !== $object->getHtmlUrl()) {
+            $data['html_url'] = $object->getHtmlUrl();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReviewCommentNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReviewCommentNormalizer.php
@@ -140,7 +140,9 @@ class ReviewCommentNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['pull_request_review_id'] = $object->getPullRequestReviewId();
+        if (null !== $object->getPullRequestReviewId()) {
+            $data['pull_request_review_id'] = $object->getPullRequestReviewId();
+        }
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }
@@ -153,7 +155,9 @@ class ReviewCommentNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getPath()) {
             $data['path'] = $object->getPath();
         }
-        $data['position'] = $object->getPosition();
+        if (null !== $object->getPosition()) {
+            $data['position'] = $object->getPosition();
+        }
         if (null !== $object->getOriginalPosition()) {
             $data['original_position'] = $object->getOriginalPosition();
         }
@@ -199,15 +203,21 @@ class ReviewCommentNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getSide()) {
             $data['side'] = $object->getSide();
         }
-        $data['start_side'] = $object->getStartSide();
+        if (null !== $object->getStartSide()) {
+            $data['start_side'] = $object->getStartSide();
+        }
         if (null !== $object->getLine()) {
             $data['line'] = $object->getLine();
         }
         if (null !== $object->getOriginalLine()) {
             $data['original_line'] = $object->getOriginalLine();
         }
-        $data['start_line'] = $object->getStartLine();
-        $data['original_start_line'] = $object->getOriginalStartLine();
+        if (null !== $object->getStartLine()) {
+            $data['start_line'] = $object->getStartLine();
+        }
+        if (null !== $object->getOriginalStartLine()) {
+            $data['original_start_line'] = $object->getOriginalStartLine();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReviewCommentUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ReviewCommentUserNormalizer.php
@@ -110,7 +110,9 @@ class ReviewCommentUserNormalizer implements DenormalizerInterface, NormalizerIn
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ScimErrorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ScimErrorNormalizer.php
@@ -72,13 +72,21 @@ class ScimErrorNormalizer implements DenormalizerInterface, NormalizerInterface,
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['message'] = $object->getMessage();
-        $data['documentation_url'] = $object->getDocumentationUrl();
-        $data['detail'] = $object->getDetail();
+        if (null !== $object->getMessage()) {
+            $data['message'] = $object->getMessage();
+        }
+        if (null !== $object->getDocumentationUrl()) {
+            $data['documentation_url'] = $object->getDocumentationUrl();
+        }
+        if (null !== $object->getDetail()) {
+            $data['detail'] = $object->getDetail();
+        }
         if (null !== $object->getStatus()) {
             $data['status'] = $object->getStatus();
         }
-        $data['scimType'] = $object->getScimType();
+        if (null !== $object->getScimType()) {
+            $data['scimType'] = $object->getScimType();
+        }
         if (null !== $object->getSchemas()) {
             $values = array();
             foreach ($object->getSchemas() as $value) {

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ScimUserNameNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ScimUserNameNormalizer.php
@@ -50,8 +50,12 @@ class ScimUserNameNormalizer implements DenormalizerInterface, NormalizerInterfa
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['givenName'] = $object->getGivenName();
-        $data['familyName'] = $object->getFamilyName();
+        if (null !== $object->getGivenName()) {
+            $data['givenName'] = $object->getGivenName();
+        }
+        if (null !== $object->getFamilyName()) {
+            $data['familyName'] = $object->getFamilyName();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ScimUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ScimUserNormalizer.php
@@ -103,8 +103,12 @@ class ScimUserNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }
-        $data['externalId'] = $object->getExternalId();
-        $data['userName'] = $object->getUserName();
+        if (null !== $object->getExternalId()) {
+            $data['externalId'] = $object->getExternalId();
+        }
+        if (null !== $object->getUserName()) {
+            $data['userName'] = $object->getUserName();
+        }
         if (null !== $object->getName()) {
             $data['name'] = $this->normalizer->normalize($object->getName(), 'json', $context);
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ScopedInstallationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ScopedInstallationNormalizer.php
@@ -65,7 +65,9 @@ class ScopedInstallationNormalizer implements DenormalizerInterface, NormalizerI
         if (null !== $object->getRepositorySelection()) {
             $data['repository_selection'] = $object->getRepositorySelection();
         }
-        $data['single_file_name'] = $object->getSingleFileName();
+        if (null !== $object->getSingleFileName()) {
+            $data['single_file_name'] = $object->getSingleFileName();
+        }
         if (null !== $object->getRepositoriesUrl()) {
             $data['repositories_url'] = $object->getRepositoriesUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/SearchResultTextMatchesItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/SearchResultTextMatchesItemNormalizer.php
@@ -63,7 +63,9 @@ class SearchResultTextMatchesItemNormalizer implements DenormalizerInterface, No
         if (null !== $object->getObjectUrl()) {
             $data['object_url'] = $object->getObjectUrl();
         }
-        $data['object_type'] = $object->getObjectType();
+        if (null !== $object->getObjectType()) {
+            $data['object_type'] = $object->getObjectType();
+        }
         if (null !== $object->getProperty()) {
             $data['property'] = $object->getProperty();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/SimpleCommitStatusNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/SimpleCommitStatusNormalizer.php
@@ -80,7 +80,9 @@ class SimpleCommitStatusNormalizer implements DenormalizerInterface, NormalizerI
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }
@@ -96,8 +98,12 @@ class SimpleCommitStatusNormalizer implements DenormalizerInterface, NormalizerI
         if (null !== $object->getTargetUrl()) {
             $data['target_url'] = $object->getTargetUrl();
         }
-        $data['required'] = $object->getRequired();
-        $data['avatar_url'] = $object->getAvatarUrl();
+        if (null !== $object->getRequired()) {
+            $data['required'] = $object->getRequired();
+        }
+        if (null !== $object->getAvatarUrl()) {
+            $data['avatar_url'] = $object->getAvatarUrl();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/SimpleUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/SimpleUserNormalizer.php
@@ -110,7 +110,9 @@ class SimpleUserNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/StargazerUserNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/StargazerUserNormalizer.php
@@ -110,7 +110,9 @@ class StargazerUserNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/StatusNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/StatusNormalizer.php
@@ -80,7 +80,9 @@ class StatusNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
-        $data['avatar_url'] = $object->getAvatarUrl();
+        if (null !== $object->getAvatarUrl()) {
+            $data['avatar_url'] = $object->getAvatarUrl();
+        }
         if (null !== $object->getId()) {
             $data['id'] = $object->getId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamDiscussionAuthorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamDiscussionAuthorNormalizer.php
@@ -110,7 +110,9 @@ class TeamDiscussionAuthorNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamDiscussionCommentAuthorNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamDiscussionCommentAuthorNormalizer.php
@@ -110,7 +110,9 @@ class TeamDiscussionCommentAuthorNormalizer implements DenormalizerInterface, No
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamFullNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamFullNormalizer.php
@@ -116,7 +116,9 @@ class TeamFullNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (null !== $object->getSlug()) {
             $data['slug'] = $object->getSlug();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getPrivacy()) {
             $data['privacy'] = $object->getPrivacy();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamFullParentNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamFullParentNormalizer.php
@@ -92,7 +92,9 @@ class TeamFullParentNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getPermission()) {
             $data['permission'] = $object->getPermission();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamNormalizer.php
@@ -92,7 +92,9 @@ class TeamNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
         if (null !== $object->getSlug()) {
             $data['slug'] = $object->getSlug();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getPrivacy()) {
             $data['privacy'] = $object->getPrivacy();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamParentNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamParentNormalizer.php
@@ -92,7 +92,9 @@ class TeamParentNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getPermission()) {
             $data['permission'] = $object->getPermission();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamProjectNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamProjectNormalizer.php
@@ -113,7 +113,9 @@ class TeamProjectNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['body'] = $object->getBody();
+        if (null !== $object->getBody()) {
+            $data['body'] = $object->getBody();
+        }
         if (null !== $object->getNumber()) {
             $data['number'] = $object->getNumber();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamRepositoryLicenseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamRepositoryLicenseNormalizer.php
@@ -68,8 +68,12 @@ class TeamRepositoryLicenseNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['url'] = $object->getUrl();
-        $data['spdx_id'] = $object->getSpdxId();
+        if (null !== $object->getUrl()) {
+            $data['url'] = $object->getUrl();
+        }
+        if (null !== $object->getSpdxId()) {
+            $data['spdx_id'] = $object->getSpdxId();
+        }
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamRepositoryNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamRepositoryNormalizer.php
@@ -360,7 +360,9 @@ class TeamRepositoryNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getHtmlUrl()) {
             $data['html_url'] = $object->getHtmlUrl();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getFork()) {
             $data['fork'] = $object->getFork();
         }
@@ -481,15 +483,21 @@ class TeamRepositoryNormalizer implements DenormalizerInterface, NormalizerInter
         if (null !== $object->getCloneUrl()) {
             $data['clone_url'] = $object->getCloneUrl();
         }
-        $data['mirror_url'] = $object->getMirrorUrl();
+        if (null !== $object->getMirrorUrl()) {
+            $data['mirror_url'] = $object->getMirrorUrl();
+        }
         if (null !== $object->getHooksUrl()) {
             $data['hooks_url'] = $object->getHooksUrl();
         }
         if (null !== $object->getSvnUrl()) {
             $data['svn_url'] = $object->getSvnUrl();
         }
-        $data['homepage'] = $object->getHomepage();
-        $data['language'] = $object->getLanguage();
+        if (null !== $object->getHomepage()) {
+            $data['homepage'] = $object->getHomepage();
+        }
+        if (null !== $object->getLanguage()) {
+            $data['language'] = $object->getLanguage();
+        }
         if (null !== $object->getForksCount()) {
             $data['forks_count'] = $object->getForksCount();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamRepositoryOwnerNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamRepositoryOwnerNormalizer.php
@@ -110,7 +110,9 @@ class TeamRepositoryOwnerNormalizer implements DenormalizerInterface, Normalizer
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamSimpleNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamSimpleNormalizer.php
@@ -92,7 +92,9 @@ class TeamSimpleNormalizer implements DenormalizerInterface, NormalizerInterface
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['description'] = $object->getDescription();
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
         if (null !== $object->getPermission()) {
             $data['permission'] = $object->getPermission();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamsTeamIdPatchBodyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TeamsTeamIdPatchBodyNormalizer.php
@@ -68,7 +68,9 @@ class TeamsTeamIdPatchBodyNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getPermission()) {
             $data['permission'] = $object->getPermission();
         }
-        $data['parent_team_id'] = $object->getParentTeamId();
+        if (null !== $object->getParentTeamId()) {
+            $data['parent_team_id'] = $object->getParentTeamId();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ThreadNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ThreadNormalizer.php
@@ -86,7 +86,9 @@ class ThreadNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if (null !== $object->getUpdatedAt()) {
             $data['updated_at'] = $object->getUpdatedAt();
         }
-        $data['last_read_at'] = $object->getLastReadAt();
+        if (null !== $object->getLastReadAt()) {
+            $data['last_read_at'] = $object->getLastReadAt();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ThreadSubscriptionNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/ThreadSubscriptionNormalizer.php
@@ -71,7 +71,9 @@ class ThreadSubscriptionNormalizer implements DenormalizerInterface, NormalizerI
         if (null !== $object->getIgnored()) {
             $data['ignored'] = $object->getIgnored();
         }
-        $data['reason'] = $object->getReason();
+        if (null !== $object->getReason()) {
+            $data['reason'] = $object->getReason();
+        }
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt()->format('Y-m-d\\TH:i:sP');
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TopicSearchResultItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/TopicSearchResultItemNormalizer.php
@@ -128,11 +128,21 @@ class TopicSearchResultItemNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['display_name'] = $object->getDisplayName();
-        $data['short_description'] = $object->getShortDescription();
-        $data['description'] = $object->getDescription();
-        $data['created_by'] = $object->getCreatedBy();
-        $data['released'] = $object->getReleased();
+        if (null !== $object->getDisplayName()) {
+            $data['display_name'] = $object->getDisplayName();
+        }
+        if (null !== $object->getShortDescription()) {
+            $data['short_description'] = $object->getShortDescription();
+        }
+        if (null !== $object->getDescription()) {
+            $data['description'] = $object->getDescription();
+        }
+        if (null !== $object->getCreatedBy()) {
+            $data['created_by'] = $object->getCreatedBy();
+        }
+        if (null !== $object->getReleased()) {
+            $data['released'] = $object->getReleased();
+        }
         if (null !== $object->getCreatedAt()) {
             $data['created_at'] = $object->getCreatedAt()->format('Y-m-d\\TH:i:sP');
         }
@@ -148,8 +158,12 @@ class TopicSearchResultItemNormalizer implements DenormalizerInterface, Normaliz
         if (null !== $object->getScore()) {
             $data['score'] = $object->getScore();
         }
-        $data['repository_count'] = $object->getRepositoryCount();
-        $data['logo_url'] = $object->getLogoUrl();
+        if (null !== $object->getRepositoryCount()) {
+            $data['repository_count'] = $object->getRepositoryCount();
+        }
+        if (null !== $object->getLogoUrl()) {
+            $data['logo_url'] = $object->getLogoUrl();
+        }
         if (null !== $object->getTextMatches()) {
             $values = array();
             foreach ($object->getTextMatches() as $value) {

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/UserMarketplacePurchaseNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/UserMarketplacePurchaseNormalizer.php
@@ -80,7 +80,9 @@ class UserMarketplacePurchaseNormalizer implements DenormalizerInterface, Normal
         if (null !== $object->getNextBillingDate()) {
             $data['next_billing_date'] = $object->getNextBillingDate()->format('Y-m-d\\TH:i:sP');
         }
-        $data['unit_count'] = $object->getUnitCount();
+        if (null !== $object->getUnitCount()) {
+            $data['unit_count'] = $object->getUnitCount();
+        }
         if (null !== $object->getOnFreeTrial()) {
             $data['on_free_trial'] = $object->getOnFreeTrial();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/UserPatchBodyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/UserPatchBodyNormalizer.php
@@ -74,7 +74,9 @@ class UserPatchBodyNormalizer implements DenormalizerInterface, NormalizerInterf
         if (null !== $object->getBlog()) {
             $data['blog'] = $object->getBlog();
         }
-        $data['twitter_username'] = $object->getTwitterUsername();
+        if (null !== $object->getTwitterUsername()) {
+            $data['twitter_username'] = $object->getTwitterUsername();
+        }
         if (null !== $object->getCompany()) {
             $data['company'] = $object->getCompany();
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/UserProjectsPostBodyNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/UserProjectsPostBodyNormalizer.php
@@ -50,7 +50,9 @@ class UserProjectsPostBodyNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getName()) {
             $data['name'] = $object->getName();
         }
-        $data['body'] = $object->getBody();
+        if (null !== $object->getBody()) {
+            $data['body'] = $object->getBody();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/UserSearchResultItemNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/UserSearchResultItemNormalizer.php
@@ -183,7 +183,9 @@ class UserSearchResultItemNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getAvatarUrl()) {
             $data['avatar_url'] = $object->getAvatarUrl();
         }
-        $data['gravatar_id'] = $object->getGravatarId();
+        if (null !== $object->getGravatarId()) {
+            $data['gravatar_id'] = $object->getGravatarId();
+        }
         if (null !== $object->getUrl()) {
             $data['url'] = $object->getUrl();
         }
@@ -241,14 +243,24 @@ class UserSearchResultItemNormalizer implements DenormalizerInterface, Normalize
         if (null !== $object->getUpdatedAt()) {
             $data['updated_at'] = $object->getUpdatedAt()->format('Y-m-d\\TH:i:sP');
         }
-        $data['name'] = $object->getName();
-        $data['bio'] = $object->getBio();
-        $data['email'] = $object->getEmail();
-        $data['location'] = $object->getLocation();
+        if (null !== $object->getName()) {
+            $data['name'] = $object->getName();
+        }
+        if (null !== $object->getBio()) {
+            $data['bio'] = $object->getBio();
+        }
+        if (null !== $object->getEmail()) {
+            $data['email'] = $object->getEmail();
+        }
+        if (null !== $object->getLocation()) {
+            $data['location'] = $object->getLocation();
+        }
         if (null !== $object->getSiteAdmin()) {
             $data['site_admin'] = $object->getSiteAdmin();
         }
-        $data['hireable'] = $object->getHireable();
+        if (null !== $object->getHireable()) {
+            $data['hireable'] = $object->getHireable();
+        }
         if (null !== $object->getTextMatches()) {
             $values = array();
             foreach ($object->getTextMatches() as $value) {
@@ -256,8 +268,12 @@ class UserSearchResultItemNormalizer implements DenormalizerInterface, Normalize
             }
             $data['text_matches'] = $values;
         }
-        $data['blog'] = $object->getBlog();
-        $data['company'] = $object->getCompany();
+        if (null !== $object->getBlog()) {
+            $data['blog'] = $object->getBlog();
+        }
+        if (null !== $object->getCompany()) {
+            $data['company'] = $object->getCompany();
+        }
         if (null !== $object->getSuspendedAt()) {
             $data['suspended_at'] = $object->getSuspendedAt()->format('Y-m-d\\TH:i:sP');
         }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/VerificationNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/VerificationNormalizer.php
@@ -62,8 +62,12 @@ class VerificationNormalizer implements DenormalizerInterface, NormalizerInterfa
         if (null !== $object->getReason()) {
             $data['reason'] = $object->getReason();
         }
-        $data['payload'] = $object->getPayload();
-        $data['signature'] = $object->getSignature();
+        if (null !== $object->getPayload()) {
+            $data['payload'] = $object->getPayload();
+        }
+        if (null !== $object->getSignature()) {
+            $data['signature'] = $object->getSignature();
+        }
         return $data;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/WorkflowRunNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/github/expected/Normalizer/WorkflowRunNormalizer.php
@@ -141,7 +141,9 @@ class WorkflowRunNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getNodeId()) {
             $data['node_id'] = $object->getNodeId();
         }
-        $data['head_branch'] = $object->getHeadBranch();
+        if (null !== $object->getHeadBranch()) {
+            $data['head_branch'] = $object->getHeadBranch();
+        }
         if (null !== $object->getHeadSha()) {
             $data['head_sha'] = $object->getHeadSha();
         }
@@ -151,8 +153,12 @@ class WorkflowRunNormalizer implements DenormalizerInterface, NormalizerInterfac
         if (null !== $object->getEvent()) {
             $data['event'] = $object->getEvent();
         }
-        $data['status'] = $object->getStatus();
-        $data['conclusion'] = $object->getConclusion();
+        if (null !== $object->getStatus()) {
+            $data['status'] = $object->getStatus();
+        }
+        if (null !== $object->getConclusion()) {
+            $data['conclusion'] = $object->getConclusion();
+        }
         if (null !== $object->getWorkflowId()) {
             $data['workflow_id'] = $object->getWorkflowId();
         }

--- a/src/OpenApi3/Tests/fixtures/issue-391/.jane-openapi
+++ b/src/OpenApi3/Tests/fixtures/issue-391/.jane-openapi
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.yaml',
+    'directory' => __DIR__ . '/generated',
+    'namespace' => 'Gounlaf\JanephpBug',
+    'date-prefer-interface' => true,
+    'date-format' => DATE_ATOM,
+    'strict' => false,
+];

--- a/src/OpenApi3/Tests/fixtures/issue-391/.jane-openapi
+++ b/src/OpenApi3/Tests/fixtures/issue-391/.jane-openapi
@@ -6,5 +6,5 @@ return [
     'namespace' => 'Gounlaf\JanephpBug',
     'date-prefer-interface' => true,
     'date-format' => DATE_ATOM,
-    'strict' => false,
+    'strict' => true,
 ];

--- a/src/OpenApi3/Tests/fixtures/issue-391/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/issue-391/expected/Client.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Gounlaf\JanephpBug;
+
+class Client extends \Jane\OpenApiRuntime\Client\Client
+{
+    /**
+     * 
+     *
+     * @param int $id ID of the entity
+     * @param \Gounlaf\JanephpBug\Model\PatchableEntity $requestBody 
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Gounlaf\JanephpBug\Exception\PatchEntityBadRequestException
+     * @throws \Gounlaf\JanephpBug\Exception\PatchEntityNotFoundException
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function patchEntity(int $id, \Gounlaf\JanephpBug\Model\PatchableEntity $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Gounlaf\JanephpBug\Endpoint\PatchEntity($id, $requestBody), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Gounlaf\JanephpBug\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/issue-391/expected/Endpoint/PatchEntity.php
+++ b/src/OpenApi3/Tests/fixtures/issue-391/expected/Endpoint/PatchEntity.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Endpoint;
+
+class PatchEntity extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Endpoint
+{
+    protected $id;
+    /**
+     * 
+     *
+     * @param int $id ID of the entity
+     * @param \Gounlaf\JanephpBug\Model\PatchableEntity $requestBody 
+     */
+    public function __construct(int $id, \Gounlaf\JanephpBug\Model\PatchableEntity $requestBody)
+    {
+        $this->id = $id;
+        $this->body = $requestBody;
+    }
+    use \Jane\OpenApiRuntime\Client\EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'PATCH';
+    }
+    public function getUri() : string
+    {
+        return str_replace(array('{id}'), array($this->id), '/patchable/entity/{id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        if ($this->body instanceof \Gounlaf\JanephpBug\Model\PatchableEntity) {
+            return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));
+        }
+        return array(array(), null);
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Gounlaf\JanephpBug\Exception\PatchEntityBadRequestException
+     * @throws \Gounlaf\JanephpBug\Exception\PatchEntityNotFoundException
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (202 === $status) {
+            return null;
+        }
+        if (400 === $status) {
+            throw new \Gounlaf\JanephpBug\Exception\PatchEntityBadRequestException();
+        }
+        if (404 === $status) {
+            throw new \Gounlaf\JanephpBug\Exception\PatchEntityNotFoundException();
+        }
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/issue-391/expected/Exception/ApiException.php
+++ b/src/OpenApi3/Tests/fixtures/issue-391/expected/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/OpenApi3/Tests/fixtures/issue-391/expected/Exception/ClientException.php
+++ b/src/OpenApi3/Tests/fixtures/issue-391/expected/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/OpenApi3/Tests/fixtures/issue-391/expected/Exception/PatchEntityBadRequestException.php
+++ b/src/OpenApi3/Tests/fixtures/issue-391/expected/Exception/PatchEntityBadRequestException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Exception;
+
+class PatchEntityBadRequestException extends \RuntimeException implements ClientException
+{
+    public function __construct()
+    {
+        parent::__construct('Invalid request', 400);
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/issue-391/expected/Exception/PatchEntityNotFoundException.php
+++ b/src/OpenApi3/Tests/fixtures/issue-391/expected/Exception/PatchEntityNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Exception;
+
+class PatchEntityNotFoundException extends \RuntimeException implements ClientException
+{
+    public function __construct()
+    {
+        parent::__construct('Entity not found', 404);
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/issue-391/expected/Exception/ServerException.php
+++ b/src/OpenApi3/Tests/fixtures/issue-391/expected/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/OpenApi3/Tests/fixtures/issue-391/expected/Model/PatchableEntity.php
+++ b/src/OpenApi3/Tests/fixtures/issue-391/expected/Model/PatchableEntity.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Model;
+
+class PatchableEntity
+{
+    /**
+     * 
+     *
+     * @var string|null
+     */
+    protected $nullableProperty;
+    /**
+     * 
+     *
+     * @var string|null
+     */
+    protected $nullableAndRequiredProperty;
+    /**
+     * 
+     *
+     * @return string|null
+     */
+    public function getNullableProperty() : ?string
+    {
+        return $this->nullableProperty;
+    }
+    /**
+     * 
+     *
+     * @param string|null $nullableProperty
+     *
+     * @return self
+     */
+    public function setNullableProperty(?string $nullableProperty) : self
+    {
+        $this->nullableProperty = $nullableProperty;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string|null
+     */
+    public function getNullableAndRequiredProperty() : ?string
+    {
+        return $this->nullableAndRequiredProperty;
+    }
+    /**
+     * 
+     *
+     * @param string|null $nullableAndRequiredProperty
+     *
+     * @return self
+     */
+    public function setNullableAndRequiredProperty(?string $nullableAndRequiredProperty) : self
+    {
+        $this->nullableAndRequiredProperty = $nullableAndRequiredProperty;
+        return $this;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/issue-391/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/issue-391/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Normalizer;
+
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('Gounlaf\\JanephpBug\\Model\\PatchableEntity' => 'Gounlaf\\JanephpBug\\Normalizer\\PatchableEntityNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchemaRuntime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/issue-391/expected/Normalizer/PatchableEntityNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/issue-391/expected/Normalizer/PatchableEntityNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Gounlaf\JanephpBug\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class PatchableEntityNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Gounlaf\\JanephpBug\\Model\\PatchableEntity';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Gounlaf\\JanephpBug\\Model\\PatchableEntity';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Gounlaf\JanephpBug\Model\PatchableEntity();
+        if (\array_key_exists('nullable_property', $data) && $data['nullable_property'] !== null) {
+            $object->setNullableProperty($data['nullable_property']);
+        }
+        elseif (\array_key_exists('nullable_property', $data) && $data['nullable_property'] === null) {
+            $object->setNullableProperty(null);
+        }
+        if (\array_key_exists('nullable_and_required_property', $data) && $data['nullable_and_required_property'] !== null) {
+            $object->setNullableAndRequiredProperty($data['nullable_and_required_property']);
+        }
+        elseif (\array_key_exists('nullable_and_required_property', $data) && $data['nullable_and_required_property'] === null) {
+            $object->setNullableAndRequiredProperty(null);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getNullableProperty()) {
+            $data['nullable_property'] = $object->getNullableProperty();
+        }
+        if (null !== $object->getNullableAndRequiredProperty()) {
+            $data['nullable_and_required_property'] = $object->getNullableAndRequiredProperty();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/issue-391/swagger.yaml
+++ b/src/OpenApi3/Tests/fixtures/issue-391/swagger.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Bug example for Jane PHP
+
+paths:
+  '/patchable/entity/{id}':
+    patch:
+      operationId: 'patchEntity'
+      summary: 'Update (partially) an entity'
+      parameters:
+        - name: id
+          in: path
+          description: ID of the entity
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchableEntity'
+      responses:
+        '202':
+          $ref: '#/components/responses/Accepted'
+        '400':
+          $ref: '#/components/responses/InvalidRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+components:
+  responses:
+    Accepted:
+      description: Request accepted
+    InvalidRequest:
+      description: Invalid request
+    NotFound:
+      description: Entity not found
+  schemas:
+    PatchableEntity:
+      type: object
+      properties:
+        nullable_property:
+          type: string
+          nullable: true
+        nullable_and_required_property:
+          type: string
+          nullable: true
+      required:
+        - nullable_and_required_property

--- a/src/OpenApi3/Tests/fixtures/skip-null-values/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/skip-null-values/expected/Normalizer/ModelNormalizer.php
@@ -53,7 +53,12 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['foo'] = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data['foo'] = $object->getFoo();
+        }
+        else {
+            $data['foo'] = null;
+        }
         if (null !== $object->getBar()) {
             $data['bar'] = $object->getBar();
         }

--- a/src/OpenApi3/Tests/fixtures/test-nullable-array/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/test-nullable-array/expected/Normalizer/ModelNormalizer.php
@@ -54,7 +54,9 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['foo'] = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data['foo'] = $object->getFoo();
+        }
         if (null !== $object->getBar()) {
             $values = array();
             foreach ($object->getBar() as $value) {

--- a/src/OpenApi3/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/test-nullable/expected/Normalizer/ModelNormalizer.php
@@ -53,7 +53,9 @@ class ModelNormalizer implements DenormalizerInterface, NormalizerInterface, Den
     public function normalize($object, $format = null, array $context = array())
     {
         $data = array();
-        $data['foo'] = $object->getFoo();
+        if (null !== $object->getFoo()) {
+            $data['foo'] = $object->getFoo();
+        }
         if (null !== $object->getBar()) {
             $data['bar'] = $object->getBar();
         }


### PR DESCRIPTION
When we had a nullable property, it wasn't handled correctly because the primitive type `null` wasn't part of the declaration, but for OpenAPI3, there is no "null" type since nullability is defined with `nullable` property.