### PR TITLE
Skip required fields in Normalizer generation

### DIFF
--- a/documentation/components/JsonSchema.rst
+++ b/documentation/components/JsonSchema.rst
@@ -144,6 +144,8 @@ Other options are available to customize the generated code:
  * ``skip-null-values``: When having nullable properties, you can enforce normalization to skip theses
    properties even if they are nullable. This option allows you to not have theses properties when they're not set
    (``null``). By default it is enabled.
+ * ``skip-required-fields``: If your model has required fields, this option allows you to skip the required behavior
+   that forces them to be present during denormalization. By default it is disabled.
 
 .. _`JSON Reference`: https://tools.ietf.org/id/draft-pbryan-zyp-json-ref-03.html
 .. _`Carbon`: https://carbon.nesbot.com/

--- a/documentation/components/OpenAPI.rst
+++ b/documentation/components/OpenAPI.rst
@@ -143,6 +143,8 @@ Other options are available to customize the generated code:
  * ``skip-null-values``: When having nullable properties, you can enforce normalization to skip theses
    properties even if they are nullable. This option allows you to not have theses properties when they're not set
    (``null``). By default it is enabled.
+ * ``skip-required-fields``: If your model has required fields, this option allows you to skip the required behavior
+   that forces them to be present during denormalization. By default it is disabled
  * ``whitelisted-paths``: This option allows you to generate only needed endpoints and related models. Be carefull,
    that option will filter models used by whitelisted endpoints and generate model & normalizer only for them. Here is
    some examples about how to use it::

--- a/src/JsonSchema/Console/Loader/ConfigLoader.php
+++ b/src/JsonSchema/Console/Loader/ConfigLoader.php
@@ -66,6 +66,7 @@ class ConfigLoader implements ConfigLoaderInterface
             'clean-generated' => true,
             'use-cacheable-supports-method' => null,
             'skip-null-values' => true,
+            'skip-required-fields' => false,
         ];
     }
 }

--- a/src/JsonSchema/Console/Loader/SchemaLoader.php
+++ b/src/JsonSchema/Console/Loader/SchemaLoader.php
@@ -39,6 +39,7 @@ class SchemaLoader implements SchemaLoaderInterface
             'clean-generated',
             'use-cacheable-supports-method',
             'skip-null-values',
+            'skip-required-fields',
         ];
     }
 

--- a/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -76,7 +76,7 @@ trait NormalizerGenerator
      *
      * @return Stmt\ClassMethod
      */
-    protected function createNormalizeMethod(string $modelFqdn, Context $context, ClassGuess $classGuess, bool $skipNullValues = true)
+    protected function createNormalizeMethod(string $modelFqdn, Context $context, ClassGuess $classGuess, bool $skipNullValues = true, bool $skipRequiredFields = false)
     {
         $context->refreshScope();
         $dataVariable = new Expr\Variable('data');
@@ -94,7 +94,7 @@ trait NormalizerGenerator
 
                 $normalizationStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\ArrayDimFetch($dataVariable, new Scalar\String_($property->getName())), $outputVar));
 
