### PR TITLE
[AutoMapper] Handle dictionary with ArrayTransformer

### DIFF
--- a/src/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -743,4 +743,54 @@ class AutoMapperTest extends AutoMapperBaseTest
 
         self::assertEquals($data, $bar->property);
     }
+
+    public function testArrayWithKeys(): void
+    {
+        $arguments = ['foo', 'azerty' => 'bar', 'baz'];
+        $parameters = new Fixtures\Parameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertEquals($arguments, $data['parameters']);
+
+        // ----------------------------------------------------------------------------------------------------
+
+        $arguments = ['foo', 'bar', 'baz'];
+        $parameters = new Fixtures\Parameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertEquals($arguments, $data['parameters']);
+
+        // ----------------------------------------------------------------------------------------------------
+
+        $arguments = ['foo' => 'azerty', 'bar' => 'qwerty', 'baz' => 'dvorak'];
+        $parameters = new Fixtures\Parameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertEquals($arguments, $data['parameters']);
+    }
+
+    public function testArrayWithFailedKeys(): void
+    {
+        $arguments = ['foo', 'azerty' => 'bar', 'baz'];
+        $parameters = new Fixtures\WrongParameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertNotEquals($arguments, $data['parameters']);
+
+        // ----------------------------------------------------------------------------------------------------
+
+        $arguments = ['foo', 'bar', 'baz'];
+        $parameters = new Fixtures\WrongParameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertEquals($arguments, $data['parameters']);
+
+        // ----------------------------------------------------------------------------------------------------
+
+        $arguments = ['foo' => 'azerty', 'bar' => 'qwerty', 'baz' => 'dvorak'];
+        $parameters = new Fixtures\WrongParameters($arguments);
+
+        $data = $this->autoMapper->map($parameters, 'array');
+        self::assertNotEquals($arguments, $data['parameters']);
+    }
 }

--- a/src/Component/AutoMapper/Tests/Fixtures/Parameters.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/Parameters.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Tests\Fixtures;
+
+class Parameters
+{
+    /** @var array<string, string> */
+    private $parameters;
+
+    /**
+     * @param array<string, string> $parameters
+     */
+    public function __construct(array $parameters)
+    {
+        $this->setParameters($parameters);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param array<string, string> $parameters
+     */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
+    }
+}

--- a/src/Component/AutoMapper/Tests/Fixtures/WrongParameters.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/WrongParameters.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Tests\Fixtures;
+
+class WrongParameters
+{
+    /** @var string[]|null */
+    private $parameters;
+
+    /**
+     * @param string[]|null $parameters
+     */
+    public function __construct(array $parameters)
+    {
+        $this->setParameters($parameters);
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * @param string[]|null $parameters
+     */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
+    }
+}

--- a/src/Component/AutoMapper/Transformer/AbstractArrayTransformer.php
+++ b/src/Component/AutoMapper/Transformer/AbstractArrayTransformer.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Transformer;
+
+use Jane\Component\AutoMapper\Extractor\PropertyMapping;
+use Jane\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+abstract class AbstractArrayTransformer implements TransformerInterface, DependentTransformerInterface
+{
+    private $itemTransformer;
+
+    public function __construct(TransformerInterface $itemTransformer)
+    {
+        $this->itemTransformer = $itemTransformer;
+    }
+
+    abstract protected function getAssignExpr(Expr $valuesVar, Expr $outputVar, Expr $loopKeyVar, bool $assignByRef): Expr;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        $valuesVar = new Expr\Variable($uniqueVariableScope->getUniqueName('values'));
+        $statements = [
+            new Stmt\Expression(new Expr\Assign($valuesVar, new Expr\Array_())),
+        ];
+
+        $loopValueVar = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
+        $loopKeyVar = new Expr\Variable($uniqueVariableScope->getUniqueName('key'));
+
+        $assignByRef = $this->itemTransformer instanceof AssignedByReferenceTransformerInterface ? $this->itemTransformer->assignByRef() : false;
+
+        [$output, $itemStatements] = $this->itemTransformer->transform($loopValueVar, $target, $propertyMapping, $uniqueVariableScope);
+        $itemStatements[] = new Stmt\Expression($this->getAssignExpr($valuesVar, $output, $loopKeyVar, $assignByRef));
+
+        $statements[] = new Stmt\Foreach_($input, $loopValueVar, [
+            'stmts' => $itemStatements,
+            'keyVar' => $loopKeyVar,
+        ]);
+
+        return [$valuesVar, $statements];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDependencies(): array
+    {
+        if (!$this->itemTransformer instanceof DependentTransformerInterface) {
+            return [];
+        }
+
+        return $this->itemTransformer->getDependencies();
+    }
+}

