### PR TITLE
Throw unexpected status code when nothing matched in Endpoint

### DIFF
--- a/documentation/components/OpenAPI.rst
+++ b/documentation/components/OpenAPI.rst
@@ -199,6 +199,8 @@ Other options are available to customize the generated code:
    given type (``bool``, ``int``, ``string``, ...) and give it your class that contains the custom normalizer by
    extending the ``\Jane\OpenApiRuntime\Client\CustomQueryResolver``. You can also filter the usage of your custom
    normalizer by giving the exact path, method and parameter name where you want to apply it.
+ * ``throw-unexpected-status-code``: Will return a ``UnexpectedStatusCodeException`` if nothing has been matched during
+   the transformation of the Endpoint body (including described exceptions). By default, it's disabled.
 
 .. _`JSON Reference`: https://tools.ietf.org/id/draft-pbryan-zyp-json-ref-03.html
 .. _`Carbon`: https://carbon.nesbot.com/

--- a/src/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -64,7 +64,7 @@ trait GetTransformResponseBodyTrait
             $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\UnexpectedStatusCodeException';
             $throwTypes[] = $throwType;
             $outputStatements = array_merge($outputStatements, [
-                new Stmt\Throw_(new Expr\New_(new Name($throwType))),
+                new Stmt\Throw_(new Expr\New_(new Name($throwType)), [new Arg(new Node\Expr\Variable('status'))]),
             ]);
         }
 

--- a/src/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -64,7 +64,7 @@ trait GetTransformResponseBodyTrait
             $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\UnexpectedStatusCodeException';
             $throwTypes[] = $throwType;
             $outputStatements = array_merge($outputStatements, [
-                new Stmt\Throw_(new Expr\New_(new Name($throwType)), [new Arg(new Node\Expr\Variable('status'))]),
+                new Stmt\Throw_(new Expr\New_(new Name($throwType), [new Arg(new Node\Expr\Variable('status'))])),
             ]);
         }
 

--- a/src/OpenApi2/Generator/EndpointGenerator.php
+++ b/src/OpenApi2/Generator/EndpointGenerator.php
@@ -76,7 +76,7 @@ class EndpointGenerator implements EndpointGeneratorInterface
         $endpointName = $this->operationNaming->getEndpointName($operation);
 
         [$constructorMethod, $methodParams, $methodParamsDoc, $pathProperties] = $this->getConstructor($operation, $context, $this->guessClass, $this->bodyParameterGenerator, $this->nonBodyParameterGenerator);
