### PR TITLE
[JsonSchema] Dictionnary better phpDoc

### DIFF
--- a/src/Component/JsonSchema/Guesser/Guess/MapType.php
+++ b/src/Component/JsonSchema/Guesser/Guess/MapType.php
@@ -15,17 +15,16 @@ class MapType extends ArrayType
         $this->itemType = $itemType;
     }
 
-    /**
-     * ({@inheritDoc}.
-     */
     public function getTypeHint(string $namespace)
     {
         return new Name('iterable');
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    public function getDocTypeHint(string $namespace)
+    {
+        return new Name(sprintf('array<string, %s>', $this->getItemType()->getDocTypeHint($namespace)));
+    }
+
     protected function createArrayValueStatement(): Expr
     {
         return new Expr\New_(new Name('\ArrayObject'), [
@@ -34,33 +33,21 @@ class MapType extends ArrayType
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function createNormalizationArrayValueStatement(): Expr
     {
         return new Expr\Array_();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function createLoopKeyStatement(Context $context): Expr
     {
         return new Expr\Variable($context->getUniqueVariableName('key'));
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function createLoopOutputAssignement(Expr $valuesVar, $loopKeyVar): Expr
     {
         return new Expr\ArrayDimFetch($valuesVar, $loopKeyVar);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function createNormalizationLoopOutputAssignement(Expr $valuesVar, $loopKeyVar): Expr
     {
         return new Expr\ArrayDimFetch($valuesVar, $loopKeyVar);

--- a/src/Component/JsonSchema/JsonSchema/Model/JsonSchema.php
+++ b/src/Component/JsonSchema/JsonSchema/Model/JsonSchema.php
@@ -15,13 +15,13 @@ class JsonSchema
     /**
      * 
      *
-     * @var JsonSchema[]|bool[]|null
+     * @var array<string, JsonSchema|bool>|null
      */
     protected $definitions;
     /**
      * 
      *
-     * @var JsonSchema[]|bool[]|string[][]|null
+     * @var array<string, JsonSchema|bool|string[]>|null
      */
     protected $dependencies;
     /**
@@ -57,25 +57,25 @@ class JsonSchema
     /**
      * 
      *
-     * @var JsonSchema[]|bool[]|null
+     * @var array<string, JsonSchema|bool>|null
      */
     protected $unevaluatedProperties;
     /**
      * 
      *
-     * @var JsonSchema[]|bool[]|null
+     * @var array<string, JsonSchema|bool>|null
      */
     protected $properties;
     /**
      * 
      *
-     * @var JsonSchema[]|bool[]|null
+     * @var array<string, JsonSchema|bool>|null
      */
     protected $patternProperties;
     /**
      * 
      *
-     * @var JsonSchema[]|bool[]|null
+     * @var array<string, JsonSchema|bool>|null
      */
     protected $dependentSchemas;
     /**
@@ -183,7 +183,7 @@ class JsonSchema
     /**
      * 
      *
-     * @var bool[]|null
+     * @var array<string, bool>|null
      */
     protected $dollarVocabulary;
     /**
@@ -195,7 +195,7 @@ class JsonSchema
     /**
      * 
      *
-     * @var JsonSchema[]|bool[]|null
+     * @var array<string, JsonSchema|bool>|null
      */
     protected $dollarDefs;
     /**
@@ -345,7 +345,7 @@ class JsonSchema
     /**
      * 
      *
-     * @var string[][]|null
+     * @var array<string, string[]>|null
      */
     protected $dependentRequired;
     /**
@@ -369,7 +369,7 @@ class JsonSchema
     /**
      * 
      *
-     * @return JsonSchema[]|bool[]|null
+     * @return array<string, JsonSchema|bool>|null
      */
     public function getDefinitions() : ?iterable
     {
@@ -378,7 +378,7 @@ class JsonSchema
     /**
      * 
      *
-     * @param JsonSchema[]|bool[]|null $definitions
+     * @param array<string, JsonSchema|bool>|null $definitions
      *
      * @return self
      */
@@ -391,7 +391,7 @@ class JsonSchema
     /**
      * 
      *
-     * @return JsonSchema[]|bool[]|string[][]|null
+     * @return array<string, JsonSchema|bool|string[]>|null
      */
     public function getDependencies() : ?iterable
     {
@@ -400,7 +400,7 @@ class JsonSchema
     /**
      * 
      *
-     * @param JsonSchema[]|bool[]|string[][]|null $dependencies
+     * @param array<string, JsonSchema|bool|string[]>|null $dependencies
      *
      * @return self
      */
@@ -523,7 +523,7 @@ class JsonSchema
     /**
      * 
      *
-     * @return JsonSchema[]|bool[]|null
+     * @return array<string, JsonSchema|bool>|null
      */
     public function getUnevaluatedProperties() : ?iterable
     {
@@ -532,7 +532,7 @@ class JsonSchema
     /**
      * 
      *
-     * @param JsonSchema[]|bool[]|null $unevaluatedProperties
+     * @param array<string, JsonSchema|bool>|null $unevaluatedProperties
      *
      * @return self
      */
@@ -545,7 +545,7 @@ class JsonSchema
     /**
      * 
      *
-     * @return JsonSchema[]|bool[]|null
+     * @return array<string, JsonSchema|bool>|null
      */
     public function getProperties() : ?iterable
     {
@@ -554,7 +554,7 @@ class JsonSchema
     /**
      * 
      *
-     * @param JsonSchema[]|bool[]|null $properties
+     * @param array<string, JsonSchema|bool>|null $properties
      *
      * @return self
      */
@@ -567,7 +567,7 @@ class JsonSchema
     /**
      * 
      *
-     * @return JsonSchema[]|bool[]|null
+     * @return array<string, JsonSchema|bool>|null
      */
     public function getPatternProperties() : ?iterable
     {
@@ -576,7 +576,7 @@ class JsonSchema
     /**
      * 
      *
-     * @param JsonSchema[]|bool[]|null $patternProperties
+     * @param array<string, JsonSchema|bool>|null $patternProperties
      *
      * @return self
      */
@@ -589,7 +589,7 @@ class JsonSchema
     /**
      * 
      *
-     * @return JsonSchema[]|bool[]|null
+     * @return array<string, JsonSchema|bool>|null
      */
     public function getDependentSchemas() : ?iterable
     {
@@ -598,7 +598,7 @@ class JsonSchema
     /**
      * 
      *
-     * @param JsonSchema[]|bool[]|null $dependentSchemas
+     * @param array<string, JsonSchema|bool>|null $dependentSchemas
      *
      * @return self
      */
@@ -985,7 +985,7 @@ class JsonSchema
     /**
      * 
      *
-     * @return bool[]|null
+     * @return array<string, bool>|null
      */
     public function getDollarVocabulary() : ?iterable
     {
@@ -994,7 +994,7 @@ class JsonSchema
     /**
      * 
      *
-     * @param bool[]|null $dollarVocabulary
+     * @param array<string, bool>|null $dollarVocabulary
      *
      * @return self
      */
@@ -1029,7 +1029,7 @@ class JsonSchema
     /**
      * 
      *
-     * @return JsonSchema[]|bool[]|null
+     * @return array<string, JsonSchema|bool>|null
      */
     public function getDollarDefs() : ?iterable
     {
@@ -1038,7 +1038,7 @@ class JsonSchema
     /**
      * 
      *
-     * @param JsonSchema[]|bool[]|null $dollarDefs
+     * @param array<string, JsonSchema|bool>|null $dollarDefs
      *
      * @return self
      */
@@ -1579,7 +1579,7 @@ class JsonSchema
     /**
      * 
      *
-     * @return string[][]|null
+     * @return array<string, string[]>|null
      */
     public function getDependentRequired() : ?iterable
     {
@@ -1588,7 +1588,7 @@ class JsonSchema
     /**
      * 
      *
-     * @param string[][]|null $dependentRequired
+     * @param array<string, string[]>|null $dependentRequired
      *
      * @return self
      */

--- a/src/Component/JsonSchema/Tests/fixtures/test-not-strict/expected/Model/Test.php
+++ b/src/Component/JsonSchema/Tests/fixtures/test-not-strict/expected/Model/Test.php
@@ -33,7 +33,7 @@ class Test
     /**
      * 
      *
-     * @var string[]|null
+     * @var array<string, string>|null
      */
     protected $object;
     /**
@@ -105,7 +105,7 @@ class Test
     /**
      * 
      *
-     * @return string[]|null
+     * @return array<string, string>|null
      */
     public function getObject() : ?iterable
     {
@@ -114,7 +114,7 @@ class Test
     /**
      * 
      *
-     * @param string[]|null $object
+     * @param array<string, string>|null $object
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Model/Schema.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Model/Schema.php
@@ -45,7 +45,7 @@ class Schema
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $mapProperty;
     /**
@@ -173,7 +173,7 @@ class Schema
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getMapProperty() : iterable
     {
@@ -182,7 +182,7 @@ class Schema
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param array<string, string> $mapProperty
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Model/Schema.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Model/Schema.php
@@ -45,7 +45,7 @@ class Schema
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $mapProperty;
     /**
@@ -173,7 +173,7 @@ class Schema
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getMapProperty() : iterable
     {
@@ -182,7 +182,7 @@ class Schema
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param array<string, string> $mapProperty
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ConfigSpec.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ConfigSpec.php
@@ -21,7 +21,7 @@ class ConfigSpec
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -63,7 +63,7 @@ class ConfigSpec
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -72,7 +72,7 @@ class ConfigSpec
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ConfigsCreatePostBody.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ConfigsCreatePostBody.php
@@ -21,7 +21,7 @@ class ConfigsCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -63,7 +63,7 @@ class ConfigsCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -72,7 +72,7 @@ class ConfigsCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ContainerConfig.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ContainerConfig.php
@@ -54,7 +54,7 @@ class ContainerConfig
     `{"<port>/<tcp|udp|sctp>": {}}`
     
     *
-    * @var mixed[]
+    * @var array<string, mixed>
     */
     protected $exposedPorts;
     /**
@@ -113,7 +113,7 @@ class ContainerConfig
     objects.
     
     *
-    * @var mixed[]
+    * @var array<string, mixed>
     */
     protected $volumes;
     /**
@@ -154,7 +154,7 @@ class ContainerConfig
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -313,7 +313,7 @@ class ContainerConfig
     `{"<port>/<tcp|udp|sctp>": {}}`
     
     *
-    * @return mixed[]
+    * @return array<string, mixed>
     */
     public function getExposedPorts() : iterable
     {
@@ -325,7 +325,7 @@ class ContainerConfig
     `{"<port>/<tcp|udp|sctp>": {}}`
     
     *
-    * @param mixed[] $exposedPorts
+    * @param array<string, mixed> $exposedPorts
     *
     * @return self
     */
@@ -522,7 +522,7 @@ class ContainerConfig
     objects.
     
     *
-    * @return mixed[]
+    * @return array<string, mixed>
     */
     public function getVolumes() : iterable
     {
@@ -533,7 +533,7 @@ class ContainerConfig
     objects.
     
     *
-    * @param mixed[] $volumes
+    * @param array<string, mixed> $volumes
     *
     * @return self
     */
@@ -666,7 +666,7 @@ class ContainerConfig
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -675,7 +675,7 @@ class ContainerConfig
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ContainerSummary.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ContainerSummary.php
@@ -69,7 +69,7 @@ class ContainerSummary
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -303,7 +303,7 @@ class ContainerSummary
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -312,7 +312,7 @@ class ContainerSummary
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ContainerSummaryNetworkSettings.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ContainerSummaryNetworkSettings.php
@@ -15,13 +15,13 @@ class ContainerSummaryNetworkSettings
     /**
      * 
      *
-     * @var EndpointSettings[]
+     * @var array<string, EndpointSettings>
      */
     protected $networks;
     /**
      * 
      *
-     * @return EndpointSettings[]
+     * @return array<string, EndpointSettings>
      */
     public function getNetworks() : iterable
     {
@@ -30,7 +30,7 @@ class ContainerSummaryNetworkSettings
     /**
      * 
      *
-     * @param EndpointSettings[] $networks
+     * @param array<string, EndpointSettings> $networks
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ContainersCreatePostBody.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ContainersCreatePostBody.php
@@ -54,7 +54,7 @@ class ContainersCreatePostBody
     `{"<port>/<tcp|udp|sctp>": {}}`
     
     *
-    * @var mixed[]
+    * @var array<string, mixed>
     */
     protected $exposedPorts;
     /**
@@ -113,7 +113,7 @@ class ContainersCreatePostBody
     objects.
     
     *
-    * @var mixed[]
+    * @var array<string, mixed>
     */
     protected $volumes;
     /**
@@ -154,7 +154,7 @@ class ContainersCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -329,7 +329,7 @@ class ContainersCreatePostBody
     `{"<port>/<tcp|udp|sctp>": {}}`
     
     *
-    * @return mixed[]
+    * @return array<string, mixed>
     */
     public function getExposedPorts() : iterable
     {
@@ -341,7 +341,7 @@ class ContainersCreatePostBody
     `{"<port>/<tcp|udp|sctp>": {}}`
     
     *
-    * @param mixed[] $exposedPorts
+    * @param array<string, mixed> $exposedPorts
     *
     * @return self
     */
@@ -538,7 +538,7 @@ class ContainersCreatePostBody
     objects.
     
     *
-    * @return mixed[]
+    * @return array<string, mixed>
     */
     public function getVolumes() : iterable
     {
@@ -549,7 +549,7 @@ class ContainersCreatePostBody
     objects.
     
     *
-    * @param mixed[] $volumes
+    * @param array<string, mixed> $volumes
     *
     * @return self
     */
@@ -682,7 +682,7 @@ class ContainersCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -691,7 +691,7 @@ class ContainersCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/DeviceRequest.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/DeviceRequest.php
@@ -41,7 +41,7 @@ class DeviceRequest
     are passed directly to the driver.
     
     *
-    * @var string[]
+    * @var array<string, string>
     */
     protected $options;
     /**
@@ -137,7 +137,7 @@ class DeviceRequest
     are passed directly to the driver.
     
     *
-    * @return string[]
+    * @return array<string, string>
     */
     public function getOptions() : iterable
     {
@@ -148,7 +148,7 @@ class DeviceRequest
     are passed directly to the driver.
     
     *
-    * @param string[] $options
+    * @param array<string, string> $options
     *
     * @return self
     */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/Driver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/Driver.php
@@ -21,7 +21,7 @@ class Driver
     /**
      * Key/value map of driver-specific options.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $options;
     /**
@@ -49,7 +49,7 @@ class Driver
     /**
      * Key/value map of driver-specific options.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getOptions() : iterable
     {
@@ -58,7 +58,7 @@ class Driver
     /**
      * Key/value map of driver-specific options.
      *
-     * @param string[] $options
+     * @param array<string, string> $options
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/EndpointSettings.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/EndpointSettings.php
@@ -89,7 +89,7 @@ class EndpointSettings
     are passed directly to the driver and are driver specific.
     
     *
-    * @var string[]|null
+    * @var array<string, string>|null
     */
     protected $driverOpts;
     /**
@@ -361,7 +361,7 @@ class EndpointSettings
     are passed directly to the driver and are driver specific.
     
     *
-    * @return string[]|null
+    * @return array<string, string>|null
     */
     public function getDriverOpts() : ?iterable
     {
@@ -372,7 +372,7 @@ class EndpointSettings
     are passed directly to the driver and are driver specific.
     
     *
-    * @param string[]|null $driverOpts
+    * @param array<string, string>|null $driverOpts
     *
     * @return self
     */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/EngineDescription.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/EngineDescription.php
@@ -21,7 +21,7 @@ class EngineDescription
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -55,7 +55,7 @@ class EngineDescription
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -64,7 +64,7 @@ class EngineDescription
     /**
      * 
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/EventActor.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/EventActor.php
@@ -21,7 +21,7 @@ class EventActor
     /**
      * Various key/value attributes of the object, depending on its type.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $attributes;
     /**
@@ -49,7 +49,7 @@ class EventActor
     /**
      * Various key/value attributes of the object, depending on its type.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getAttributes() : iterable
     {
@@ -58,7 +58,7 @@ class EventActor
     /**
      * Various key/value attributes of the object, depending on its type.
      *
-     * @param string[] $attributes
+     * @param array<string, string> $attributes
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/GraphDriverData.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/GraphDriverData.php
@@ -21,7 +21,7 @@ class GraphDriverData
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $data;
     /**
@@ -49,7 +49,7 @@ class GraphDriverData
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getData() : iterable
     {
@@ -58,7 +58,7 @@ class GraphDriverData
     /**
      * 
      *
-     * @param string[] $data
+     * @param array<string, string> $data
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/HostConfig.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/HostConfig.php
@@ -348,7 +348,7 @@ class HostConfig
     are added to the mapping table.
     
     *
-    * @var PortBinding[][]
+    * @var array<string, PortBinding[]>
     */
     protected $portBindings;
     /**
@@ -535,7 +535,7 @@ class HostConfig
     /**
      * Storage driver options for this container, in the form `{"size": "120G"}`.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $storageOpt;
     /**
@@ -547,7 +547,7 @@ class HostConfig
     ```
     
     *
-    * @var string[]
+    * @var array<string, string>
     */
     protected $tmpfs;
     /**
@@ -579,7 +579,7 @@ class HostConfig
     ```
     
     *
-    * @var string[]
+    * @var array<string, string>
     */
     protected $sysctls;
     /**
@@ -1639,7 +1639,7 @@ class HostConfig
     are added to the mapping table.
     
     *
-    * @return PortBinding[][]
+    * @return array<string, PortBinding[]>
     */
     public function getPortBindings() : iterable
     {
@@ -1654,7 +1654,7 @@ class HostConfig
     are added to the mapping table.
     
     *
-    * @param PortBinding[][] $portBindings
+    * @param array<string, PortBinding[]> $portBindings
     *
     * @return self
     */
@@ -2249,7 +2249,7 @@ class HostConfig
     /**
      * Storage driver options for this container, in the form `{"size": "120G"}`.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getStorageOpt() : iterable
     {
@@ -2258,7 +2258,7 @@ class HostConfig
     /**
      * Storage driver options for this container, in the form `{"size": "120G"}`.
      *
-     * @param string[] $storageOpt
+     * @param array<string, string> $storageOpt
      *
      * @return self
      */
@@ -2277,7 +2277,7 @@ class HostConfig
     ```
     
     *
-    * @return string[]
+    * @return array<string, string>
     */
     public function getTmpfs() : iterable
     {
@@ -2292,7 +2292,7 @@ class HostConfig
     ```
     
     *
-    * @param string[] $tmpfs
+    * @param array<string, string> $tmpfs
     *
     * @return self
     */
@@ -2381,7 +2381,7 @@ class HostConfig
     ```
     
     *
-    * @return string[]
+    * @return array<string, string>
     */
     public function getSysctls() : iterable
     {
@@ -2396,7 +2396,7 @@ class HostConfig
     ```
     
     *
-    * @param string[] $sysctls
+    * @param array<string, string> $sysctls
     *
     * @return self
     */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/HostConfigLogConfig.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/HostConfigLogConfig.php
@@ -21,7 +21,7 @@ class HostConfigLogConfig
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $config;
     /**
@@ -49,7 +49,7 @@ class HostConfigLogConfig
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getConfig() : iterable
     {
@@ -58,7 +58,7 @@ class HostConfigLogConfig
     /**
      * 
      *
-     * @param string[] $config
+     * @param array<string, string> $config
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/IPAM.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/IPAM.php
@@ -26,13 +26,13 @@ class IPAM
     ```
     
     *
-    * @var string[][]
+    * @var array<string, string>[]
     */
     protected $config;
     /**
      * Driver-specific options, specified as a map.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $options;
     /**
@@ -65,7 +65,7 @@ class IPAM
     ```
     
     *
-    * @return string[][]
+    * @return array<string, string>[]
     */
     public function getConfig() : array
     {
@@ -79,7 +79,7 @@ class IPAM
     ```
     
     *
-    * @param string[][] $config
+    * @param array<string, string>[] $config
     *
     * @return self
     */
@@ -92,7 +92,7 @@ class IPAM
     /**
      * Driver-specific options, specified as a map.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getOptions() : iterable
     {
@@ -101,7 +101,7 @@ class IPAM
     /**
      * Driver-specific options, specified as a map.
      *
-     * @param string[] $options
+     * @param array<string, string> $options
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ImageSummary.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ImageSummary.php
@@ -63,7 +63,7 @@ class ImageSummary
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -251,7 +251,7 @@ class ImageSummary
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -260,7 +260,7 @@ class ImageSummary
     /**
      * 
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/MountVolumeOptions.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/MountVolumeOptions.php
@@ -21,7 +21,7 @@ class MountVolumeOptions
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -55,7 +55,7 @@ class MountVolumeOptions
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -64,7 +64,7 @@ class MountVolumeOptions
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/MountVolumeOptionsDriverConfig.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/MountVolumeOptionsDriverConfig.php
@@ -21,7 +21,7 @@ class MountVolumeOptionsDriverConfig
     /**
      * key/value map of driver specific options.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $options;
     /**
@@ -49,7 +49,7 @@ class MountVolumeOptionsDriverConfig
     /**
      * key/value map of driver specific options.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getOptions() : iterable
     {
@@ -58,7 +58,7 @@ class MountVolumeOptionsDriverConfig
     /**
      * key/value map of driver specific options.
      *
-     * @param string[] $options
+     * @param array<string, string> $options
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/Network.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/Network.php
@@ -75,19 +75,19 @@ class Network
     /**
      * 
      *
-     * @var NetworkContainer[]
+     * @var array<string, NetworkContainer>
      */
     protected $containers;
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $options;
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -313,7 +313,7 @@ class Network
     /**
      * 
      *
-     * @return NetworkContainer[]
+     * @return array<string, NetworkContainer>
      */
     public function getContainers() : iterable
     {
@@ -322,7 +322,7 @@ class Network
     /**
      * 
      *
-     * @param NetworkContainer[] $containers
+     * @param array<string, NetworkContainer> $containers
      *
      * @return self
      */
@@ -335,7 +335,7 @@ class Network
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getOptions() : iterable
     {
@@ -344,7 +344,7 @@ class Network
     /**
      * 
      *
-     * @param string[] $options
+     * @param array<string, string> $options
      *
      * @return self
      */
@@ -357,7 +357,7 @@ class Network
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -366,7 +366,7 @@ class Network
     /**
      * 
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/NetworkAttachmentConfig.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/NetworkAttachmentConfig.php
@@ -27,7 +27,7 @@ class NetworkAttachmentConfig
     /**
      * Driver attachment options for the network target.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $driverOpts;
     /**
@@ -77,7 +77,7 @@ class NetworkAttachmentConfig
     /**
      * Driver attachment options for the network target.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getDriverOpts() : iterable
     {
@@ -86,7 +86,7 @@ class NetworkAttachmentConfig
     /**
      * Driver attachment options for the network target.
      *
-     * @param string[] $driverOpts
+     * @param array<string, string> $driverOpts
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/NetworkSettings.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/NetworkSettings.php
@@ -51,7 +51,7 @@ class NetworkSettings
     are added to the mapping table.
     
     *
-    * @var PortBinding[][]
+    * @var array<string, PortBinding[]>
     */
     protected $ports;
     /**
@@ -195,7 +195,7 @@ class NetworkSettings
     /**
      * Information about all networks that the container is connected to.
      *
-     * @var EndpointSettings[]
+     * @var array<string, EndpointSettings>
      */
     protected $networks;
     /**
@@ -317,7 +317,7 @@ class NetworkSettings
     are added to the mapping table.
     
     *
-    * @return PortBinding[][]
+    * @return array<string, PortBinding[]>
     */
     public function getPorts() : iterable
     {
@@ -332,7 +332,7 @@ class NetworkSettings
     are added to the mapping table.
     
     *
-    * @param PortBinding[][] $ports
+    * @param array<string, PortBinding[]> $ports
     *
     * @return self
     */
@@ -731,7 +731,7 @@ class NetworkSettings
     /**
      * Information about all networks that the container is connected to.
      *
-     * @return EndpointSettings[]
+     * @return array<string, EndpointSettings>
      */
     public function getNetworks() : iterable
     {
@@ -740,7 +740,7 @@ class NetworkSettings
     /**
      * Information about all networks that the container is connected to.
      *
-     * @param EndpointSettings[] $networks
+     * @param array<string, EndpointSettings> $networks
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/NetworkingConfig.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/NetworkingConfig.php
@@ -15,13 +15,13 @@ class NetworkingConfig
     /**
      * A mapping of network name to endpoint configuration for that network.
      *
-     * @var EndpointSettings[]
+     * @var array<string, EndpointSettings>
      */
     protected $endpointsConfig;
     /**
      * A mapping of network name to endpoint configuration for that network.
      *
-     * @return EndpointSettings[]
+     * @return array<string, EndpointSettings>
      */
     public function getEndpointsConfig() : iterable
     {
@@ -30,7 +30,7 @@ class NetworkingConfig
     /**
      * A mapping of network name to endpoint configuration for that network.
      *
-     * @param EndpointSettings[] $endpointsConfig
+     * @param array<string, EndpointSettings> $endpointsConfig
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/NetworksCreatePostBody.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/NetworksCreatePostBody.php
@@ -74,13 +74,13 @@ class NetworksCreatePostBody
     /**
      * Network specific options to be used by the drivers.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $options;
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -284,7 +284,7 @@ class NetworksCreatePostBody
     /**
      * Network specific options to be used by the drivers.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getOptions() : iterable
     {
@@ -293,7 +293,7 @@ class NetworksCreatePostBody
     /**
      * Network specific options to be used by the drivers.
      *
-     * @param string[] $options
+     * @param array<string, string> $options
      *
      * @return self
      */
@@ -306,7 +306,7 @@ class NetworksCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -315,7 +315,7 @@ class NetworksCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/NodeSpec.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/NodeSpec.php
@@ -21,7 +21,7 @@ class NodeSpec
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -61,7 +61,7 @@ class NodeSpec
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -70,7 +70,7 @@ class NodeSpec
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/RegistryServiceConfig.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/RegistryServiceConfig.php
@@ -97,7 +97,7 @@ class RegistryServiceConfig
     /**
      * 
      *
-     * @var IndexInfo[]
+     * @var array<string, IndexInfo>
      */
     protected $indexConfigs;
     /**
@@ -305,7 +305,7 @@ class RegistryServiceConfig
     /**
      * 
      *
-     * @return IndexInfo[]
+     * @return array<string, IndexInfo>
      */
     public function getIndexConfigs() : iterable
     {
@@ -314,7 +314,7 @@ class RegistryServiceConfig
     /**
      * 
      *
-     * @param IndexInfo[] $indexConfigs
+     * @param array<string, IndexInfo> $indexConfigs
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SecretSpec.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SecretSpec.php
@@ -21,7 +21,7 @@ class SecretSpec
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -72,7 +72,7 @@ class SecretSpec
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -81,7 +81,7 @@ class SecretSpec
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SecretsCreatePostBody.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SecretsCreatePostBody.php
@@ -21,7 +21,7 @@ class SecretsCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -72,7 +72,7 @@ class SecretsCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -81,7 +81,7 @@ class SecretsCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ServiceSpec.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ServiceSpec.php
@@ -21,7 +21,7 @@ class ServiceSpec
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -85,7 +85,7 @@ class ServiceSpec
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -94,7 +94,7 @@ class ServiceSpec
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ServicesCreatePostBody.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ServicesCreatePostBody.php
@@ -21,7 +21,7 @@ class ServicesCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -85,7 +85,7 @@ class ServicesCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -94,7 +94,7 @@ class ServicesCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ServicesIdUpdatePostBody.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/ServicesIdUpdatePostBody.php
@@ -21,7 +21,7 @@ class ServicesIdUpdatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -85,7 +85,7 @@ class ServicesIdUpdatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -94,7 +94,7 @@ class ServicesIdUpdatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SwarmSpec.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SwarmSpec.php
@@ -21,7 +21,7 @@ class SwarmSpec
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -85,7 +85,7 @@ class SwarmSpec
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -94,7 +94,7 @@ class SwarmSpec
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SwarmSpecCAConfigExternalCAsItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SwarmSpecCAConfigExternalCAsItem.php
@@ -31,7 +31,7 @@ class SwarmSpecCAConfigExternalCAsItem
     protocol-specific options for the external CA driver.
     
     *
-    * @var string[]
+    * @var array<string, string>
     */
     protected $options;
     /**
@@ -96,7 +96,7 @@ class SwarmSpecCAConfigExternalCAsItem
     protocol-specific options for the external CA driver.
     
     *
-    * @return string[]
+    * @return array<string, string>
     */
     public function getOptions() : iterable
     {
@@ -107,7 +107,7 @@ class SwarmSpecCAConfigExternalCAsItem
     protocol-specific options for the external CA driver.
     
     *
-    * @param string[] $options
+    * @param array<string, string> $options
     *
     * @return self
     */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SwarmSpecTaskDefaultsLogDriver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SwarmSpecTaskDefaultsLogDriver.php
@@ -23,7 +23,7 @@ class SwarmSpecTaskDefaultsLogDriver
     as key/value pairs.
     
     *
-    * @var string[]
+    * @var array<string, string>
     */
     protected $options;
     /**
@@ -53,7 +53,7 @@ class SwarmSpecTaskDefaultsLogDriver
     as key/value pairs.
     
     *
-    * @return string[]
+    * @return array<string, string>
     */
     public function getOptions() : iterable
     {
@@ -64,7 +64,7 @@ class SwarmSpecTaskDefaultsLogDriver
     as key/value pairs.
     
     *
-    * @param string[] $options
+    * @param array<string, string> $options
     *
     * @return self
     */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SystemInfo.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/SystemInfo.php
@@ -459,7 +459,7 @@ class SystemInfo
     runtimes can be configured by the user and will be listed here.
     
     *
-    * @var Runtime[]
+    * @var array<string, Runtime>
     */
     protected $runtimes;
     /**
@@ -1951,7 +1951,7 @@ class SystemInfo
     runtimes can be configured by the user and will be listed here.
     
     *
-    * @return Runtime[]
+    * @return array<string, Runtime>
     */
     public function getRuntimes() : iterable
     {
@@ -1970,7 +1970,7 @@ class SystemInfo
     runtimes can be configured by the user and will be listed here.
     
     *
-    * @param Runtime[] $runtimes
+    * @param array<string, Runtime> $runtimes
     *
     * @return self
     */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/Task.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/Task.php
@@ -55,7 +55,7 @@ class Task
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -251,7 +251,7 @@ class Task
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -260,7 +260,7 @@ class Task
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/TaskSpecContainerSpec.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/TaskSpecContainerSpec.php
@@ -21,7 +21,7 @@ class TaskSpecContainerSpec
     /**
      * User-defined key/value data.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -183,7 +183,7 @@ class TaskSpecContainerSpec
     Service.
     
     *
-    * @var string[]
+    * @var array<string, string>
     */
     protected $sysctls;
     /**
@@ -233,7 +233,7 @@ class TaskSpecContainerSpec
     /**
      * User-defined key/value data.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -242,7 +242,7 @@ class TaskSpecContainerSpec
     /**
      * User-defined key/value data.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */
@@ -770,7 +770,7 @@ class TaskSpecContainerSpec
     Service.
     
     *
-    * @return string[]
+    * @return array<string, string>
     */
     public function getSysctls() : iterable
     {
@@ -786,7 +786,7 @@ class TaskSpecContainerSpec
     Service.
     
     *
-    * @param string[] $sysctls
+    * @param array<string, string> $sysctls
     *
     * @return self
     */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/TaskSpecLogDriver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/TaskSpecLogDriver.php
@@ -21,7 +21,7 @@ class TaskSpecLogDriver
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $options;
     /**
@@ -49,7 +49,7 @@ class TaskSpecLogDriver
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getOptions() : iterable
     {
@@ -58,7 +58,7 @@ class TaskSpecLogDriver
     /**
      * 
      *
-     * @param string[] $options
+     * @param array<string, string> $options
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/Volume.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/Volume.php
@@ -45,13 +45,13 @@ class Volume
     does not support this feature.
     
     *
-    * @var mixed[]
+    * @var array<string, mixed>
     */
     protected $status;
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -65,7 +65,7 @@ class Volume
     /**
      * The driver specific options used when creating the volume.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $options;
     /**
@@ -173,7 +173,7 @@ class Volume
     does not support this feature.
     
     *
-    * @return mixed[]
+    * @return array<string, mixed>
     */
     public function getStatus() : iterable
     {
@@ -188,7 +188,7 @@ class Volume
     does not support this feature.
     
     *
-    * @param mixed[] $status
+    * @param array<string, mixed> $status
     *
     * @return self
     */
@@ -201,7 +201,7 @@ class Volume
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -210,7 +210,7 @@ class Volume
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */
@@ -249,7 +249,7 @@ class Volume
     /**
      * The driver specific options used when creating the volume.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getOptions() : iterable
     {
@@ -258,7 +258,7 @@ class Volume
     /**
      * The driver specific options used when creating the volume.
      *
-     * @param string[] $options
+     * @param array<string, string> $options
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/VolumesCreatePostBody.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Model/VolumesCreatePostBody.php
@@ -29,13 +29,13 @@ class VolumesCreatePostBody
     passed directly to the driver and are driver specific.
     
     *
-    * @var string[]
+    * @var array<string, string>
     */
     protected $driverOpts;
     /**
      * User-defined key/value metadata.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $labels;
     /**
@@ -87,7 +87,7 @@ class VolumesCreatePostBody
     passed directly to the driver and are driver specific.
     
     *
-    * @return string[]
+    * @return array<string, string>
     */
     public function getDriverOpts() : iterable
     {
@@ -98,7 +98,7 @@ class VolumesCreatePostBody
     passed directly to the driver and are driver specific.
     
     *
-    * @param string[] $driverOpts
+    * @param array<string, string> $driverOpts
     *
     * @return self
     */
@@ -111,7 +111,7 @@ class VolumesCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getLabels() : iterable
     {
@@ -120,7 +120,7 @@ class VolumesCreatePostBody
     /**
      * User-defined key/value metadata.
      *
-     * @param string[] $labels
+     * @param array<string, string> $labels
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Model/Schema.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Model/Schema.php
@@ -39,7 +39,7 @@ class Schema
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $mapProperty;
     /**
@@ -145,7 +145,7 @@ class Schema
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getMapProperty() : iterable
     {
@@ -154,7 +154,7 @@ class Schema
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param array<string, string> $mapProperty
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Model/Schema.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Model/Schema.php
@@ -45,7 +45,7 @@ class Schema
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $mapProperty;
     /**
@@ -173,7 +173,7 @@ class Schema
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getMapProperty() : iterable
     {
@@ -182,7 +182,7 @@ class Schema
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param array<string, string> $mapProperty
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Model/Schema.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Model/Schema.php
@@ -45,7 +45,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $mapProperty;
     /**
@@ -173,7 +173,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getMapProperty() : iterable
     {
@@ -182,7 +182,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param array<string, string> $mapProperty
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Model/Schema.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Model/Schema.php
@@ -45,7 +45,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $mapProperty;
     /**
@@ -173,7 +173,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getMapProperty() : iterable
     {
@@ -182,7 +182,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param array<string, string> $mapProperty
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/AuthenticationToken.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/AuthenticationToken.php
@@ -27,7 +27,7 @@ class AuthenticationToken extends \ArrayObject
     /**
      * 
      *
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     protected $permissions;
     /**
@@ -95,7 +95,7 @@ class AuthenticationToken extends \ArrayObject
     /**
      * 
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function getPermissions() : iterable
     {
@@ -104,7 +104,7 @@ class AuthenticationToken extends \ArrayObject
     /**
      * 
      *
-     * @param mixed[] $permissions
+     * @param array<string, mixed> $permissions
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/AuthorizationInstallation.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/AuthorizationInstallation.php
@@ -15,7 +15,7 @@ class AuthorizationInstallation extends \ArrayObject
     /**
      * 
      *
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     protected $permissions;
     /**
@@ -45,7 +45,7 @@ class AuthorizationInstallation extends \ArrayObject
     /**
      * 
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function getPermissions() : iterable
     {
@@ -54,7 +54,7 @@ class AuthorizationInstallation extends \ArrayObject
     /**
      * 
      *
-     * @param mixed[] $permissions
+     * @param array<string, mixed> $permissions
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/BaseGist.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/BaseGist.php
@@ -63,7 +63,7 @@ class BaseGist extends \ArrayObject
     /**
      * 
      *
-     * @var BaseGistFilesItem[]
+     * @var array<string, BaseGistFilesItem>
      */
     protected $files;
     /**
@@ -311,7 +311,7 @@ class BaseGist extends \ArrayObject
     /**
      * 
      *
-     * @return BaseGistFilesItem[]
+     * @return array<string, BaseGistFilesItem>
      */
     public function getFiles() : iterable
     {
@@ -320,7 +320,7 @@ class BaseGist extends \ArrayObject
     /**
      * 
      *
-     * @param BaseGistFilesItem[] $files
+     * @param array<string, BaseGistFilesItem> $files
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFull.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFull.php
@@ -63,7 +63,7 @@ class GistFull extends \ArrayObject
     /**
      * 
      *
-     * @var GistSimpleFilesItem[]
+     * @var array<string, GistSimpleFilesItem>
      */
     protected $files;
     /**
@@ -317,7 +317,7 @@ class GistFull extends \ArrayObject
     /**
      * 
      *
-     * @return GistSimpleFilesItem[]
+     * @return array<string, GistSimpleFilesItem>
      */
     public function getFiles() : iterable
     {
@@ -326,7 +326,7 @@ class GistFull extends \ArrayObject
     /**
      * 
      *
-     * @param GistSimpleFilesItem[] $files
+     * @param array<string, GistSimpleFilesItem> $files
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullforkOf.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullforkOf.php
@@ -63,7 +63,7 @@ class GistFullforkOf extends \ArrayObject
     /**
      * 
      *
-     * @var GistSimpleFilesItem[]
+     * @var array<string, GistSimpleFilesItem>
      */
     protected $files;
     /**
@@ -299,7 +299,7 @@ class GistFullforkOf extends \ArrayObject
     /**
      * 
      *
-     * @return GistSimpleFilesItem[]
+     * @return array<string, GistSimpleFilesItem>
      */
     public function getFiles() : iterable
     {
@@ -308,7 +308,7 @@ class GistFullforkOf extends \ArrayObject
     /**
      * 
      *
-     * @param GistSimpleFilesItem[] $files
+     * @param array<string, GistSimpleFilesItem> $files
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistSimple.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistSimple.php
@@ -63,7 +63,7 @@ class GistSimple extends \ArrayObject
     /**
      * 
      *
-     * @var GistSimpleFilesItem[]
+     * @var array<string, GistSimpleFilesItem>
      */
     protected $files;
     /**
@@ -299,7 +299,7 @@ class GistSimple extends \ArrayObject
     /**
      * 
      *
-     * @return GistSimpleFilesItem[]
+     * @return array<string, GistSimpleFilesItem>
      */
     public function getFiles() : iterable
     {
@@ -308,7 +308,7 @@ class GistSimple extends \ArrayObject
     /**
      * 
      *
-     * @param GistSimpleFilesItem[] $files
+     * @param array<string, GistSimpleFilesItem> $files
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistsGistIdPatchBody.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistsGistIdPatchBody.php
@@ -21,7 +21,7 @@ class GistsGistIdPatchBody extends \ArrayObject
     /**
      * Names of files to be updated
      *
-     * @var GistsGistIdPatchBodyFilesItem[]
+     * @var array<string, GistsGistIdPatchBodyFilesItem>
      */
     protected $files;
     /**
@@ -49,7 +49,7 @@ class GistsGistIdPatchBody extends \ArrayObject
     /**
      * Names of files to be updated
      *
-     * @return GistsGistIdPatchBodyFilesItem[]
+     * @return array<string, GistsGistIdPatchBodyFilesItem>
      */
     public function getFiles() : iterable
     {
@@ -58,7 +58,7 @@ class GistsGistIdPatchBody extends \ArrayObject
     /**
      * Names of files to be updated
      *
-     * @param GistsGistIdPatchBodyFilesItem[] $files
+     * @param array<string, GistsGistIdPatchBodyFilesItem> $files
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistsPostBody.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistsPostBody.php
@@ -21,7 +21,7 @@ class GistsPostBody extends \ArrayObject
     /**
      * Names and content for the files that make up the gist
      *
-     * @var GistsPostBodyFilesItem[]
+     * @var array<string, GistsPostBodyFilesItem>
      */
     protected $files;
     /**
@@ -55,7 +55,7 @@ class GistsPostBody extends \ArrayObject
     /**
      * Names and content for the files that make up the gist
      *
-     * @return GistsPostBodyFilesItem[]
+     * @return array<string, GistsPostBodyFilesItem>
      */
     public function getFiles() : iterable
     {
@@ -64,7 +64,7 @@ class GistsPostBody extends \ArrayObject
     /**
      * Names and content for the files that make up the gist
      *
-     * @param GistsPostBodyFilesItem[] $files
+     * @param array<string, GistsPostBodyFilesItem> $files
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBody.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBody.php
@@ -21,7 +21,7 @@ class ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBody extends \ArrayO
     /**
      * Input keys and values configured in the workflow file. The maximum number of properties is 10. Any default properties configured in the workflow file will be used when `inputs` are omitted.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $inputs;
     /**
@@ -49,7 +49,7 @@ class ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBody extends \ArrayO
     /**
      * Input keys and values configured in the workflow file. The maximum number of properties is 10. Any default properties configured in the workflow file will be used when `inputs` are omitted.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getInputs() : iterable
     {
@@ -58,7 +58,7 @@ class ReposOwnerRepoActionsWorkflowsWorkflowIdDispatchesPostBody extends \ArrayO
     /**
      * Input keys and values configured in the workflow file. The maximum number of properties is 10. Any default properties configured in the workflow file will be used when `inputs` are omitted.
      *
-     * @param string[] $inputs
+     * @param array<string, string> $inputs
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/ReposOwnerRepoDispatchesPostBody.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/ReposOwnerRepoDispatchesPostBody.php
@@ -21,7 +21,7 @@ class ReposOwnerRepoDispatchesPostBody extends \ArrayObject
     /**
      * JSON payload with extra information about the webhook event that your action or worklow may use.
      *
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     protected $clientPayload;
     /**
@@ -49,7 +49,7 @@ class ReposOwnerRepoDispatchesPostBody extends \ArrayObject
     /**
      * JSON payload with extra information about the webhook event that your action or worklow may use.
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function getClientPayload() : iterable
     {
@@ -58,7 +58,7 @@ class ReposOwnerRepoDispatchesPostBody extends \ArrayObject
     /**
      * JSON payload with extra information about the webhook event that your action or worklow may use.
      *
-     * @param mixed[] $clientPayload
+     * @param array<string, mixed> $clientPayload
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/ScopedInstallation.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/ScopedInstallation.php
@@ -15,7 +15,7 @@ class ScopedInstallation extends \ArrayObject
     /**
      * 
      *
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     protected $permissions;
     /**
@@ -45,7 +45,7 @@ class ScopedInstallation extends \ArrayObject
     /**
      * 
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function getPermissions() : iterable
     {
@@ -54,7 +54,7 @@ class ScopedInstallation extends \ArrayObject
     /**
      * 
      *
-     * @param mixed[] $permissions
+     * @param array<string, mixed> $permissions
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Model/SearchNoResultsError.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Model/SearchNoResultsError.php
@@ -21,7 +21,7 @@ class SearchNoResultsError extends \ArrayObject
     /**
      * 
      *
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     protected $companies;
     /**
@@ -55,7 +55,7 @@ class SearchNoResultsError extends \ArrayObject
     /**
      * 
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function getCompanies() : iterable
     {
@@ -64,7 +64,7 @@ class SearchNoResultsError extends \ArrayObject
     /**
      * 
      *
-     * @param mixed[] $companies
+     * @param array<string, mixed> $companies
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ApiStatisticsEvent.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ApiStatisticsEvent.php
@@ -15,13 +15,13 @@ class ApiStatisticsEvent extends ApplicationEvent
     /**
      * 
      *
-     * @var int[]|null
+     * @var array<string, int>|null
      */
     protected $requestsPerClient;
     /**
      * 
      *
-     * @return int[]|null
+     * @return array<string, int>|null
      */
     public function getRequestsPerClient() : ?iterable
     {
@@ -30,7 +30,7 @@ class ApiStatisticsEvent extends ApplicationEvent
     /**
      * 
      *
-     * @param int[]|null $requestsPerClient
+     * @param array<string, int>|null $requestsPerClient
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/AssignLayerAction.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/AssignLayerAction.php
@@ -21,7 +21,7 @@ class AssignLayerAction extends BusinessRuleAction
     /**
      * An object containing default values (used for example to populate required fields).
      *
-     * @var mixed[]|null
+     * @var array<string, mixed>|null
      */
     protected $defaultValues;
     /**
@@ -49,7 +49,7 @@ class AssignLayerAction extends BusinessRuleAction
     /**
      * An object containing default values (used for example to populate required fields).
      *
-     * @return mixed[]|null
+     * @return array<string, mixed>|null
      */
     public function getDefaultValues() : ?iterable
     {
@@ -58,7 +58,7 @@ class AssignLayerAction extends BusinessRuleAction
     /**
      * An object containing default values (used for example to populate required fields).
      *
-     * @param mixed[]|null $defaultValues
+     * @param array<string, mixed>|null $defaultValues
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/BusinessRuleTracedEvaluation.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/BusinessRuleTracedEvaluation.php
@@ -39,7 +39,7 @@ class BusinessRuleTracedEvaluation
     /**
      * State of variables after all transformation groups were ran.
      *
-     * @var string[]|null
+     * @var array<string, string>|null
      */
     protected $variables;
     /**
@@ -133,7 +133,7 @@ class BusinessRuleTracedEvaluation
     /**
      * State of variables after all transformation groups were ran.
      *
-     * @return string[]|null
+     * @return array<string, string>|null
      */
     public function getVariables() : ?iterable
     {
@@ -142,7 +142,7 @@ class BusinessRuleTracedEvaluation
     /**
      * State of variables after all transformation groups were ran.
      *
-     * @param string[]|null $variables
+     * @param array<string, string>|null $variables
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ChannelUpdateRequest.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ChannelUpdateRequest.php
@@ -33,7 +33,7 @@ class ChannelUpdateRequest
     /**
      * A custom dictionary type to distinguish language specific class properties.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $names;
     /**
@@ -147,7 +147,7 @@ class ChannelUpdateRequest
     /**
      * A custom dictionary type to distinguish language specific class properties.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getNames() : iterable
     {
@@ -156,7 +156,7 @@ class ChannelUpdateRequest
     /**
      * A custom dictionary type to distinguish language specific class properties.
      *
-     * @param string[] $names
+     * @param array<string, string> $names
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/Content.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/Content.php
@@ -39,7 +39,7 @@ class Content
     /**
      * Contains display values of the specified language, rendered according to the content schema's display pattern configuration.
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $displayValues;
     /**
@@ -163,7 +163,7 @@ class Content
     /**
      * Contains display values of the specified language, rendered according to the content schema's display pattern configuration.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getDisplayValues() : iterable
     {
@@ -172,7 +172,7 @@ class Content
     /**
      * Contains display values of the specified language, rendered according to the content schema's display pattern configuration.
      *
-     * @param string[] $displayValues
+     * @param array<string, string> $displayValues
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ContentCreateRequest.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ContentCreateRequest.php
@@ -29,7 +29,7 @@ class ContentCreateRequest
     /**
      * The content data of the content. It's an object of dynamic metadata whose structure is defined in the Content schema identified by the ContentSchemaId property.
      *
-     * @var mixed[]|null
+     * @var array<string, mixed>|null
      */
     protected $content;
     /**
@@ -37,7 +37,7 @@ class ContentCreateRequest
     The metadata belonging to the layers of the content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $metadata;
     /**
@@ -105,7 +105,7 @@ class ContentCreateRequest
     /**
      * The content data of the content. It's an object of dynamic metadata whose structure is defined in the Content schema identified by the ContentSchemaId property.
      *
-     * @return mixed[]|null
+     * @return array<string, mixed>|null
      */
     public function getContent() : ?iterable
     {
@@ -114,7 +114,7 @@ class ContentCreateRequest
     /**
      * The content data of the content. It's an object of dynamic metadata whose structure is defined in the Content schema identified by the ContentSchemaId property.
      *
-     * @param mixed[]|null $content
+     * @param array<string, mixed>|null $content
      *
      * @return self
      */
@@ -129,7 +129,7 @@ class ContentCreateRequest
     The metadata belonging to the layers of the content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getMetadata() : ?iterable
     {
@@ -140,7 +140,7 @@ class ContentCreateRequest
     The metadata belonging to the layers of the content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @param mixed[]|null $metadata
+    * @param array<string, mixed>|null $metadata
     *
     * @return self
     */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ContentDetail.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ContentDetail.php
@@ -49,14 +49,14 @@ class ContentDetail
     * The content data of the content. It's an object of dynamic metadata whose structure is defined in the Content schema identified.
     by the ContentSchemaId property.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $content;
     /**
     * The metadata belonging to the layers of the content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $metadata;
     /**
@@ -246,7 +246,7 @@ class ContentDetail
     * The content data of the content. It's an object of dynamic metadata whose structure is defined in the Content schema identified.
     by the ContentSchemaId property.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getContent() : ?iterable
     {
@@ -256,7 +256,7 @@ class ContentDetail
     * The content data of the content. It's an object of dynamic metadata whose structure is defined in the Content schema identified.
     by the ContentSchemaId property.
     *
-    * @param mixed[]|null $content
+    * @param array<string, mixed>|null $content
     *
     * @return self
     */
@@ -270,7 +270,7 @@ class ContentDetail
     * The metadata belonging to the layers of the content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getMetadata() : ?iterable
     {
@@ -280,7 +280,7 @@ class ContentDetail
     * The metadata belonging to the layers of the content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @param mixed[]|null $metadata
+    * @param array<string, mixed>|null $metadata
     *
     * @return self
     */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ContentMetadataUpdateItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ContentMetadataUpdateItem.php
@@ -25,7 +25,7 @@ class ContentMetadataUpdateItem extends \ArrayObject
     whose ContentType is Virtual).
     Update of content data will be done only if this attribute has any data, i.e. if it's not null or empty.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $content;
     /**
@@ -34,7 +34,7 @@ class ContentMetadataUpdateItem extends \ArrayObject
     by the LayerSchemaIds property.
     If there are no data for a specified LayerSchemaId, it is treated as empty.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $metadata;
     /**
@@ -102,7 +102,7 @@ class ContentMetadataUpdateItem extends \ArrayObject
     whose ContentType is Virtual).
     Update of content data will be done only if this attribute has any data, i.e. if it's not null or empty.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getContent() : ?iterable
     {
@@ -114,7 +114,7 @@ class ContentMetadataUpdateItem extends \ArrayObject
     whose ContentType is Virtual).
     Update of content data will be done only if this attribute has any data, i.e. if it's not null or empty.
     *
-    * @param mixed[]|null $content
+    * @param array<string, mixed>|null $content
     *
     * @return self
     */
@@ -130,7 +130,7 @@ class ContentMetadataUpdateItem extends \ArrayObject
     by the LayerSchemaIds property.
     If there are no data for a specified LayerSchemaId, it is treated as empty.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getMetadata() : ?iterable
     {
@@ -142,7 +142,7 @@ class ContentMetadataUpdateItem extends \ArrayObject
     by the LayerSchemaIds property.
     If there are no data for a specified LayerSchemaId, it is treated as empty.
     *
-    * @param mixed[]|null $metadata
+    * @param array<string, mixed>|null $metadata
     *
     * @return self
     */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ContentMetadataUpdateRequest.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ContentMetadataUpdateRequest.php
@@ -25,7 +25,7 @@ class ContentMetadataUpdateRequest
     whose ContentType is Virtual).
     Update of content data will be done only if this attribute has any data, i.e. if it's not null or empty.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $content;
     /**
@@ -34,7 +34,7 @@ class ContentMetadataUpdateRequest
     by the LayerSchemaIds property.
     If there are no data for a specified LayerSchemaId, it is treated as empty.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $metadata;
     /**
@@ -96,7 +96,7 @@ class ContentMetadataUpdateRequest
     whose ContentType is Virtual).
     Update of content data will be done only if this attribute has any data, i.e. if it's not null or empty.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getContent() : ?iterable
     {
@@ -108,7 +108,7 @@ class ContentMetadataUpdateRequest
     whose ContentType is Virtual).
     Update of content data will be done only if this attribute has any data, i.e. if it's not null or empty.
     *
-    * @param mixed[]|null $content
+    * @param array<string, mixed>|null $content
     *
     * @return self
     */
@@ -124,7 +124,7 @@ class ContentMetadataUpdateRequest
     by the LayerSchemaIds property.
     If there are no data for a specified LayerSchemaId, it is treated as empty.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getMetadata() : ?iterable
     {
@@ -136,7 +136,7 @@ class ContentMetadataUpdateRequest
     by the LayerSchemaIds property.
     If there are no data for a specified LayerSchemaId, it is treated as empty.
     *
-    * @param mixed[]|null $metadata
+    * @param array<string, mixed>|null $metadata
     *
     * @return self
     */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/FileTransferCreateItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/FileTransferCreateItem.php
@@ -28,7 +28,7 @@ class FileTransferCreateItem
     * The metadata to be assigned to the imported content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $metadata;
     /**
@@ -85,7 +85,7 @@ class FileTransferCreateItem
     * The metadata to be assigned to the imported content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getMetadata() : ?iterable
     {
@@ -95,7 +95,7 @@ class FileTransferCreateItem
     * The metadata to be assigned to the imported content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @param mixed[]|null $metadata
+    * @param array<string, mixed>|null $metadata
     *
     * @return self
     */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ImportTransferRequest.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ImportTransferRequest.php
@@ -22,7 +22,7 @@ class ImportTransferRequest
     * The metadata to be assigned to the imported content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $metadata;
     /**
@@ -57,7 +57,7 @@ class ImportTransferRequest
     * The metadata to be assigned to the imported content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getMetadata() : ?iterable
     {
@@ -67,7 +67,7 @@ class ImportTransferRequest
     * The metadata to be assigned to the imported content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @param mixed[]|null $metadata
+    * @param array<string, mixed>|null $metadata
     *
     * @return self
     */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/IndexField.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/IndexField.php
@@ -33,14 +33,14 @@ class IndexField
     /**
      * Contains all index field name variants of the field.
      *
-     * @var string[]|null
+     * @var array<string, string>|null
      */
     protected $indexFields;
     /**
     * Contains all simple search field name variants of the field.
     The amount of simple search fields can be equal or less to the amount of IndexFields, but never more.
     *
-    * @var string[]|null
+    * @var array<string, string>|null
     */
     protected $simpleSearchFields;
     /**
@@ -136,7 +136,7 @@ class IndexField
     /**
      * Contains all index field name variants of the field.
      *
-     * @return string[]|null
+     * @return array<string, string>|null
      */
     public function getIndexFields() : ?iterable
     {
@@ -145,7 +145,7 @@ class IndexField
     /**
      * Contains all index field name variants of the field.
      *
-     * @param string[]|null $indexFields
+     * @param array<string, string>|null $indexFields
      *
      * @return self
      */
@@ -159,7 +159,7 @@ class IndexField
     * Contains all simple search field name variants of the field.
     The amount of simple search fields can be equal or less to the amount of IndexFields, but never more.
     *
-    * @return string[]|null
+    * @return array<string, string>|null
     */
     public function getSimpleSearchFields() : ?iterable
     {
@@ -169,7 +169,7 @@ class IndexField
     * Contains all simple search field name variants of the field.
     The amount of simple search fields can be equal or less to the amount of IndexFields, but never more.
     *
-    * @param string[]|null $simpleSearchFields
+    * @param array<string, string>|null $simpleSearchFields
     *
     * @return self
     */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ListItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ListItem.php
@@ -39,7 +39,7 @@ class ListItem
     /**
      * The content data of the list item.
      *
-     * @var mixed[]|null
+     * @var array<string, mixed>|null
      */
     protected $content;
     /**
@@ -157,7 +157,7 @@ class ListItem
     /**
      * The content data of the list item.
      *
-     * @return mixed[]|null
+     * @return array<string, mixed>|null
      */
     public function getContent() : ?iterable
     {
@@ -166,7 +166,7 @@ class ListItem
     /**
      * The content data of the list item.
      *
-     * @param mixed[]|null $content
+     * @param array<string, mixed>|null $content
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ListItemCreateRequest.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ListItemCreateRequest.php
@@ -21,7 +21,7 @@ class ListItemCreateRequest
     /**
      * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema.
      *
-     * @var mixed[]|null
+     * @var array<string, mixed>|null
      */
     protected $content;
     /**
@@ -57,7 +57,7 @@ class ListItemCreateRequest
     /**
      * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema.
      *
-     * @return mixed[]|null
+     * @return array<string, mixed>|null
      */
     public function getContent() : ?iterable
     {
@@ -66,7 +66,7 @@ class ListItemCreateRequest
     /**
      * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema.
      *
-     * @param mixed[]|null $content
+     * @param array<string, mixed>|null $content
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ListItemDetail.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ListItemDetail.php
@@ -28,7 +28,7 @@ class ListItemDetail
     * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema specified
     by the ContentSchemaId property.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $content;
     /**
@@ -116,7 +116,7 @@ class ListItemDetail
     * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema specified
     by the ContentSchemaId property.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getContent() : ?iterable
     {
@@ -126,7 +126,7 @@ class ListItemDetail
     * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema specified
     by the ContentSchemaId property.
     *
-    * @param mixed[]|null $content
+    * @param array<string, mixed>|null $content
     *
     * @return self
     */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ListItemUpdateItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ListItemUpdateItem.php
@@ -15,7 +15,7 @@ class ListItemUpdateItem extends \ArrayObject
     /**
      * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema of the list item.
      *
-     * @var mixed[]|null
+     * @var array<string, mixed>|null
      */
     protected $content;
     /**
@@ -36,7 +36,7 @@ class ListItemUpdateItem extends \ArrayObject
     /**
      * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema of the list item.
      *
-     * @return mixed[]|null
+     * @return array<string, mixed>|null
      */
     public function getContent() : ?iterable
     {
@@ -45,7 +45,7 @@ class ListItemUpdateItem extends \ArrayObject
     /**
      * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema of the list item.
      *
-     * @param mixed[]|null $content
+     * @param array<string, mixed>|null $content
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ListItemUpdateRequest.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ListItemUpdateRequest.php
@@ -15,7 +15,7 @@ class ListItemUpdateRequest
     /**
      * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema of the list item.
      *
-     * @var mixed[]|null
+     * @var array<string, mixed>|null
      */
     protected $content;
     /**
@@ -30,7 +30,7 @@ class ListItemUpdateRequest
     /**
      * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema of the list item.
      *
-     * @return mixed[]|null
+     * @return array<string, mixed>|null
      */
     public function getContent() : ?iterable
     {
@@ -39,7 +39,7 @@ class ListItemUpdateRequest
     /**
      * The content data of the list item. It's an object of dynamic metadata whose structure is defined in the Content schema of the list item.
      *
-     * @param mixed[]|null $content
+     * @param array<string, mixed>|null $content
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/MetadataStatus.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/MetadataStatus.php
@@ -33,7 +33,7 @@ class MetadataStatus
     /**
      * The field ids that that cannot be used and needs to be cleaned up after updating the outdated contents and list items.
      *
-     * @var string[][]|null
+     * @var array<string, string[]>|null
      */
     protected $fieldIdsToCleanup;
     /**
@@ -105,7 +105,7 @@ class MetadataStatus
     /**
      * The field ids that that cannot be used and needs to be cleaned up after updating the outdated contents and list items.
      *
-     * @return string[][]|null
+     * @return array<string, string[]>|null
      */
     public function getFieldIdsToCleanup() : ?iterable
     {
@@ -114,7 +114,7 @@ class MetadataStatus
     /**
      * The field ids that that cannot be used and needs to be cleaned up after updating the outdated contents and list items.
      *
-     * @param string[][]|null $fieldIdsToCleanup
+     * @param array<string, string[]>|null $fieldIdsToCleanup
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/MetadataValuesSchemaReplaceCommand.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/MetadataValuesSchemaReplaceCommand.php
@@ -15,13 +15,13 @@ class MetadataValuesSchemaReplaceCommand extends MetadataValuesChangeCommandBase
     /**
      * An object containing the metadata values for the schema. The existing dictionary will be entirely overwritten.
      *
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     protected $value;
     /**
      * An object containing the metadata values for the schema. The existing dictionary will be entirely overwritten.
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function getValue() : iterable
     {
@@ -30,7 +30,7 @@ class MetadataValuesSchemaReplaceCommand extends MetadataValuesChangeCommandBase
     /**
      * An object containing the metadata values for the schema. The existing dictionary will be entirely overwritten.
      *
-     * @param mixed[] $value
+     * @param array<string, mixed> $value
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/MetadataValuesSchemaUpdateCommand.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/MetadataValuesSchemaUpdateCommand.php
@@ -15,13 +15,13 @@ class MetadataValuesSchemaUpdateCommand extends MetadataValuesChangeCommandBase
     /**
      * An object containing the metadata values to add / update.
      *
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     protected $value;
     /**
      * An object containing the metadata values to add / update.
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function getValue() : iterable
     {
@@ -30,7 +30,7 @@ class MetadataValuesSchemaUpdateCommand extends MetadataValuesChangeCommandBase
     /**
      * An object containing the metadata values to add / update.
      *
-     * @param mixed[] $value
+     * @param array<string, mixed> $value
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/MetadataValuesSchemaUpsertCommand.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/MetadataValuesSchemaUpsertCommand.php
@@ -15,13 +15,13 @@ class MetadataValuesSchemaUpsertCommand extends MetadataValuesChangeCommandBase
     /**
      * An object containing the metadata values to add / update.
      *
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     protected $value;
     /**
      * An object containing the metadata values to add / update.
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function getValue() : iterable
     {
@@ -30,7 +30,7 @@ class MetadataValuesSchemaUpsertCommand extends MetadataValuesChangeCommandBase
     /**
      * An object containing the metadata values to add / update.
      *
-     * @param mixed[] $value
+     * @param array<string, mixed> $value
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ProblemDetails.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ProblemDetails.php
@@ -45,7 +45,7 @@ class ProblemDetails
     /**
      * 
      *
-     * @var mixed[]|null
+     * @var array<string, mixed>|null
      */
     protected $extensions;
     /**
@@ -161,7 +161,7 @@ class ProblemDetails
     /**
      * 
      *
-     * @return mixed[]|null
+     * @return array<string, mixed>|null
      */
     public function getExtensions() : ?iterable
     {
@@ -170,7 +170,7 @@ class ProblemDetails
     /**
      * 
      *
-     * @param mixed[]|null $extensions
+     * @param array<string, mixed>|null $extensions
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ShareContentDetail.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Model/ShareContentDetail.php
@@ -28,14 +28,14 @@ class ShareContentDetail
     * The content data. It's an object of dynamic metadata whose structure is defined in the Content schema specified
     by the ContentSchemaId property.
     *
-    * @var mixed[]
+    * @var array<string, mixed>
     */
     protected $content;
     /**
     * The metadata belonging to the layers of the content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @var mixed[]|null
+    * @var array<string, mixed>|null
     */
     protected $metadata;
     /**
@@ -116,7 +116,7 @@ class ShareContentDetail
     * The content data. It's an object of dynamic metadata whose structure is defined in the Content schema specified
     by the ContentSchemaId property.
     *
-    * @return mixed[]
+    * @return array<string, mixed>
     */
     public function getContent() : iterable
     {
@@ -126,7 +126,7 @@ class ShareContentDetail
     * The content data. It's an object of dynamic metadata whose structure is defined in the Content schema specified
     by the ContentSchemaId property.
     *
-    * @param mixed[] $content
+    * @param array<string, mixed> $content
     *
     * @return self
     */
@@ -140,7 +140,7 @@ class ShareContentDetail
     * The metadata belonging to the layers of the content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @return mixed[]|null
+    * @return array<string, mixed>|null
     */
     public function getMetadata() : ?iterable
     {
@@ -150,7 +150,7 @@ class ShareContentDetail
     * The metadata belonging to the layers of the content. It's a dictionary of dynamic metadata whose structure is defined in the Layer schemas identified
     by the LayerSchemaIds property.
     *
-    * @param mixed[]|null $metadata
+    * @param array<string, mixed>|null $metadata
     *
     * @return self
     */

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Model/Schema.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Model/Schema.php
@@ -39,7 +39,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $mapProperty;
     /**
@@ -145,7 +145,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getMapProperty() : iterable
     {
@@ -154,7 +154,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param array<string, string> $mapProperty
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Model/Geo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Model/Geo.php
@@ -33,7 +33,7 @@ class Geo extends \ArrayObject
     /**
      * 
      *
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     protected $properties;
     /**
@@ -105,7 +105,7 @@ class Geo extends \ArrayObject
     /**
      * 
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function getProperties() : iterable
     {
@@ -114,7 +114,7 @@ class Geo extends \ArrayObject
     /**
      * 
      *
-     * @param mixed[] $properties
+     * @param array<string, mixed> $properties
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Model/InvalidRequestProblemErrorsItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Model/InvalidRequestProblemErrorsItem.php
@@ -15,7 +15,7 @@ class InvalidRequestProblemErrorsItem extends \ArrayObject
     /**
      * 
      *
-     * @var string[][]
+     * @var array<string, string[]>
      */
     protected $parameters;
     /**
@@ -27,7 +27,7 @@ class InvalidRequestProblemErrorsItem extends \ArrayObject
     /**
      * 
      *
-     * @return string[][]
+     * @return array<string, string[]>
      */
     public function getParameters() : iterable
     {
@@ -36,7 +36,7 @@ class InvalidRequestProblemErrorsItem extends \ArrayObject
     /**
      * 
      *
-     * @param string[][] $parameters
+     * @param array<string, string[]> $parameters
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Model/RulesResponseMetadata.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Model/RulesResponseMetadata.php
@@ -21,7 +21,7 @@ class RulesResponseMetadata extends \ArrayObject
     /**
      * 
      *
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     protected $summary;
     /**
@@ -49,7 +49,7 @@ class RulesResponseMetadata extends \ArrayObject
     /**
      * 
      *
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     public function getSummary() : iterable
     {
@@ -58,7 +58,7 @@ class RulesResponseMetadata extends \ArrayObject
     /**
      * 
      *
-     * @param mixed[] $summary
+     * @param array<string, mixed> $summary
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Model/Schema.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Model/Schema.php
@@ -45,7 +45,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @var string[]
+     * @var array<string, string>
      */
     protected $mapProperty;
     /**
@@ -173,7 +173,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public function getMapProperty() : iterable
     {
@@ -182,7 +182,7 @@ class Schema extends \ArrayObject
     /**
      * 
      *
-     * @param string[] $mapProperty
+     * @param array<string, string> $mapProperty
      *
      * @return self
      */


### PR DESCRIPTION
Following #433, we need to have better phpDoc for dictionary.
So I changed them to handle this properly.

The issue here is that we (sometimes) have union types as array values, which is currently not supported by `symfony/property-info` (see https://github.com/symfony/symfony/issues/38093). We should take a look at that before merging this PR.