### PR TITLE
Fix mapping for empty collection value on an array property

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
       - name: setup
         uses: shivammathur/setup-php@2.5.0
         with:
-          php-version: 7.2
+          php-version: 7.4
           extensions: mbstring, fileinfo, json, intl, dom
       - name: install
         run: composer update --prefer-stable

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         "phpdocumentor/reflection-docblock": "Allow to extract informations from PHP Doc blocks"
     },
     "conflict": {
-        "symfony/framework-bundle": "5.1.0"
+        "symfony/framework-bundle": "5.1.0",
+        "symfony/property-info": "5.1.6 || 5.1.7"
     },
     "extra": {
         "branch-alias": {

--- a/src/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/AutoMapper/Tests/AutoMapperTest.php
@@ -692,4 +692,16 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertEquals(1000, $newOrder->price->getAmount());
         self::assertEquals('EUR', $newOrder->price->getCurrency()->getCode());
     }
+
+    /**
+     * @requires PHP >= 7.4
+     */
+    public function testIssue425(): void
+    {
+        $data = [1, 2, 3, 4, 5];
+        $foo = new Fixtures\Issue425\Foo($data);
+        $bar = $this->autoMapper->map($foo, Fixtures\Issue425\Bar::class);
+
+        self::assertEquals($data, $bar->property);
+    }
 }

--- a/src/AutoMapper/Tests/Fixtures/Issue425/Bar.php
+++ b/src/AutoMapper/Tests/Fixtures/Issue425/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jane\AutoMapper\Tests\Fixtures\Issue425;
+
+class Bar
+{
+    public array $property = [];
+}

--- a/src/AutoMapper/Tests/Fixtures/Issue425/Foo.php
+++ b/src/AutoMapper/Tests/Fixtures/Issue425/Foo.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Jane\AutoMapper\Tests\Fixtures\Issue425;
+
+class Foo
+{
+    /** @var bigint[] */
+    private array $property = [];
+
+    public function __construct(array $property)
+    {
+        $this->property = $property;
+    }
+
+    public function getProperty(): array
+    {
+        return $this->property;
+    }
+}

--- a/src/AutoMapper/composer.json
+++ b/src/AutoMapper/composer.json
@@ -29,7 +29,8 @@
     },
     "conflict": {
         "symfony/serializer": "<4.2",
-        "symfony/framework-bundle": "5.1.0"
+        "symfony/framework-bundle": "5.1.0",
+        "symfony/property-info": "5.1.6 || 5.1.7"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Fix #425 

When an array has no description about its collection value type, it was not considered as transformable by the AutoMapper.
This is because of https://github.com/symfony/symfony/pull/38041, I fixed it in https://github.com/symfony/symfony/pull/38446, so we just have to flag `symfony/property-info` v5.1.6 & v5.1.7 as conflict with us.