### PR TITLE
[AutoMapper] Ignore API Platform resources when using AutoMapper normalizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,13 @@
         "symfony/string": "^5.0",
         "symfony/translation-contracts": "^2.0",
         "symfony/var-dumper": "^4.4 || ^5.0",
-        "symfony/yaml": "~4.4.9 || ^5.0"
+        "symfony/yaml": "~4.4.9 || ^5.0",
+        "api-platform/core": "^2.5"
     },
     "replace": {
         "jane-php/automapper": "self.version",
         "jane-php/automapper-bundle": "self.version",
+        "jane-php/api-platform-bridge": "self.version",
         "jane-php/json-schema": "self.version",
         "jane-php/json-schema-runtime": "self.version",
         "jane-php/open-api-common": "self.version",
@@ -48,14 +50,16 @@
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",
-        "phpdocumentor/reflection-docblock": "^3.0 || ^4.0 || ^5.0",
         "friendsofphp/php-cs-fixer": "2.17.2",
-        "phpbench/phpbench": "@dev",
-        "phpunit/phpunit": "^8.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0",
-        "moneyphp/money": "^3.0",
         "kriswallsmith/buzz": "^1.1",
-        "nyholm/psr7": "^1.3"
+        "moneyphp/money": "^3.0",
+        "nyholm/psr7": "^1.3",
+        "phpbench/phpbench": "@dev",
+        "phpdocumentor/reflection-docblock": "^3.0 || ^4.0 || ^5.0",
+        "phpunit/phpunit": "^8.0",
+        "sensio/framework-extra-bundle": "^5.6",
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/twig-bundle": "^4.4 || ^5.0"
     },
     "suggest": {
         "friendsofphp/php-cs-fixer": "Allow to automatically fix cs on generated code for better visualisation",
@@ -81,6 +85,7 @@
     "autoload-dev": {
         "classmap": [
             "src/Bundle/AutoMapperBundle/Tests/Resources/app/AppKernel.php",
+            "src/Bridge/ApiPlatform/Tests/Resources/app/AppKernel.php",
             "src/Component/OpenApi2/Tests/",
             "src/Component/OpenApi3/Tests/"
         ],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,10 @@
             <directory>./src/Bundle/AutoMapperBundle/Tests</directory>
         </testsuite>
 
+        <testsuite name="Jane AutoMapper Api Platform Bridge Test Suite">
+            <directory>./src/Bridge/ApiPlatform/Tests</directory>
+        </testsuite>
+
         <testsuite name="Jane Unit Test Suite">
             <directory>./src/Component/*/Tests</directory>
             <exclude>./src/Component/JsonSchema/Tests/fixtures</exclude>
@@ -26,6 +30,7 @@
             <exclude>
                 <directory>./src/Component/*/Tests</directory>
                 <directory>./src/Bundle/AutoMapperBundle/Tests</directory>
+                <directory>./src/Bridge/ApiPlatform/Tests</directory>
                 <directory>./src/Component/JsonSchema/Model</directory>
                 <directory>./src/Component/JsonSchema/Normalizer</directory>
                 <directory>./src/Component/OpenApi2/JsonSchema</directory>
@@ -39,9 +44,4 @@
             <group>prism</group>
         </exclude>
     </groups>
-
-    <php>
-        <server name="KERNEL_DIR" value="./src/Bundle/AutoMapperBundle/Tests/Resources/app" />
-        <server name="KERNEL_CLASS" value="DummyApp\AppKernel" />
-    </php>
 </phpunit>

--- a/src/Bridge/ApiPlatform/.gitignore
+++ b/src/Bridge/ApiPlatform/.gitignore
@@ -1,0 +1,2 @@
+Tests/Resources/app/cache
+Tests/Resources/var

--- a/src/Bridge/ApiPlatform/Normalizer/AutoMapperNormalizer.php
+++ b/src/Bridge/ApiPlatform/Normalizer/AutoMapperNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Jane\Bridge\ApiPlatform\Normalizer;
+
+use ApiPlatform\Core\Api\ResourceClassResolverInterface;
+use ApiPlatform\Core\Util\ClassInfoTrait;
+use Jane\Component\AutoMapper\Normalizer\AutoMapperNormalizer as BaseNormalizer;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Bridge for symfony/serializer with api-platform/core.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class AutoMapperNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
+{
+    use ClassInfoTrait;
+
+    private $normalizer;
+    private $resourceClassResolver;
+    private $resourceCache = [];
+
+    public function __construct(BaseNormalizer $normalizer, ResourceClassResolverInterface $resourceClassResolver)
+    {
+        $this->normalizer = $normalizer;
+        $this->resourceClassResolver = $resourceClassResolver;
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        return $this->normalizer->normalize($object, $format, $context);
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        return $this->normalizer->denormalize($data, $class, $format, $context);
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        if (\is_object($data) && null !== $this->resourceClassResolver && ($this->resourceCache[$objectClass = $this->getObjectClass($data)] ?? $this->resourceCache[$objectClass] = $this->resourceClassResolver->isResourceClass($objectClass))) {
+            return false; // skip API Platform resources
+        }
+
+        return $this->normalizer->supportsNormalization($data, $format);
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        if (null !== $this->resourceClassResolver && ($this->resourceCache[$type] ?? $this->resourceCache[$type] = $this->resourceClassResolver->isResourceClass($type))) {
+            return false; // skip API Platform resources
+        }
+
+        return $this->normalizer->supportsDenormalization($data, $type, $format);
+    }
+
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return true;
+    }
+}

--- a/src/Bridge/ApiPlatform/README.md
+++ b/src/Bridge/ApiPlatform/README.md
@@ -1,3 +1,7 @@
 # ApiPlatform Bridge
 
-@todo
+The ApiPlatform bridge provides integration for [ApiPlatform](https://github.com/api-platform/core/) with the
+[AutoMapper bundle](https://github.com/janephp/automapper-bundle).
+
+If you use the AutoMapper bundle, the bridge will be automatically loaded and will ignore any ApiPlatform resources
+if you try to normalize/denormalize some of them.

--- a/src/Bridge/ApiPlatform/README.md
+++ b/src/Bridge/ApiPlatform/README.md
@@ -1,0 +1,3 @@
+# ApiPlatform Bridge
+
+@todo

--- a/src/Bridge/ApiPlatform/Tests/ApiTest.php
+++ b/src/Bridge/ApiPlatform/Tests/ApiTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\Bridge\ApiPlatform\Tests;
+
+use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
+use Bridge\ApiPlatform\App\Foo;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class ApiTest extends ApiTestCase
+{
+    protected function setUp(): void
+    {
+        static::$class = null;
+        $_SERVER['KERNEL_DIR'] = __DIR__ . '/Resources/app';
+        $_SERVER['KERNEL_CLASS'] = 'Bridge\ApiPlatform\App\AppKernel';
+
+        @unlink(__DIR__ . '/Resources/var/cache/test');
+    }
+
+    public function testApiRessource(): void
+    {
+        static::bootKernel();
+        $container = static::$kernel->getContainer();
+        /** @var SerializerInterface $serializer */
+        $serializer = $container->get('serializer');
+
+        $foo = new Foo();
+        $foo->id = 1;
+        $foo->name = 'Bar';
+        $output = $serializer->serialize($foo, 'json');
+        $this->assertEquals('{"id":1,"name":"Bar"}', $output);
+
+        $foo = '{"id":1,"name":"Bar"}';
+        $object = $serializer->deserialize($foo, Foo::class, 'json');
+        $this->assertInstanceOf(Foo::class, $object);
+        $this->assertEquals(1, $object->id);
+        $this->assertEquals('Bar', $object->name);
+    }
+
+    public function testNonApiResource(): void
+    {
+        static::bootKernel();
+        $container = static::$kernel->getContainer();
+        /** @var SerializerInterface $serializer */
+        $serializer = $container->get('serializer');
+
+        $user = new Fixtures\User();
+        $user->id = 1;
+        $user->name = 'Gérard';
+        $output = $serializer->serialize($user, 'json');
+        $this->assertEquals('{"id":1,"name":"G\u00e9rard"}', $output);
+
+        $user = '{"id":1,"name":"Gérard"}';
+        $object = $serializer->deserialize($user, Fixtures\User::class, 'json');
+        $this->assertInstanceOf(Fixtures\User::class, $object);
+        $this->assertEquals(1, $object->id);
+        $this->assertEquals('Gérard', $object->name);
+    }
+}

--- a/src/Bridge/ApiPlatform/Tests/Fixtures/User.php
+++ b/src/Bridge/ApiPlatform/Tests/Fixtures/User.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jane\Bridge\ApiPlatform\Tests\Fixtures;
+
+class User
+{
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $name;
+}

--- a/src/Bridge/ApiPlatform/Tests/Resources/app/AppKernel.php
+++ b/src/Bridge/ApiPlatform/Tests/Resources/app/AppKernel.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Bridge\ApiPlatform\App;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Core\Bridge\Symfony\Bundle\ApiPlatformBundle;
+use Jane\Bridge\ApiPlatform\Normalizer\AutoMapperNormalizer as ApiPlatformNormalizer;
+use Jane\Bundle\AutoMapperBundle\JaneAutoMapperBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+class AppKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+            new ApiPlatformBundle(),
+            new JaneAutoMapperBundle(),
+            new TwigBundle(),
+        ];
+    }
+
+    protected function configureRoutes(RouteCollectionBuilder $routes)
+    {
+        $routes->add('/', 'kernel::indexAction');
+        $routes->import(__DIR__ . '/routes.yaml');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
+    {
+        $loader->load(__DIR__ . '/config.yml');
+    }
+
+    public function indexAction()
+    {
+        return new Response();
+    }
+
+    public function getProjectDir()
+    {
+        return __DIR__ . '/..';
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+        $container->addCompilerPass(new TestPass());
+    }
+}
+
+class TestPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $container->getDefinition(ApiPlatformNormalizer::class)->setPublic(true);
+        $container->getDefinition('serializer')->setPublic(true);
+    }
+}
+
+final class Foo
+{
+    /**
+     * @var int
+     * @ApiProperty(identifier=true)
+     * @Groups({"foo:read", "foo:write"})
+     */
+    public $id;
+
+    /**
+     * @Groups({"foo:read", "foo:write"})
+     */
+    public $name;
+}

