### PR TITLE
Fix version constraints for Jane Packages in 6.2 version

### DIFF
--- a/src/OpenApi2/composer.json
+++ b/src/OpenApi2/composer.json
@@ -29,8 +29,8 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "jane-php/json-schema": "~6.1.0",
-        "jane-php/open-api-common": "~6.1.0",
+        "jane-php/json-schema": "~6.2.0",
+        "jane-php/open-api-common": "~6.2.0",
         "nikic/php-parser": "^4.0",
         "symfony/serializer": "^4.4 || ^5.0",
         "symfony/yaml": "~4.4.9 || ^5.0"

--- a/src/OpenApi3/composer.json
+++ b/src/OpenApi3/composer.json
@@ -29,8 +29,8 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "jane-php/json-schema": "~6.1.0",
-        "jane-php/open-api-common": "~6.1.0",
+        "jane-php/json-schema": "~6.2.0",
+        "jane-php/open-api-common": "~6.2.0",
         "nikic/php-parser": "^4.0",
         "symfony/serializer": "^4.4 || ^5.0",
         "symfony/yaml": "~4.4.9 || ^5.0"

--- a/src/OpenApiCommon/composer.json
+++ b/src/OpenApiCommon/composer.json
@@ -27,8 +27,8 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
-        "jane-php/json-schema": "~6.1.0",
-        "jane-php/open-api-runtime": "~6.1.0",
+        "jane-php/json-schema": "~6.2.0",
+        "jane-php/open-api-runtime": "~6.2.0",
         "symfony/console": "^4.4 || ^5.0",
         "symfony/filesystem": "^4.4 || ^5.0",
         "symfony/string": "^5.0",

--- a/src/OpenApiRuntime/composer.json
+++ b/src/OpenApiRuntime/composer.json
@@ -29,7 +29,7 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "symfony/options-resolver": "^4.4 || ^5.0",
-        "jane-php/json-schema-runtime": "~6.1.0"
+        "jane-php/json-schema-runtime": "~6.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
Hi

When I tried to use jane 6.2, the generation failed, because it was using packages from 6.1, which were missing some classes after runtime refactorings in 6.2 version.