### PR TITLE
[AutoMapper] Add a second parameter to `forMember` with target object

### DIFF
--- a/src/AutoMapper/Bundle/DependencyInjection/JaneAutoMapperExtension.php
+++ b/src/AutoMapper/Bundle/DependencyInjection/JaneAutoMapperExtension.php
@@ -2,12 +2,12 @@
 
 namespace Jane\AutoMapper\Bundle\DependencyInjection;
 
-use Jane\AutoMapper\AutoMapperNormalizer;
 use Jane\AutoMapper\Bundle\AutoMapper;
 use Jane\AutoMapper\Bundle\Configuration\RestrictConfigurationPass;
 use Jane\AutoMapper\MapperGeneratorMetadataFactory;
 use Jane\AutoMapper\MapperGeneratorMetadataInterface;
 use Jane\AutoMapper\MapperMetadata;
+use Jane\AutoMapper\Normalizer\AutoMapperNormalizer;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;

--- a/src/AutoMapper/Bundle/Resources/config/services.xml
+++ b/src/AutoMapper/Bundle/Resources/config/services.xml
@@ -55,7 +55,7 @@
         <service id="Jane\AutoMapper\Transformer\ChainTransformerFactory" />
         <service id="Jane\AutoMapper\Transformer\TransformerFactoryInterface" alias="Jane\AutoMapper\Transformer\ChainTransformerFactory" />
 
-        <service id="Jane\AutoMapper\AutoMapperNormalizer">
+        <service id="Jane\AutoMapper\Normalizer\AutoMapperNormalizer">
             <argument type="service" id="Jane\AutoMapper\AutoMapperInterface" />
         </service>
 

--- a/src/AutoMapper/Generator/Generator.php
+++ b/src/AutoMapper/Generator/Generator.php
@@ -138,7 +138,7 @@ final class Generator
                 continue;
             }
 