--- a/src/Bridge/ApiPlatform/Tests/Resources/app/api.yaml
+++ b/src/Bridge/ApiPlatform/Tests/Resources/app/api.yaml
@@ -1,0 +1,16 @@
+resources:
+  Bridge\ApiPlatform\App\Foo:
+    shortName: 'foo'
+    attributes:
+      normalization_context:
+        groups: ['foo:read']
+        swagger_definition_name: 'foo-read'
+      denormalization_context:
+        groups: ['foo:write']
+        swagger_definition_name: 'foo-write'
+        disable_type_enforcement: true
+    collectionOperations:
+      get: ~
+      post: ~
+    itemOperations:
+      get: ~

--- a/src/Bridge/ApiPlatform/Tests/Resources/app/config.yml
+++ b/src/Bridge/ApiPlatform/Tests/Resources/app/config.yml
@@ -1,0 +1,13 @@
+framework:
+    secret: jane-automapper-apip-bridge
+    property_info: ~
+    test: ~
+
+jane_auto_mapper:
+    normalizer: true
+
+api_platform:
+  mapping:
+    paths: ['%kernel.project_dir%/app/api.yaml']
+
+services: ~

--- a/src/Bridge/ApiPlatform/Tests/Resources/app/routes.yaml
+++ b/src/Bridge/ApiPlatform/Tests/Resources/app/routes.yaml
@@ -1,0 +1,4 @@
+api_platform:
+  resource: .
+  type: api_platform
+  prefix: /ecommerce-private/v1