--- a/src/Component/AutoMapper/Transformer/ArrayTransformer.php
+++ b/src/Component/AutoMapper/Transformer/ArrayTransformer.php
@@ -2,58 +2,27 @@
 
 namespace Jane\Component\AutoMapper\Transformer;
 
-use Jane\Component\AutoMapper\Extractor\PropertyMapping;
-use Jane\Component\AutoMapper\Generator\UniqueVariableScope;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Stmt;
 
 /**
  * Transformer array decorator.
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class ArrayTransformer implements TransformerInterface, DependentTransformerInterface
+
+/**
+ * Transformer array decorator.
+ *
+ * @author Joel Wurtz <jwurtz@jolicode.com>
+ */
+final class ArrayTransformer extends AbstractArrayTransformer
 {
-    private $itemTransformer;
-
-    public function __construct(TransformerInterface $itemTransformer)
+    protected function getAssignExpr(Expr $valuesVar, Expr $outputVar, Expr $loopKeyVar, bool $assignByRef): Expr
     {
-        $this->itemTransformer = $itemTransformer;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
-    {
-        $valuesVar = new Expr\Variable($uniqueVariableScope->getUniqueName('values'));
-        $statements = [
-            // $values = [];
-            new Stmt\Expression(new Expr\Assign($valuesVar, new Expr\Array_())),
-        ];
-
-        $loopValueVar = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
-
-        [$output, $itemStatements] = $this->itemTransformer->transform($loopValueVar, $target, $propertyMapping, $uniqueVariableScope);
-
-        if ($this->itemTransformer instanceof AssignedByReferenceTransformerInterface && $this->itemTransformer->assignByRef()) {
-            $itemStatements[] = new Stmt\Expression(new Expr\AssignRef(new Expr\ArrayDimFetch($valuesVar), $output));
-        } else {
-            $itemStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\ArrayDimFetch($valuesVar), $output));
+        if ($assignByRef) {
+            return new Expr\AssignRef(new Expr\ArrayDimFetch($valuesVar), $outputVar);
         }
 
-        $statements[] = new Stmt\Foreach_($input, $loopValueVar, [
-            'stmts' => $itemStatements,
-        ]);
-
-        return [$valuesVar, $statements];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDependencies(): array
-    {
-        return $this->itemTransformer->getDependencies();
+        return new Expr\Assign(new Expr\ArrayDimFetch($valuesVar), $outputVar);
     }
 }

--- a/src/Component/AutoMapper/Transformer/ArrayTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/ArrayTransformerFactory.php
@@ -39,6 +39,10 @@ final class ArrayTransformerFactory extends AbstractUniqueTypeTransformerFactory
         $subItemTransformer = $this->chainTransformerFactory->getTransformer([$sourceType->getCollectionValueType()], [$targetType->getCollectionValueType()], $mapperMetadata);
 
         if (null !== $subItemTransformer) {
+            if (Type::BUILTIN_TYPE_INT !== $sourceType->getCollectionKeyType()->getBuiltinType()) {
+                return new DictionaryTransformer($subItemTransformer);
+            }
+
             return new ArrayTransformer($subItemTransformer);
         }
 

--- a/src/Component/AutoMapper/Transformer/DictionaryTransformer.php
+++ b/src/Component/AutoMapper/Transformer/DictionaryTransformer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Transformer;
+
+use PhpParser\Node\Expr;
+
+/**
+ * Transformer dictionary decorator.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class DictionaryTransformer extends AbstractArrayTransformer
+{
+    protected function getAssignExpr(Expr $valuesVar, Expr $outputVar, Expr $loopKeyVar, bool $assignByRef): Expr
+    {
+        if ($assignByRef) {
+            return new Expr\AssignRef(new Expr\ArrayDimFetch($valuesVar, $loopKeyVar), $outputVar);
+        }
+
+        return new Expr\Assign(new Expr\ArrayDimFetch($valuesVar, $loopKeyVar), $outputVar);
+    }
+}

--- a/src/Component/AutoMapper/composer.json
+++ b/src/Component/AutoMapper/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.2.5",
         "doctrine/inflector": "^1.4 || ^2.0",
         "nikic/php-parser": "^4.0",
-        "symfony/property-info": "^5.1"
+        "symfony/property-info": "^5.2"
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",


### PR DESCRIPTION
Since `symfony/property-info` 5.2, we can handle dictionary in the AutoMapper (see https://github.com/symfony/symfony/pull/37559), we just have to have the phpDoc `array<string, string>` on the related property.
So I introduced the `DictionaryTransformer` to handle this behavior !