-        [$transformBodyMethod, $outputTypes, $throwTypes] = $this->getTransformResponseBody($operation, $endpointName, $this->guessClass, $context);
+        [$transformBodyMethod, $outputTypes, $throwTypes] = $this->getTransformResponseBody($operation, $endpointName, $this->guessClass, $this->exceptionGenerator, $context);
         $class = new Stmt\Class_($endpointName, [
             'extends' => new Name\FullyQualified(BaseEndpoint::class),
             'implements' => [new Name\FullyQualified(Endpoint::class)],

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/.jane-openapi
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/.jane-openapi
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ .  '/swagger.json',
+    'namespace' => 'Jane\OpenApi2\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'throw-unexpected-status-code' => true,
+    'use-fixer' => false,
+];

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Client.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\OpenApi2\Tests\Expected\Exception\UnexpectedStatusCodeException
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function testNoTag(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\OpenApi2\Tests\Expected\Endpoint\TestNoTag(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Endpoint/TestNoTag.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Endpoint/TestNoTag.php
@@ -29,7 +29,7 @@ class TestNoTag extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jan
         if (200 === $status) {
             return null;
         }
-        throw new \Jane\OpenApi2\Tests\Expected\Exception\UnexpectedStatusCodeException();
+        throw new \Jane\OpenApi2\Tests\Expected\Exception\UnexpectedStatusCodeException($status);
     }
     public function getAuthenticationScopes() : array
     {

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Endpoint/TestNoTag.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Endpoint/TestNoTag.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Endpoint;
+
+class TestNoTag extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Endpoint
+{
+    use \Jane\OpenApiRuntime\Client\EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/test-exception';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\OpenApi2\Tests\Expected\Exception\UnexpectedStatusCodeException
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType)
+    {
+        if (200 === $status) {
+            return null;
+        }
+        throw new \Jane\OpenApi2\Tests\Expected\Exception\UnexpectedStatusCodeException();
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/ApiException.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/ClientException.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/ServerException.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Exception;
+
+final class UnexpectedStatusCodeException implements ClientException
+{
+}

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -4,4 +4,8 @@ namespace Jane\OpenApi2\Tests\Expected\Exception;
 
 final class UnexpectedStatusCodeException implements ClientException
 {
+    public function __construct($status)
+    {
+        parent::__construct('', $status)
+    }
 }

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -6,6 +6,6 @@ final class UnexpectedStatusCodeException implements ClientException
 {
     public function __construct($status)
     {
-        parent::__construct('', $status)
+        parent::__construct('', $status);
     }
 }

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchemaRuntime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/swagger.json
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/swagger.json
@@ -1,0 +1,16 @@
+{
+    "swagger": "2.0",
+    "basePath": "/",
+    "paths": {
+        "/test-exception": {
+            "get": {
+                "operationId": "Test No Tag",
+                "responses": {
+                    "200": {
+                        "description": "Bad request on test exception",
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -85,7 +85,7 @@ trait GetTransformResponseBodyTrait
             $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\UnexpectedStatusCodeException';
             $throwTypes[] = $throwType;
             $outputStatements = array_merge($outputStatements, [
-                new Stmt\Throw_(new Expr\New_(new Name($throwType))),
+                new Stmt\Throw_(new Expr\New_(new Name($throwType), [new Node\Arg(new Node\Expr\Variable('status'))])),
             ]);
         }
 

--- a/src/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -79,6 +79,16 @@ trait GetTransformResponseBodyTrait
             $throwTypes = array_unique($throwTypes);
         }
 
+        if ($context->getRegistry()->getThrowUnexpectedStatusCode()) {
+            $exceptionGenerator->createBaseExceptions($context);
+
+            $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\UnexpectedStatusCodeException';
+            $throwTypes[] = $throwType;
+            $outputStatements = array_merge($outputStatements, [
+                new Stmt\Throw_(new Expr\New_(new Name($throwType))),
+            ]);
+        }
+
         $returnDoc = implode('', array_map(function ($value) {
             return ' * @throws ' . $value . "\n";
         }, $throwTypes))

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/.jane-openapi
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.yaml',
+    'namespace' => 'Jane\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'throw-unexpected-status-code' => true,
+];

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Client.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\OpenApiRuntime\Client\Client
+{
+    /**
+     * 
+     *
+     * @param \Jane\OpenApi3\Tests\Expected\Model\FooPayload $requestBody 
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function postFoo(\Jane\OpenApi3\Tests\Expected\Model\FooPayload $requestBody, string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\OpenApi3\Tests\Expected\Endpoint\PostFoo($requestBody), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Endpoint/PostFoo.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Endpoint/PostFoo.php
@@ -41,7 +41,7 @@ class PostFoo extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\
         if (200 === $status) {
             return null;
         }
-        throw new \Jane\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException();
+        throw new \Jane\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException($status);
     }
     public function getAuthenticationScopes() : array
     {

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Endpoint/PostFoo.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Endpoint/PostFoo.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Endpoint;
+
+class PostFoo extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Jane\OpenApiRuntime\Client\Endpoint
+{
+    /**
+     * 
+     *
+     * @param \Jane\OpenApi3\Tests\Expected\Model\FooPayload $requestBody 
+     */
+    public function __construct(\Jane\OpenApi3\Tests\Expected\Model\FooPayload $requestBody)
+    {
+        $this->body = $requestBody;
+    }
+    use \Jane\OpenApiRuntime\Client\EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'POST';
+    }
+    public function getUri() : string
+    {
+        return '/foo';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        if ($this->body instanceof \Jane\OpenApi3\Tests\Expected\Model\FooPayload) {
+            return array(array('Content-Type' => array('application/json')), $serializer->serialize($this->body, 'json'));
+        }
+        return array(array(), null);
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status) {
+            return null;
+        }
+        throw new \Jane\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException();
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/ApiException.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/ClientException.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/ServerException.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -6,6 +6,6 @@ final class UnexpectedStatusCodeException implements ClientException
 {
     public function __construct($status)
     {
-        parent::__construct('', $status)
+        parent::__construct('', $status);
     }
 }

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Exception;
+
+final class UnexpectedStatusCodeException implements ClientException
+{
+}

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -4,4 +4,8 @@ namespace Jane\OpenApi3\Tests\Expected\Exception;
 
 final class UnexpectedStatusCodeException implements ClientException
 {
+    public function __construct($status)
+    {
+        parent::__construct('', $status)
+    }
 }

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Model/FooPayload.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Model/FooPayload.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Model;
+
+class FooPayload
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $label;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getLabel() : string
+    {
+        return $this->label;
+    }
+    /**
+     * 
+     *
+     * @param string $label
+     *
+     * @return self
+     */
+    public function setLabel(string $label) : self
+    {
+        $this->label = $label;
+        return $this;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Normalizer/FooPayloadNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Normalizer/FooPayloadNormalizer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FooPayloadNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\OpenApi3\\Tests\\Expected\\Model\\FooPayload';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi3\\Tests\\Expected\\Model\\FooPayload';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\OpenApi3\Tests\Expected\Model\FooPayload();
+        if (\array_key_exists('label', $data)) {
+            $object->setLabel($data['label']);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getLabel()) {
+            $data['label'] = $object->getLabel();
+        }
+        return $data;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('Jane\\OpenApi3\\Tests\\Expected\\Model\\FooPayload' => 'Jane\\OpenApi3\\Tests\\Expected\\Normalizer\\FooPayloadNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchemaRuntime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/swagger.yaml
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/swagger.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Whitelist - Request body processing
+  version: 1.0.0
+paths:
+  /foo:
+    post:
+      summary: Add foo entity
+      requestBody:
+        description: Foo item to add
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FooPayload'
+      responses:
+        '200':
+          description: Foo item created
+
+components:
+  schemas:
+    FooPayload:
+      type: object
+      properties:
+        label:
+          type: string
+

--- a/src/OpenApiCommon/Console/Command/GenerateCommand.php
+++ b/src/OpenApiCommon/Console/Command/GenerateCommand.php
@@ -70,6 +70,7 @@ class GenerateCommand extends BaseGenerateCommand
         $registry = new Registry();
         $registry->setOpenApiClass($this->matcher->match($schemaFile));
         $registry->setWhitelistedPaths($options['whitelisted-paths'] ?? []);
+        $registry->setThrowUnexpectedStatusCode($options['throw-unexpected-status-code'] ?? false);
 
         $customQueryResolver = [];
         foreach ($options['custom-query-resolver'] ?? [] as $path => $methods) {

--- a/src/OpenApiCommon/Console/Loader/ConfigLoader.php
+++ b/src/OpenApiCommon/Console/Loader/ConfigLoader.php
@@ -27,6 +27,7 @@ class ConfigLoader extends BaseConfigLoader implements ConfigLoaderInterface
             'whitelisted-paths' => null,
             'endpoint-generator' => null,
             'custom-query-resolver' => [],
+            'throw-unexpected-status-code' => false,
         ]);
     }
 }

--- a/src/OpenApiCommon/Console/Loader/SchemaLoader.php
+++ b/src/OpenApiCommon/Console/Loader/SchemaLoader.php
@@ -33,6 +33,7 @@ class SchemaLoader extends BaseSchemaLoader implements SchemaLoaderInterface
             'whitelisted-paths',
             'endpoint-generator',
             'custom-query-resolver',
+            'throw-unexpected-status-code',
         ];
     }
 

--- a/src/OpenApiCommon/Generator/ExceptionGenerator.php
+++ b/src/OpenApiCommon/Generator/ExceptionGenerator.php
@@ -179,6 +179,20 @@ class ExceptionGenerator
                             new Name('ClientException'),
                         ],
                         'flags' => Stmt\Class_::MODIFIER_FINAL,
+                        'stmts' => [
+                            new Stmt\ClassMethod('__construct', [
+                                'type' => Stmt\Class_::MODIFIER_PUBLIC,
+                                'params' => [
+                                    new Param(new Expr\Variable('status')),
+                                ],
+                                'stmts' => [
+                                    new Expr\StaticCall(new Name('parent'), '__construct', [
+                                        new Node\Arg(new Scalar\String_('')),
+                                        new Node\Arg(new Expr\Variable('status')),
+                                    ]),
+                                ],
+                            ]),
+                        ],
                     ]
                 ),
             ]);