--- a/src/Bridge/ApiPlatform/Tests/ServiceInstantiationTest.php
+++ b/src/Bridge/ApiPlatform/Tests/ServiceInstantiationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Jane\Bridge\ApiPlatform\Tests;
+
+use Jane\Bridge\ApiPlatform\Normalizer\AutoMapperNormalizer;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ServiceInstantiationTest extends WebTestCase
+{
+    protected function setUp(): void
+    {
+        static::$class = null;
+        $_SERVER['KERNEL_DIR'] = __DIR__ . '/Resources/app';
+        $_SERVER['KERNEL_CLASS'] = 'Bridge\ApiPlatform\App\AppKernel';
+
+        @unlink(__DIR__ . '/Resources/var/cache/test');
+    }
+
+    public function testAutoMapper()
+    {
+        static::bootKernel();
+        $container = static::$kernel->getContainer();
+        $this->assertTrue($container->has(AutoMapperNormalizer::class), sprintf('Service %s not found.', AutoMapperNormalizer::class));
+        $this->assertInstanceOf(AutoMapperNormalizer::class, $normalizer = $container->get(AutoMapperNormalizer::class));
+    }
+}

--- a/src/Bridge/ApiPlatform/composer.json
+++ b/src/Bridge/ApiPlatform/composer.json
@@ -1,15 +1,11 @@
 {
-    "name": "jane-php/automapper-bundle",
+    "name": "jane-php/api-platform-bridge",
     "type": "library",
-    "description": "Jane AutoMapper Symfony Bundle",
-    "keywords": ["bundle", "symfony"],
+    "description": "Jane AutoMapper ApiPlatform Bridge",
+    "keywords": ["bridge", "symfony", "automapper", "api-platform"],
     "homepage": "https://github.com/janephp/janephp",
     "license": "MIT",
     "authors": [
-        {
-            "name": "Joel Wurtz",
-            "email": "jwurtz@jolicode.com"
-        },
         {
             "name": "Baptiste Leduc",
             "email": "baptiste.leduc@gmail.com"
@@ -17,11 +13,14 @@
     ],
     "require": {
         "php": "^7.2.5",
+        "api-platform/core": "^2.5",
         "jane-php/automapper": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0"
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "sensio/framework-extra-bundle": "^5.6",
+        "symfony/twig-bundle": "^4.4 || ^5.0"
     },
     "conflict": {
         "symfony/framework-bundle": "5.1.0"
@@ -33,7 +32,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Jane\\Bundle\\AutoMapper\\": ""
+            "Jane\\Bridge\\ApiPlatform\\": ""
         },
         "exclude-from-classmap": [
             "/Tests/"

--- a/src/Bridge/ApiPlatform/phpunit.xml
+++ b/src/Bridge/ApiPlatform/phpunit.xml
@@ -14,7 +14,7 @@
 
 
     <testsuites>
-        <testsuite name="Jane AutoMapper Bundle Test Suite">
+        <testsuite name="Jane AutoMapper Api Platform Bridge Test Suite">
             <directory>./Tests</directory>
         </testsuite>
     </testsuites>

--- a/src/Bundle/AutoMapperBundle/DependencyInjection/Compiler/ApiPlatformPass.php
+++ b/src/Bundle/AutoMapperBundle/DependencyInjection/Compiler/ApiPlatformPass.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Jane\Bundle\AutoMapperBundle\DependencyInjection\Compiler;
+
+use Jane\Bridge\ApiPlatform\Normalizer\AutoMapperNormalizer as ApiPlatformNormalizer;
+use Jane\Component\AutoMapper\Normalizer\AutoMapperNormalizer;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ApiPlatformPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->has('api_platform.resource_class_resolver') && class_exists(ApiPlatformNormalizer::class)) {
+            $container
+                ->register(ApiPlatformNormalizer::class, ApiPlatformNormalizer::class)
+                ->addArgument($container->getDefinition(AutoMapperNormalizer::class))
+                ->addArgument($container->getDefinition('api_platform.resource_class_resolver'))
+                ->addTag('serializer.normalizer', ['priority' => 1000])
+            ;
+
+            $container
+                ->getDefinition(AutoMapperNormalizer::class)
+                ->clearTag('serializer.normalizer')
+            ;
+        }
+    }
+}

