### PR TITLE
Update AutoMapper to be able to bind custom TransformerFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img width="500" height="180" src="https://raw.githubusercontent.com/janephp/janephp/master/identity/logo_jane_full@4x.png" alt="Jane logo" />
+    <img width="500" height="180" src="https://raw.githubusercontent.com/janephp/janephp/next/identity/logo_jane_full@4x.png" alt="Jane logo" />
 </p>
 
 [![Latest Version](https://img.shields.io/github/release/janephp/janephp.svg?style=flat-square)](https://github.com/janephp/janephp/releases)

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "friendsofphp/php-cs-fixer": "2.16.3",
         "phpbench/phpbench": "@dev",
         "phpunit/phpunit": "^8.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0"
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "moneyphp/money": "^3.0"
     },
     "suggest": {
         "friendsofphp/php-cs-fixer": "Allow to automatically fix cs on generated code for better visualisation"

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -5,10 +5,10 @@ Documentation for the Jane libraries
 ## Resources
 
  * [Documentation](http://jane.readthedocs.io/en/latest/)
- * [Contributing](https://github.com/janephp/janephp/blob/master/CONTRIBUTING.md)
- * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls) 
+ * [Contributing](https://github.com/janephp/janephp/blob/next/CONTRIBUTING.md)
+ * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls)
  in the [main Jane Repository](https://github.com/janephp/janephp)
- 
+
 ## Sponsor
 
 [![JoliCode](https://jolicode.com/images/logo.svg)](https://jolicode.com)

--- a/documentation/components/AutoMapper.rst
+++ b/documentation/components/AutoMapper.rst
@@ -130,6 +130,21 @@ Type casting
 
 This component will try to correctly map scalar values (going from int to string, etc).
 
+Transformer extension
+~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes you have to convert special objects (such as ``\Money\Money`` from ``moneyphp\money`` package), to do that you should create a
+custom TransformerFactory and its Transformers. We made `an example in the AutoMapper tests files`_ that you can look at.
+
+To use a custom TransformerFactory class, you have to do as following::
+
+    $autoMapper->bindTransformer(new TransformerFactory());
+
+With the Symfony bundle, you have to tag your TransformerFactory class with a ``jane_auto_mapper.transformer_factory`` tag.
+This will use automatically the TransformerFactory.
+
+.. _`an example in the AutoMapper tests files`: https://github.com/janephp/janephp/tree/next/src/AutoMapper/Tests/Fixtures/Transformer
+
 Implementation
 --------------
 

--- a/src/AutoMapper/AutoMapper.php
+++ b/src/AutoMapper/AutoMapper.php
@@ -168,7 +168,9 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface, Ma
      */
     public function bindTransformerFactory(TransformerFactoryInterface $transformerFactory): void
     {
-        $this->chainTransformerFactory->addTransformerFactory($transformerFactory);
+        if (!$this->chainTransformerFactory->hasTransformerFactory($transformerFactory)) {
+            $this->chainTransformerFactory->addTransformerFactory($transformerFactory);
+        }
     }
 
     /**

--- a/src/AutoMapper/Bundle/Resources/config/services.xml
+++ b/src/AutoMapper/Bundle/Resources/config/services.xml
@@ -6,6 +6,7 @@
     <services>
         <service id="Jane\AutoMapper\Bundle\AutoMapper">
             <argument type="service" id="Jane\AutoMapper\Loader\FileLoader" />
+            <argument type="service" id="Jane\AutoMapper\Transformer\ChainTransformerFactory" />
             <argument type="service" id="Jane\AutoMapper\MapperGeneratorMetadataFactoryInterface" />
         </service>
         <service id="Jane\AutoMapper\AutoMapperInterface" alias="Jane\AutoMapper\Bundle\AutoMapper" public="true" />

--- a/src/AutoMapper/MapperGeneratorMetadataRegistryInterface.php
+++ b/src/AutoMapper/MapperGeneratorMetadataRegistryInterface.php
@@ -2,6 +2,8 @@
 
 namespace Jane\AutoMapper;
 
+use Jane\AutoMapper\Transformer\TransformerFactoryInterface;
+
 /**
  * Registry of metadata.
  *
@@ -13,6 +15,11 @@ interface MapperGeneratorMetadataRegistryInterface
      * Register metadata.
      */
     public function register(MapperGeneratorMetadataInterface $configuration): void;
+
+    /**
+     * Bind custom TransformerFactory to the AutoMapper.
+     */
+    public function bindTransformerFactory(TransformerFactoryInterface $transformerFactory): void;
 
     /**
      * Get metadata for a source and a target.

--- a/src/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/AutoMapper/Tests/AutoMapperTest.php
@@ -676,4 +676,20 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertEquals(1000, $data['price']['amount']);
         self::assertEquals('EUR', $data['price']['currency']);
     }
+
+    public function testCustomTransformerFromObjectToObject(): void
+    {
+        $this->autoMapper->bindTransformerFactory(new MoneyTransformerFactory());
+
+        $order = new Order();
+        $order->id = 4582;
+        $order->price = new \Money\Money(1000, new \Money\Currency('EUR'));
+        $newOrder = new Order();
+        $newOrder = $this->autoMapper->map($order, $newOrder);
+
+        self::assertInstanceOf(Fixtures\Order::class, $newOrder);
+        self::assertInstanceOf(\Money\Money::class, $newOrder->price);
+        self::assertEquals(1000, $newOrder->price->getAmount());
+        self::assertEquals('EUR', $newOrder->price->getCurrency()->getCode());
+    }
 }

--- a/src/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/AutoMapper/Tests/AutoMapperTest.php
@@ -6,6 +6,8 @@ use Jane\AutoMapper\AutoMapper;
 use Jane\AutoMapper\Exception\CircularReferenceException;
 use Jane\AutoMapper\Exception\NoMappingFoundException;
 use Jane\AutoMapper\MapperContext;
+use Jane\AutoMapper\Tests\Fixtures\Order;
+use Jane\AutoMapper\Tests\Fixtures\Transformer\MoneyTransformerFactory;
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 
 /**
@@ -638,5 +640,40 @@ class AutoMapperTest extends AutoMapperBaseTest
 
         self::assertInstanceOf(Fixtures\UserDTOProperties::class, $dto);
         self::assertSame(['foo' => 'bar'], $dto->getProperties());
+    }
+
+    public function testCustomTransformerFromArrayToObject(): void
+    {
+        $this->autoMapper->bindTransformerFactory(new MoneyTransformerFactory());
+
+        $data = [
+            'id' => 4582,
+            'price' => [
+                'amount' => 1000,
+                'currency' => 'EUR',
+            ],
+        ];
+        $order = $this->autoMapper->map($data, Fixtures\Order::class);
+
+        self::assertInstanceOf(Fixtures\Order::class, $order);
+        self::assertInstanceOf(\Money\Money::class, $order->price);
+        self::assertEquals(1000, $order->price->getAmount());
+        self::assertEquals('EUR', $order->price->getCurrency()->getCode());
+    }
+
+    public function testCustomTransformerFromObjectToArray(): void
+    {
+        $this->autoMapper->bindTransformerFactory(new MoneyTransformerFactory());
+
+        $order = new Order();
+        $order->id = 4582;
+        $order->price = new \Money\Money(1000, new \Money\Currency('EUR'));
+        $data = $this->autoMapper->map($order, 'array');
+
+        self::assertIsArray($data);
+        self::assertEquals(4582, $data['id']);
+        self::assertIsArray($data['price']);
+        self::assertEquals(1000, $data['price']['amount']);
+        self::assertEquals('EUR', $data['price']['currency']);
     }
 }

--- a/src/AutoMapper/Tests/Fixtures/Order.php
+++ b/src/AutoMapper/Tests/Fixtures/Order.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jane\AutoMapper\Tests\Fixtures;
+
+use Money\Money;
+
+class Order
+{
+    /** @var int */
+    public $id;
+
+    /** @var Money */
+    public $price;
+}

--- a/src/AutoMapper/Tests/Fixtures/Transformer/ArrayToMoneyTransformer.php
+++ b/src/AutoMapper/Tests/Fixtures/Transformer/ArrayToMoneyTransformer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\AutoMapper\Tests\Fixtures\Transformer;
+
+use Jane\AutoMapper\Extractor\PropertyMapping;
+use Jane\AutoMapper\Generator\UniqueVariableScope;
+use Jane\AutoMapper\Transformer\TransformerInterface;
+use Money\Currency;
+use Money\Money;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+
+/**
+ * Transform an array to Money\Money object.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class ArrayToMoneyTransformer implements TransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [new Expr\New_(new Name\FullyQualified(Money::class), [
+            new Arg(new Expr\ArrayDimFetch($input, new String_('amount'))),
+            new Arg(new Expr\New_(new Name\FullyQualified(Currency::class), [
+                new Arg(new Expr\ArrayDimFetch($input, new String_('currency'))),
+            ])),
+        ]), []];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assignByRef(): bool
+    {
+        return false;
+    }
+}

--- a/src/AutoMapper/Tests/Fixtures/Transformer/MoneyToArrayTransformer.php
+++ b/src/AutoMapper/Tests/Fixtures/Transformer/MoneyToArrayTransformer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Jane\AutoMapper\Tests\Fixtures\Transformer;
+
+use Jane\AutoMapper\Extractor\PropertyMapping;
+use Jane\AutoMapper\Generator\UniqueVariableScope;
+use Jane\AutoMapper\Transformer\TransformerInterface;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Expression;
+
+/**
+ * Transform a Money\Money object to an array.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class MoneyToArrayTransformer implements TransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        $moneyVar = new Expr\Variable($uniqueVariableScope->getUniqueName('money'));
+
+        return [$moneyVar, [
+            new Expression(new Expr\Assign(new Expr\ArrayDimFetch($moneyVar, new String_('amount')), new Expr\MethodCall($input, 'getAmount'))),
+            new Expression(new Expr\Assign(new Expr\ArrayDimFetch($moneyVar, new String_('currency')), new Expr\MethodCall(new Expr\MethodCall($input, 'getCurrency'), 'getCode'))),
+        ]];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assignByRef(): bool
+    {
+        return false;
+    }
+}

--- a/src/AutoMapper/Tests/Fixtures/Transformer/MoneyToMoneyTransformer.php
+++ b/src/AutoMapper/Tests/Fixtures/Transformer/MoneyToMoneyTransformer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Jane\AutoMapper\Tests\Fixtures\Transformer;
+
+use Jane\AutoMapper\Extractor\PropertyMapping;
+use Jane\AutoMapper\Generator\UniqueVariableScope;
+use Jane\AutoMapper\Transformer\TransformerInterface;
+use Money\Currency;
+use Money\Money;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+
+/**
+ * Transform a Money\Money object to a new Money\Money object.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class MoneyToMoneyTransformer implements TransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [
+            new Expr\New_(new Name\FullyQualified(Money::class), [
+                new Arg(new Expr\MethodCall($input, 'getAmount')),
+                new Arg(new Expr\New_(new Name\FullyQualified(Currency::class), [
+                    new Arg(new Expr\MethodCall(new Expr\MethodCall($input, 'getCurrency'), 'getCode')),
+                ])),
+            ]),
+            [],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function assignByRef(): bool
+    {
+        return false;
+    }
+}

--- a/src/AutoMapper/Tests/Fixtures/Transformer/MoneyTransformerFactory.php
+++ b/src/AutoMapper/Tests/Fixtures/Transformer/MoneyTransformerFactory.php
@@ -21,6 +21,10 @@ final class MoneyTransformerFactory extends AbstractUniqueTypeTransformerFactory
         $isSourceMoney = $this->isMoneyType($sourceType);
         $isTargetMoney = $this->isMoneyType($targetType);
 
+        if ($isSourceMoney && $isTargetMoney) {
+            return $this->createTransformerForSourceAndTarget();
+        }
+
         if ($isSourceMoney && !$isTargetMoney) {
             return $this->createTransformerForSource($targetType);
         }
@@ -48,6 +52,11 @@ final class MoneyTransformerFactory extends AbstractUniqueTypeTransformerFactory
         }
 
         return null;
+    }
+
+    protected function createTransformerForSourceAndTarget(): TransformerInterface
+    {
+        return new MoneyToMoneyTransformer();
     }
 
     private function isMoneyType(Type $type): bool

--- a/src/AutoMapper/Tests/Fixtures/Transformer/MoneyTransformerFactory.php
+++ b/src/AutoMapper/Tests/Fixtures/Transformer/MoneyTransformerFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Jane\AutoMapper\Tests\Fixtures\Transformer;
+
+use Jane\AutoMapper\MapperMetadataInterface;
+use Jane\AutoMapper\Transformer\AbstractUniqueTypeTransformerFactory;
+use Jane\AutoMapper\Transformer\TransformerInterface;
+use Money\Money;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class MoneyTransformerFactory extends AbstractUniqueTypeTransformerFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createTransformer(Type $sourceType, Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        $isSourceMoney = $this->isMoneyType($sourceType);
+        $isTargetMoney = $this->isMoneyType($targetType);
+
+        if ($isSourceMoney && !$isTargetMoney) {
+            return $this->createTransformerForSource($targetType);
+        }
+
+        if ($isTargetMoney && !$isSourceMoney) {
+            return $this->createTransformerForTarget($sourceType);
+        }
+
+        return null;
+    }
+
+    protected function createTransformerForSource(Type $targetType): ?TransformerInterface
+    {
+        if (Type::BUILTIN_TYPE_ARRAY === $targetType->getBuiltinType()) {
+            return new MoneyToArrayTransformer();
+        }
+
+        return null;
+    }
+
+    protected function createTransformerForTarget(Type $sourceType): ?TransformerInterface
+    {
+        if (Type::BUILTIN_TYPE_ARRAY === $sourceType->getBuiltinType()) {
+            return new ArrayToMoneyTransformer();
+        }
+
+        return null;
+    }
+
+    private function isMoneyType(Type $type): bool
+    {
+        if (Type::BUILTIN_TYPE_OBJECT !== $type->getBuiltinType()) {
+            return false;
+        }
+
+        if (Money::class !== $type->getClassName() && !is_subclass_of($type->getClassName(), Money::class)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 3;
+    }
+}

--- a/src/AutoMapper/Transformer/ArrayTransformerFactory.php
+++ b/src/AutoMapper/Transformer/ArrayTransformerFactory.php
@@ -44,4 +44,12 @@ final class ArrayTransformerFactory extends AbstractUniqueTypeTransformerFactory
 
         return null;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 4;
+    }
 }

--- a/src/AutoMapper/Transformer/BuiltinTransformerFactory.php
+++ b/src/AutoMapper/Transformer/BuiltinTransformerFactory.php
@@ -37,4 +37,12 @@ final class BuiltinTransformerFactory implements TransformerFactoryInterface
 
         return null;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 8;
+    }
 }

--- a/src/AutoMapper/Transformer/ChainTransformerFactory.php
+++ b/src/AutoMapper/Transformer/ChainTransformerFactory.php
@@ -12,9 +12,13 @@ final class ChainTransformerFactory implements TransformerFactoryInterface
     /** @var TransformerFactoryInterface[] */
     private $factories = [];
 
+    /** @var TransformerFactoryInterface[]|null */
+    private $sorted = null;
+
     public function addTransformerFactory(TransformerFactoryInterface $transformerFactory): void
     {
-        $this->factories[] = $transformerFactory;
+        $this->sorted = null;
+        $this->factories[$transformerFactory->getPriority()] = $transformerFactory;
     }
 
     /**
@@ -22,7 +26,12 @@ final class ChainTransformerFactory implements TransformerFactoryInterface
      */
     public function getTransformer(?array $sourcesTypes, ?array $targetTypes, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
     {
-        foreach ($this->factories as $factory) {
+        if (null === $this->sorted) {
+            $this->sorted = $this->factories;
+            krsort($this->sorted);
+        }
+
+        foreach ($this->sorted as $factory) {
             $transformer = $factory->getTransformer($sourcesTypes, $targetTypes, $mapperMetadata);
 
             if (null !== $transformer) {
@@ -31,5 +40,10 @@ final class ChainTransformerFactory implements TransformerFactoryInterface
         }
 
         return null;
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
     }
 }

--- a/src/AutoMapper/Transformer/ChainTransformerFactory.php
+++ b/src/AutoMapper/Transformer/ChainTransformerFactory.php
@@ -21,6 +21,18 @@ final class ChainTransformerFactory implements TransformerFactoryInterface
         $this->factories[$transformerFactory->getPriority()] = $transformerFactory;
     }
 
+    public function hasTransformerFactory(TransformerFactoryInterface $transformerFactory): bool
+    {
+        $transformerFactoryClass = \get_class($transformerFactory);
+        foreach ($this->factories as $factory) {
+            if (is_a($factory, $transformerFactoryClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/AutoMapper/Transformer/DateTimeTransformerFactory.php
+++ b/src/AutoMapper/Transformer/DateTimeTransformerFactory.php
@@ -97,4 +97,12 @@ final class DateTimeTransformerFactory extends AbstractUniqueTypeTransformerFact
 
         return true;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 16;
+    }
 }

--- a/src/AutoMapper/Transformer/MultipleTransformerFactory.php
+++ b/src/AutoMapper/Transformer/MultipleTransformerFactory.php
@@ -48,4 +48,12 @@ final class MultipleTransformerFactory implements TransformerFactoryInterface
 
         return null;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 128;
+    }
 }

--- a/src/AutoMapper/Transformer/NullableTransformerFactory.php
+++ b/src/AutoMapper/Transformer/NullableTransformerFactory.php
@@ -60,4 +60,12 @@ final class NullableTransformerFactory implements TransformerFactoryInterface
         // Remove nullable property here to avoid infinite loop
         return new NullableTransformer($subTransformer, $isTargetNullable);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 64;
+    }
 }

--- a/src/AutoMapper/Transformer/ObjectTransformerFactory.php
+++ b/src/AutoMapper/Transformer/ObjectTransformerFactory.php
@@ -54,4 +54,12 @@ final class ObjectTransformerFactory extends AbstractUniqueTypeTransformerFactor
             (Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType() && !$type->isCollection())
         ;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 2;
+    }
 }

--- a/src/AutoMapper/Transformer/TransformerFactoryInterface.php
+++ b/src/AutoMapper/Transformer/TransformerFactoryInterface.php
@@ -19,4 +19,9 @@ interface TransformerFactoryInterface
      * @param Type[] $targetTypes
      */
     public function getTransformer(?array $sourcesTypes, ?array $targetTypes, MapperMetadataInterface $mapperMetadata): ?TransformerInterface;
+
+    /**
+     * TransformerFactory priority.
+     */
+    public function getPriority(): int;
 }

--- a/src/AutoMapper/Transformer/UniqueTypeTransformerFactory.php
+++ b/src/AutoMapper/Transformer/UniqueTypeTransformerFactory.php
@@ -48,4 +48,12 @@ final class UniqueTypeTransformerFactory implements TransformerFactoryInterface
 
         return null;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return 32;
+    }
 }

--- a/src/AutoMapper/composer.json
+++ b/src/AutoMapper/composer.json
@@ -20,7 +20,8 @@
     "require-dev": {
         "doctrine/annotations": "~1.0",
         "phpdocumentor/reflection-docblock": "^3.0 || ^4.0 || ^5.0",
-        "symfony/serializer": "^4.2 || ^5.0"
+        "symfony/serializer": "^4.2 || ^5.0",
+        "moneyphp/money": "^3.0"
     },
     "suggest": {
         "symfony/serializer": "Allow to bridge mappers to normalizer and denormalizer"


### PR DESCRIPTION
Fix #366

Sometimes, we need to have custom `TransformerFactory` because we have objects that don't match their properties when being normalized. This PR introduce a way to add this custom `TransformerFactory` and add a complete test with `Money\Money` object from the `moneyphp/money` package.

- [x] Implementation
- [x] Test with [moneyphp/money](https://github.com/moneyphp/money)
- [x] Documentation