-            [$output, $propStatements] = $transformer->transform($propertyMapping->getReadAccessor()->getExpression($sourceInput), $propertyMapping, $uniqueVariableScope);
+            [$output, $propStatements] = $transformer->transform($propertyMapping->getReadAccessor()->getExpression($sourceInput), $result, $propertyMapping, $uniqueVariableScope);
             $writeExpression = $propertyMapping->getWriteMutator()->getExpression($result, $output, $transformer->assignByRef());
 
             if (null === $writeExpression) {
@@ -316,7 +316,7 @@ final class Generator
         $classDiscriminatorMapping = 'array' !== $target && null !== $this->classDiscriminator ? $this->classDiscriminator->getMappingForClass($target) : null;
 
         if (null !== $classDiscriminatorMapping && null !== ($propertyMapping = $mapperMetadata->getPropertyMapping($classDiscriminatorMapping->getTypeProperty()))) {
-            [$output, $createObjectStatements] = $propertyMapping->getTransformer()->transform($propertyMapping->getReadAccessor()->getExpression($sourceInput), $propertyMapping, $uniqueVariableScope);
+            [$output, $createObjectStatements] = $propertyMapping->getTransformer()->transform($propertyMapping->getReadAccessor()->getExpression($sourceInput), $result, $propertyMapping, $uniqueVariableScope);
 
             foreach ($classDiscriminatorMapping->getTypesMapping() as $typeValue => $typeTarget) {
                 $mapperName = 'Discriminator_Mapper_' . $source . '_' . $typeTarget;
@@ -357,7 +357,7 @@ final class Generator
 
                 $constructVar = new Expr\Variable($uniqueVariableScope->getUniqueName('constructArg'));
 
-                [$output, $propStatements] = $propertyMapping->getTransformer()->transform($propertyMapping->getReadAccessor()->getExpression($sourceInput), $propertyMapping, $uniqueVariableScope);
+                [$output, $propStatements] = $propertyMapping->getTransformer()->transform($propertyMapping->getReadAccessor()->getExpression($sourceInput), $constructVar, $propertyMapping, $uniqueVariableScope);
                 $constructArguments[$parameter->getPosition()] = new Arg($constructVar);
 
                 $propStatements[] = new Stmt\Expression(new Expr\Assign($constructVar, $output));

--- a/src/AutoMapper/Normalizer/AutoMapperNormalizer.php
+++ b/src/AutoMapper/Normalizer/AutoMapperNormalizer.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace Jane\AutoMapper;
+namespace Jane\AutoMapper\Normalizer;
 
+use Jane\AutoMapper\AutoMapper;
+use Jane\AutoMapper\MapperContext;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -22,16 +24,12 @@ class AutoMapperNormalizer implements NormalizerInterface, DenormalizerInterface
 
     public function normalize($object, $format = null, array $context = [])
     {
-        $autoMapperContext = $this->createAutoMapperContext($context);
-
-        return $this->autoMapper->map($object, 'array', $autoMapperContext);
+        return $this->autoMapper->map($object, 'array', $this->createAutoMapperContext($context));
     }
 
     public function denormalize($data, $class, $format = null, array $context = [])
     {
-        $autoMapperContext = $this->createAutoMapperContext($context);
-
-        return $this->autoMapper->map($data, $class, $autoMapperContext);
+        return $this->autoMapper->map($data, $class, $this->createAutoMapperContext($context));
     }
 
     public function supportsNormalization($data, $format = null)

--- a/src/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/AutoMapper/Tests/AutoMapperTest.php
@@ -533,6 +533,45 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertNull($userDto->getName());
     }
 
+    public function testMappingWithTargetObjectWithNoObjectToPopulate(): void
+    {
+        $configurationUser = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTOMerged::class);
+        $configurationUser->forMember('properties', function (Fixtures\User $user, Fixtures\UserDTOMerged $target) {
+            return array_merge($target->getProperties(), [
+                'name' => $user->name,
+                'age' => $user->age,
+            ]);
+        });
+
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $userDto = $this->autoMapper->map($user, Fixtures\UserDTOMerged::class);
+
+        self::assertArrayHasKey('name', $userDto->getProperties());
+        self::assertArrayHasKey('age', $userDto->getProperties());
+        self::assertArrayNotHasKey('gender', $userDto->getProperties());
+    }
+
+    public function testMappingWithTargetObjectWithObjectToPopulate(): void
+    {
+        $configurationUser = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTOMerged::class);
+        $configurationUser->forMember('properties', function (Fixtures\User $user, Fixtures\UserDTOMerged $target) {
+            return array_merge($target->getProperties(), [
+                'name' => $user->name,
+                'age' => $user->age,
+            ]);
+        });
+
+        $user = new Fixtures\User(1, 'yolo', '13');
+        $dto = new Fixtures\UserDTOMerged();
+        $dto->setProperties(['gender' => 1]);
+
+        $userDto = $this->autoMapper->map($user, $dto);
+
+        self::assertArrayHasKey('name', $userDto->getProperties());
+        self::assertArrayHasKey('age', $userDto->getProperties());
+        self::assertArrayHasKey('gender', $userDto->getProperties());
+    }
+
     public function testNameConverter(): void
     {
         $nameConverter = new class() implements AdvancedNameConverterInterface {

--- a/src/AutoMapper/Tests/Fixtures/Transformer/ArrayToMoneyTransformer.php
+++ b/src/AutoMapper/Tests/Fixtures/Transformer/ArrayToMoneyTransformer.php
@@ -22,7 +22,7 @@ final class ArrayToMoneyTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         return [new Expr\New_(new Name\FullyQualified(Money::class), [
             new Arg(new Expr\ArrayDimFetch($input, new String_('amount'))),

--- a/src/AutoMapper/Tests/Fixtures/Transformer/MoneyToArrayTransformer.php
+++ b/src/AutoMapper/Tests/Fixtures/Transformer/MoneyToArrayTransformer.php
@@ -19,7 +19,7 @@ final class MoneyToArrayTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         $moneyVar = new Expr\Variable($uniqueVariableScope->getUniqueName('money'));
 

--- a/src/AutoMapper/Tests/Fixtures/Transformer/MoneyToMoneyTransformer.php
+++ b/src/AutoMapper/Tests/Fixtures/Transformer/MoneyToMoneyTransformer.php
@@ -21,7 +21,7 @@ final class MoneyToMoneyTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         return [
             new Expr\New_(new Name\FullyQualified(Money::class), [

--- a/src/AutoMapper/Tests/Fixtures/UserDTOMerged.php
+++ b/src/AutoMapper/Tests/Fixtures/UserDTOMerged.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jane\AutoMapper\Tests\Fixtures;
+
+class UserDTOMerged
+{
+    /**
+     * @var mixed[]
+     */
+    protected $properties = [];
+
+    public function getProperties(): iterable
+    {
+        return $this->properties;
+    }
+
+    public function setProperties(iterable $properties): void
+    {
+        $this->properties = $properties;
+    }
+}

--- a/src/AutoMapper/Tests/Normalizer/AutoMapperNormalizerTest.php
+++ b/src/AutoMapper/Tests/Normalizer/AutoMapperNormalizerTest.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace Jane\AutoMapper\Tests;
+namespace Jane\AutoMapper\Tests\Normalizer;
 
-use Jane\AutoMapper\AutoMapperNormalizer;
+use Jane\AutoMapper\Normalizer\AutoMapperNormalizer;
+use Jane\AutoMapper\Tests\AutoMapperBaseTest;
+use Jane\AutoMapper\Tests\Fixtures;
 
 /**
  * @author Baptiste Leduc <baptiste.leduc@gmail.com>

--- a/src/AutoMapper/Tests/Transformer/EvalTransformerTrait.php
+++ b/src/AutoMapper/Tests/Transformer/EvalTransformerTrait.php
@@ -29,7 +29,8 @@ trait EvalTransformerTrait
         $inputName = $variableScope->getUniqueName('input');
         $inputExpr = new Expr\Variable($inputName);
 
-        [$outputExpr, $stmts] = $transformer->transform($inputExpr, $propertyMapping, $variableScope);
+        // we give $inputExpr as $targetExpr since we don't use it there and this is needed by TransformerInterface
+        [$outputExpr, $stmts] = $transformer->transform($inputExpr, $inputExpr, $propertyMapping, $variableScope);
 
         $stmts[] = new Stmt\Return_($outputExpr);
 

--- a/src/AutoMapper/Transformer/ArrayTransformer.php
+++ b/src/AutoMapper/Transformer/ArrayTransformer.php
@@ -24,7 +24,7 @@ final class ArrayTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         $valuesVar = new Expr\Variable($uniqueVariableScope->getUniqueName('values'));
         $statements = [
@@ -34,7 +34,7 @@ final class ArrayTransformer implements TransformerInterface
 
         $loopValueVar = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
 
-        [$output, $itemStatements] = $this->itemTransformer->transform($loopValueVar, $propertyMapping, $uniqueVariableScope);
+        [$output, $itemStatements] = $this->itemTransformer->transform($loopValueVar, $target, $propertyMapping, $uniqueVariableScope);
 
         if ($this->itemTransformer->assignByRef()) {
             $itemStatements[] = new Stmt\Expression(new Expr\AssignRef(new Expr\ArrayDimFetch($valuesVar), $output));

--- a/src/AutoMapper/Transformer/BuiltinTransformer.php
+++ b/src/AutoMapper/Transformer/BuiltinTransformer.php
@@ -69,7 +69,7 @@ final class BuiltinTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         $targetTypes = array_map(function (Type $type) {
             return $type->getBuiltinType();

--- a/src/AutoMapper/Transformer/CallbackTransformer.php
+++ b/src/AutoMapper/Transformer/CallbackTransformer.php
@@ -25,15 +25,21 @@ final class CallbackTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         /*
          * $output = $this->callbacks[$callbackName]($input);
          */
+
+        $arguments = [
+            new Arg($input),
+        ];
+        if ($target instanceof Expr) {
+            $arguments[] = new Arg($target);
+        }
+
         return [new Expr\FuncCall(
-            new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'callbacks'), new Scalar\String_($this->callbackName)), [
-                new Arg($input),
-            ]),
+            new Expr\ArrayDimFetch(new Expr\PropertyFetch(new Expr\Variable('this'), 'callbacks'), new Scalar\String_($this->callbackName)), $arguments),
             [],
         ];
     }

--- a/src/AutoMapper/Transformer/CopyTransformer.php
+++ b/src/AutoMapper/Transformer/CopyTransformer.php
@@ -16,7 +16,7 @@ final class CopyTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         return [$input, []];
     }

--- a/src/AutoMapper/Transformer/DateTimeImmutableToMutableTransformer.php
+++ b/src/AutoMapper/Transformer/DateTimeImmutableToMutableTransformer.php
@@ -19,7 +19,7 @@ final class DateTimeImmutableToMutableTransformer implements TransformerInterfac
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         return [
             new Expr\StaticCall(new Name\FullyQualified(\DateTime::class), 'createFromFormat', [

--- a/src/AutoMapper/Transformer/DateTimeMutableToImmutableTransformer.php
+++ b/src/AutoMapper/Transformer/DateTimeMutableToImmutableTransformer.php
@@ -18,7 +18,7 @@ final class DateTimeMutableToImmutableTransformer implements TransformerInterfac
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         return [
             new Expr\StaticCall(new Name\FullyQualified(\DateTimeImmutable::class), 'createFromMutable', [

--- a/src/AutoMapper/Transformer/DateTimeToStringTransformer.php
+++ b/src/AutoMapper/Transformer/DateTimeToStringTransformer.php
@@ -25,7 +25,7 @@ final class DateTimeToStringTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         return [new Expr\MethodCall($input, 'format', [
             new Arg(new String_($this->format)),

--- a/src/AutoMapper/Transformer/MultipleTransformer.php
+++ b/src/AutoMapper/Transformer/MultipleTransformer.php
@@ -43,7 +43,7 @@ final class MultipleTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         $output = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
         $statements = [
@@ -54,7 +54,7 @@ final class MultipleTransformer implements TransformerInterface
             $transformer = $transformerData['transformer'];
             $type = $transformerData['type'];
 
-            [$transformerOutput, $transformerStatements] = $transformer->transform($input, $propertyMapping, $uniqueVariableScope);
+            [$transformerOutput, $transformerStatements] = $transformer->transform($input, $target, $propertyMapping, $uniqueVariableScope);
 
             $assignClass = $transformer->assignByRef() ? Expr\AssignRef::class : Expr\Assign::class;
             $statements[] = new Stmt\If_(

--- a/src/AutoMapper/Transformer/NullableTransformer.php
+++ b/src/AutoMapper/Transformer/NullableTransformer.php
@@ -27,9 +27,9 @@ final class NullableTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
-        [$output, $itemStatements] = $this->itemTransformer->transform($input, $propertyMapping, $uniqueVariableScope);
+        [$output, $itemStatements] = $this->itemTransformer->transform($input, $target, $propertyMapping, $uniqueVariableScope);
 
         $newOutput = null;
         $statements = [];

--- a/src/AutoMapper/Transformer/ObjectTransformer.php
+++ b/src/AutoMapper/Transformer/ObjectTransformer.php
@@ -31,7 +31,7 @@ final class ObjectTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         $mapperName = $this->getDependencyName();
 

--- a/src/AutoMapper/Transformer/StringToDateTimeTransformer.php
+++ b/src/AutoMapper/Transformer/StringToDateTimeTransformer.php
@@ -29,7 +29,7 @@ final class StringToDateTimeTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
     {
         $className = \DateTimeInterface::class === $this->className ? \DateTimeImmutable::class : $this->className;
 

--- a/src/AutoMapper/Transformer/TransformerInterface.php
+++ b/src/AutoMapper/Transformer/TransformerInterface.php
@@ -19,7 +19,7 @@ interface TransformerInterface
      *
      * @return [Expr, Stmt[]] First value is the output expression, second value is an array of stmt needed to get the output
      */
-    public function transform(Expr $input, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array;
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array;
 
     /**
      * Get dependencies for this transformer.


### PR DESCRIPTION
Fixes #430 

## Contains

- Quick clean to the Normalizer
- Add a second parameter to `forMember` mapping to recover the create object (which can be an existing object to populate)

## Quick examples on how to use that new parameter:
### AutoMapper configuration:
```php
$configurationUser = $this->autoMapper->getMetadata(Fixtures\User::class, Fixtures\UserDTOProperties::class);
$configurationUser->forMember('properties', function (Fixtures\User $user, Fixtures\UserDTOProperties $target) {
  return array_merge($target->getProperties(), [
    'name' => $user->name,
    'age' => $user->age,
  ]);
});
```

### With no Object to populate
```php
$user = new Fixtures\User(1, 'yolo', '13');
$userDto = $this->autoMapper->map($user, Fixtures\UserDTOProperties::class);
var_dump($userDto->getProperties()); // output will be ['name' => 'yolo', 'age' => '13']
```

### With an Object to populate
```php
$user = new Fixtures\User(1, 'yolo', '13');
$dto = new Fixtures\UserDTOProperties();
$dto->setProperties(['gender' => 1]);

$userDto = $this->autoMapper->map($user, $dto]);
var_dump($userDto->getProperties()); // output will be ['name' => 'yolo', 'age' => '13', 'gender' => 1]
```