--- a/src/Bundle/AutoMapperBundle/JaneAutoMapperBundle.php
+++ b/src/Bundle/AutoMapperBundle/JaneAutoMapperBundle.php
@@ -2,8 +2,10 @@
 
 namespace Jane\Bundle\AutoMapperBundle;
 
+use Jane\Bundle\AutoMapperBundle\DependencyInjection\Compiler\ApiPlatformPass;
 use Jane\Bundle\AutoMapperBundle\DependencyInjection\Compiler\MapperConfigurationPass;
 use Jane\Bundle\AutoMapperBundle\DependencyInjection\Compiler\TransformerFactoryPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -15,5 +17,6 @@ class JaneAutoMapperBundle extends Bundle
 
         $container->addCompilerPass(new MapperConfigurationPass());
         $container->addCompilerPass(new TransformerFactoryPass());
+        $container->addCompilerPass(new ApiPlatformPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 100);
     }
 }

--- a/src/Bundle/AutoMapperBundle/Tests/Resources/app/AppKernel.php
+++ b/src/Bundle/AutoMapperBundle/Tests/Resources/app/AppKernel.php
@@ -9,7 +9,6 @@ require_once __DIR__ . '/Transformer/MoneyToMoneyTransformer.php';
 
 namespace DummyApp;
 