--- a/src/OpenApiCommon/Generator/ExceptionGenerator.php
+++ b/src/OpenApiCommon/Generator/ExceptionGenerator.php
@@ -186,10 +186,10 @@ class ExceptionGenerator
                                     new Param(new Expr\Variable('status')),
                                 ],
                                 'stmts' => [
-                                    new Expr\StaticCall(new Name('parent'), '__construct', [
+                                    new Stmt\Expression(new Expr\StaticCall(new Name('parent'), '__construct', [
                                         new Node\Arg(new Scalar\String_('')),
                                         new Node\Arg(new Expr\Variable('status')),
-                                    ]),
+                                    ])),
                                 ],
                             ]),
                         ],

--- a/src/OpenApiCommon/Generator/ExceptionGenerator.php
+++ b/src/OpenApiCommon/Generator/ExceptionGenerator.php
@@ -5,7 +5,6 @@ namespace Jane\OpenApiCommon\Generator;
 use Jane\JsonSchema\Generator\Context\Context;
 use Jane\JsonSchema\Generator\File;
 use Jane\JsonSchema\Guesser\Guess\ClassGuess;
-use Jane\JsonSchema\Registry\Schema;
 use Jane\OpenApiCommon\Naming\ExceptionNaming;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
@@ -32,13 +31,7 @@ class ExceptionGenerator
         }
 
         $schema = $context->getCurrentSchema();