-                if ($property->isRequired()) {
+                if (!$skipRequiredFields && $property->isRequired()) {
                     $statements = array_merge($statements, $normalizationStatements);
 
                     continue;

--- a/src/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/NormalizerGenerator.php
@@ -46,17 +46,23 @@ class NormalizerGenerator implements GeneratorInterface
     protected $skipNullValues;
 
     /**
+     * @var bool if we handle required fields or not during Normalizer generation
+     */
+    protected $skipRequiedFields;
+
+    /**
      * @param bool $useReference               Whether to generate the JSON Reference system
      * @param bool $useCacheableSupportsMethod Whether to use the CacheableSupportsMethodInterface interface, for >sf 4.1
      * @param bool $skipNullValues             Skip null values or not
      */
-    public function __construct(Naming $naming, Parser $parser, bool $useReference = true, bool $useCacheableSupportsMethod = null, bool $skipNullValues = true)
+    public function __construct(Naming $naming, Parser $parser, bool $useReference = true, bool $useCacheableSupportsMethod = null, bool $skipNullValues = true, bool $skipRequiedFields = false)
     {
         $this->naming = $naming;
         $this->parser = $parser;
         $this->useReference = $useReference;
         $this->useCacheableSupportsMethod = $this->canUseCacheableSupportsMethod($useCacheableSupportsMethod);
         $this->skipNullValues = $skipNullValues;
+        $this->skipRequiedFields = $skipRequiedFields;
     }
 
     /**
@@ -81,7 +87,7 @@ class NormalizerGenerator implements GeneratorInterface
             $methods[] = $this->createSupportsDenormalizationMethod($modelFqdn);
             $methods[] = $this->createSupportsNormalizationMethod($modelFqdn);
             $methods[] = $this->createDenormalizeMethod($modelFqdn, $context, $class);
-            $methods[] = $this->createNormalizeMethod($modelFqdn, $context, $class, $this->skipNullValues);
+            $methods[] = $this->createNormalizeMethod($modelFqdn, $context, $class, $this->skipNullValues, $this->skipRequiedFields);
 
             if ($this->useCacheableSupportsMethod) {
                 $methods[] = $this->createHasCacheableSupportsMethod();

--- a/src/JsonSchema/Jane.php
+++ b/src/JsonSchema/Jane.php
@@ -105,7 +105,7 @@ class Jane extends ChainGenerator
 
         $self = new self($serializer, $chainGuesser, $naming, $options['strict']);
         $self->addGenerator(new ModelGenerator($naming, $parser));
-        $self->addGenerator(new NormalizerGenerator($naming, $parser, $options['reference'], $options['use-cacheable-supports-method'] ?? false, $options['skip-null-values'] ?? true));
+        $self->addGenerator(new NormalizerGenerator($naming, $parser, $options['reference'], $options['use-cacheable-supports-method'] ?? false, $options['skip-null-values'] ?? true, $options['skip-required-fields'] ?? false));
         $self->addGenerator(new RuntimeGenerator($naming, $parser));
 
         return $self;

--- a/src/JsonSchema/Tests/fixtures/disabled-strict-required/.jane
+++ b/src/JsonSchema/Tests/fixtures/disabled-strict-required/.jane
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'json-schema-file' => __DIR__ . '/schema.json',
+    'root-class' => 'Nullable',
+    'namespace' => 'Jane\JsonSchema\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'strict' => false,
+    'skip-required-fields' => true,
+];

--- a/src/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Model/Nullable.php
+++ b/src/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Model/Nullable.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Model;
+
+class Nullable
+{
+    /**
+     * 
+     *
+     * @var null
+     */
+    protected $onlyNull;
+    /**
+     * 
+     *
+     * @var string|null
+     */
+    protected $nullOrString;
+    /**
+     * 
+     *
+     * @var string|null
+     */
+    protected $required;
+    /**
+     * 
+     *
+     * @var string|null
+     */
+    protected $requiredNull;
+    /**
+     * 
+     *
+     * @return null
+     */
+    public function getOnlyNull()
+    {
+        return $this->onlyNull;
+    }
+    /**
+     * 
+     *
+     * @param null $onlyNull
+     *
+     * @return self
+     */
+    public function setOnlyNull($onlyNull) : self
+    {
+        $this->onlyNull = $onlyNull;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string|null
+     */
+    public function getNullOrString() : ?string
+    {
+        return $this->nullOrString;
+    }
+    /**
+     * 
+     *
+     * @param string|null $nullOrString
+     *
+     * @return self
+     */
+    public function setNullOrString(?string $nullOrString) : self
+    {
+        $this->nullOrString = $nullOrString;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string|null
+     */
+    public function getRequired() : ?string
+    {
+        return $this->required;
+    }
+    /**
+     * 
+     *
+     * @param string|null $required
+     *
+     * @return self
+     */
+    public function setRequired(?string $required) : self
+    {
+        $this->required = $required;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string|null
+     */
+    public function getRequiredNull() : ?string
+    {
+        return $this->requiredNull;
+    }
+    /**
+     * 
+     *
+     * @param string|null $requiredNull
+     *
+     * @return self
+     */
+    public function setRequiredNull(?string $requiredNull) : self
+    {
+        $this->requiredNull = $requiredNull;
+        return $this;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('Jane\\JsonSchema\\Tests\\Expected\\Model\\Nullable' => 'Jane\\JsonSchema\\Tests\\Expected\\Normalizer\\NullableNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchema\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Normalizer/NullableNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Normalizer/NullableNormalizer.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class NullableNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\JsonSchema\\Tests\\Expected\\Model\\Nullable';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\JsonSchema\Tests\Expected\Model\Nullable;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\JsonSchema\Tests\Expected\Model\Nullable();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('onlyNull', $data) && $data['onlyNull'] !== null) {
+            $object->setOnlyNull($data['onlyNull']);
+        }
+        elseif (\array_key_exists('onlyNull', $data) && $data['onlyNull'] === null) {
+            $object->setOnlyNull(null);
+        }
+        if (\array_key_exists('nullOrString', $data) && $data['nullOrString'] !== null) {
+            $value = $data['nullOrString'];
+            if (is_string($data['nullOrString'])) {
+                $value = $data['nullOrString'];
+            } elseif (is_null($data['nullOrString'])) {
+                $value = $data['nullOrString'];
+            }
+            $object->setNullOrString($value);
+        }
+        elseif (\array_key_exists('nullOrString', $data) && $data['nullOrString'] === null) {
+            $object->setNullOrString(null);
+        }
+        if (\array_key_exists('required', $data) && $data['required'] !== null) {
+            $object->setRequired($data['required']);
+        }
+        elseif (\array_key_exists('required', $data) && $data['required'] === null) {
+            $object->setRequired(null);
+        }
+        if (\array_key_exists('requiredNull', $data) && $data['requiredNull'] !== null) {
+            $value_1 = $data['requiredNull'];
+            if (is_string($data['requiredNull'])) {
+                $value_1 = $data['requiredNull'];
+            } elseif (is_null($data['requiredNull'])) {
+                $value_1 = $data['requiredNull'];
+            }
+            $object->setRequiredNull($value_1);
+        }
+        elseif (\array_key_exists('requiredNull', $data) && $data['requiredNull'] === null) {
+            $object->setRequiredNull(null);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getOnlyNull()) {
+            $data['onlyNull'] = $object->getOnlyNull();
+        }
+        if (null !== $object->getNullOrString()) {
+            $value = $object->getNullOrString();
+            if (is_string($object->getNullOrString())) {
+                $value = $object->getNullOrString();
+            } elseif (is_null($object->getNullOrString())) {
+                $value = $object->getNullOrString();
+            }
+            $data['nullOrString'] = $value;
+        }
+        if (null !== $object->getRequired()) {
+            $data['required'] = $object->getRequired();
+        }
+        if (null !== $object->getRequiredNull()) {
+            $value_1 = $object->getRequiredNull();
+            if (is_string($object->getRequiredNull())) {
+                $value_1 = $object->getRequiredNull();
+            } elseif (is_null($object->getRequiredNull())) {
+                $value_1 = $object->getRequiredNull();
+            }
+            $data['requiredNull'] = $value_1;
+        }
+        return $data;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array) : bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Runtime\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $object->getReferenceUri();
+        return $ref;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof Reference;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/disabled-strict-required/schema.json
+++ b/src/JsonSchema/Tests/fixtures/disabled-strict-required/schema.json
@@ -1,0 +1,24 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Schema for object with null values",
+    "type": "object",
+    "properties": {
+        "onlyNull": {
+            "type": "null"
+        },
+        "nullOrString": {
+            "type": ["string", "null"]
+        },
+        "required": {
+            "type": "string"
+        },
+        "requiredNull": {
+            "type": ["string", "null"]
+        }
+    },
+    "required": [
+        "required",
+        "requiredNull"
+    ]
+}

--- a/src/OpenApi2/JaneOpenApi.php
+++ b/src/OpenApi2/JaneOpenApi.php
@@ -38,7 +38,7 @@ class JaneOpenApi extends CommonJaneOpenApi
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
 
         yield new ModelGenerator($naming, $parser);
-        yield new NormalizerGenerator($naming, $parser, $options['reference'] ?? false, $options['use-cacheable-supports-method'] ?? false, $options['skip-null-values'] ?? true);
+        yield new NormalizerGenerator($naming, $parser, $options['reference'] ?? false, $options['use-cacheable-supports-method'] ?? false, $options['skip-null-values'] ?? true, $options['skip-required-fields'] ?? false);
         yield new AuthenticationGenerator();
         yield GeneratorFactory::build($denormalizer, $options['endpoint-generator'] ?: EndpointGenerator::class);
         yield new RuntimeGenerator($naming, $parser);

--- a/src/OpenApi3/JaneOpenApi.php
+++ b/src/OpenApi3/JaneOpenApi.php
@@ -37,7 +37,7 @@ class JaneOpenApi extends CommonJaneOpenApi
         $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
 
         yield new ModelGenerator($naming, $parser);
-        yield new NormalizerGenerator($naming, $parser, $options['reference'] ?? false, $options['use-cacheable-supports-method'] ?? false, $options['skip-null-values'] ?? true);
+        yield new NormalizerGenerator($naming, $parser, $options['reference'] ?? false, $options['use-cacheable-supports-method'] ?? false, $options['skip-null-values'] ?? true, $options['skip-required-fields'] ?? false);
         yield new AuthenticationGenerator();
         yield GeneratorFactory::build($denormalizer, $options['endpoint-generator'] ?: EndpointGenerator::class);
         yield new RuntimeGenerator($naming, $parser);

--- a/src/OpenApiCommon/Console/Loader/SchemaLoader.php
+++ b/src/OpenApiCommon/Console/Loader/SchemaLoader.php
@@ -29,6 +29,7 @@ class SchemaLoader extends BaseSchemaLoader implements SchemaLoaderInterface
             'clean-generated',
             'use-cacheable-supports-method',
             'skip-null-values',
+            'skip-required-fields',
             'version',
             'whitelisted-paths',
             'endpoint-generator',


### PR DESCRIPTION
Sometimes, we do not want to handle required fields, following #404, this PR introduce the `skip-required-fields` option to avoid the required behavior.
This option will be set to `false` by default (required fields will be handled).

/cc @Gounlaf