### PR TITLE
Suggest phpdocumentor/reflection-docblock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "symfony/framework-bundle": "^4.4 || ^5.0"
     },
     "suggest": {
-        "friendsofphp/php-cs-fixer": "Allow to automatically fix cs on generated code for better visualisation"
+        "friendsofphp/php-cs-fixer": "Allow to automatically fix cs on generated code for better visualisation",
+        "phpdocumentor/reflection-docblock": "Allow to extract informations from PHP Doc blocks"
     },
     "conflict": {
         "symfony/framework-bundle": "5.1.0"

--- a/src/AutoMapper/composer.json
+++ b/src/AutoMapper/composer.json
@@ -23,7 +23,8 @@
         "symfony/serializer": "^4.2 || ^5.0"
     },
     "suggest": {
-        "symfony/serializer": "Allow to bridge mappers to normalizer and denormalizer"
+        "symfony/serializer": "Allow to bridge mappers to normalizer and denormalizer",
+        "phpdocumentor/reflection-docblock": "Allow to extract informations from PHP Doc blocks"
     },
     "conflict": {
         "symfony/serializer": "<4.2",


### PR DESCRIPTION
I encountered a "bug" in production where some objects where not correctly hydrated.

I added the missing package (which is needed for my usage) in the `suggest` part of the composer.json but we should definitively add some documentation regarding this package which is IMO **almost** required. :)