-use Jane\Bundle\AutoMapperBundle\Configuration\ConfigurationPassInterface;
 use Jane\Bundle\AutoMapperBundle\Configuration\MapperConfigurationInterface;
 use Jane\Bundle\AutoMapperBundle\JaneAutoMapperBundle;
 use Jane\Bundle\AutoMapperBundle\Tests\Fixtures\UserDTO;

--- a/src/Bundle/AutoMapperBundle/Tests/Resources/app/config.yml
+++ b/src/Bundle/AutoMapperBundle/Tests/Resources/app/config.yml
@@ -11,7 +11,6 @@ services:
   _defaults:
     autoconfigure: true
 
-  DummyApp\UserConfigurationPass: ~
   DummyApp\UserMapperConfiguration: ~
   DummyApp\IdNameConverter: ~
   DummyApp\Transformer\MoneyTransformerFactory: ~

--- a/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
+++ b/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
@@ -13,6 +13,10 @@ class ServiceInstantiationTest extends WebTestCase
 {
     protected function setUp(): void
     {
+        static::$class = null;
+        $_SERVER['KERNEL_DIR'] = __DIR__ . '/Resources/app';
+        $_SERVER['KERNEL_CLASS'] = 'DummyApp\AppKernel';
+
         @unlink(__DIR__ . '/Resources/var/cache/test');
     }
 

--- a/src/Component/AutoMapper/Normalizer/AutoMapperNormalizer.php
+++ b/src/Component/AutoMapper/Normalizer/AutoMapperNormalizer.php
@@ -2,9 +2,10 @@
 
 namespace Jane\Component\AutoMapper\Normalizer;
 
-use Jane\Component\AutoMapper\AutoMapper;
+use Jane\Component\AutoMapper\AutoMapperInterface;
 use Jane\Component\AutoMapper\MapperContext;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -13,11 +14,11 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-class AutoMapperNormalizer implements NormalizerInterface, DenormalizerInterface
+class AutoMapperNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
 {
     private $autoMapper;
 
-    public function __construct(AutoMapper $autoMapper)
+    public function __construct(AutoMapperInterface $autoMapper)
     {
         $this->autoMapper = $autoMapper;
     }


### PR DESCRIPTION
Since AutoMapper can't handle API Platform resources actually, I made this patch to ignore resources from API Platform when using AutoMapperNormalizer.

Also understand that we don't activate that normalizer by default in the AutoMapper bundle, it's opt-in.