-        $schema->getRootName();
-
-        $unique = $schema->getRootName() . $schema->getDirectory();
-        if (!isset($this->intialized[$unique])) {
-            $this->intialized[$unique] = true;
-            $this->createBaseExceptions($schema);
-        }
+        $this->createBaseExceptions($context);
 
         $exceptionName = $this->exceptionNaming->generateExceptionName($status, $functionName);
 
@@ -129,8 +122,17 @@ class ExceptionGenerator
         return $exceptionName;
     }
 
-    protected function createBaseExceptions(Schema $schema): void
+    public function createBaseExceptions(Context $context): void
     {
+        $schema = $context->getCurrentSchema();
+        $registry = $context->getRegistry();
+
+        $unique = $schema->getRootName() . $schema->getDirectory();
+        if (\array_key_exists($unique, $this->intialized)) {
+            return;
+        }
+        $this->intialized[$unique] = true;
+
         $apiException = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Exception'), [
             new Stmt\Interface_(
                 new Name('ApiException'),
@@ -167,5 +169,21 @@ class ExceptionGenerator
         $schema->addFile(new File($schema->getDirectory() . '/Exception/ApiException.php', $apiException, 'Exception'));
         $schema->addFile(new File($schema->getDirectory() . '/Exception/ClientException.php', $clientException, 'Exception'));
         $schema->addFile(new File($schema->getDirectory() . '/Exception/ServerException.php', $serverException, 'Exception'));
+
+        if ($registry->getThrowUnexpectedStatusCode()) {
+            $unexpectedStatusCodeException = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Exception'), [
+                new Stmt\Class_(
+                    new Name('UnexpectedStatusCodeException'),
+                    [
+                        'implements' => [
+                            new Name('ClientException'),
+                        ],
+                        'flags' => Stmt\Class_::MODIFIER_FINAL,
+                    ]
+                ),
+            ]);
+
+            $schema->addFile(new File($schema->getDirectory() . '/Exception/UnexpectedStatusCodeException.php', $unexpectedStatusCodeException, 'Exception'));
+        }
     }
 }

--- a/src/OpenApiCommon/Registry/Registry.php
+++ b/src/OpenApiCommon/Registry/Registry.php
@@ -17,6 +17,9 @@ class Registry extends BaseRegistry implements RegistryInterface
     /** @var array */
     private $customQueryResolver;
 
+    /** @var bool */
+    private $throwUnexpectedStatusCode;
+
     public function setOpenApiClass(string $openApiClass): void
     {
         $this->openApiClass = $openApiClass;
@@ -47,6 +50,16 @@ class Registry extends BaseRegistry implements RegistryInterface
         return $this->customQueryResolver;
     }
 
+    public function setThrowUnexpectedStatusCode(bool $throwUnexpectedStatusCode): void
+    {
+        $this->throwUnexpectedStatusCode = $throwUnexpectedStatusCode;
+    }
+
+    public function getThrowUnexpectedStatusCode(): bool
+    {
+        return $this->throwUnexpectedStatusCode;
+    }
+
     public function hasSecurityScheme($securitySchemeReference): bool
     {
         return null !== $this->getClass($securitySchemeReference);
@@ -69,6 +82,7 @@ class Registry extends BaseRegistry implements RegistryInterface
         return md5(json_encode([
             'open-api-class' => $this->getOpenApiClass(),
             'whitelisted-paths' => $this->getWhitelistedPaths(),
+            'throw-unexpected-status-code' => $this->getThrowUnexpectedStatusCode(),
         ]));
     }
 }


### PR DESCRIPTION
Fix #377

Will allow to throw an `UnexpectedStatusCodeException` if nothing has been matched during an Endpoint body transformation.