### PR TITLE
[AutoMapper] Improve services definition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First, thank you!
 
 Here are a few rules to follow in order to ease code reviews, and discussions before maintainers accept and merge your work.
 
-* You **MUST** follow the [PSR-1](http://www.php-fig.org/psr/1/) and [PSR-2](http://www.php-fig.org/psr/2/).
+* You **MUST** follow the [PSR-1](https://www.php-fig.org/psr/psr-1/) and [PSR-2](https://www.php-fig.org/psr/psr-2/).
 * You **MUST** run the test suite.
 * You **MUST** write (or update) unit tests.
 * You **SHOULD** write documentation.

--- a/src/AutoMapper/Bundle/Resources/config/services.xml
+++ b/src/AutoMapper/Bundle/Resources/config/services.xml
@@ -5,7 +5,7 @@
 
     <services>
         <service id="Jane\AutoMapper\Bundle\AutoMapper">
-            <argument type="service" id="Jane\AutoMapper\Loader\FileLoader" />
+            <argument type="service" id="Jane\AutoMapper\Loader\ClassLoaderInterface" />
             <argument type="service" id="Jane\AutoMapper\Transformer\ChainTransformerFactory" />
             <argument type="service" id="Jane\AutoMapper\MapperGeneratorMetadataFactoryInterface" />
         </service>


### PR DESCRIPTION
Context :
Using the AutoMapper on Heroku and having speed troubles with writing to disk, I wanted to use something else than the FileLoader.

I'm proposing this fix to be able to override only the ClassLoaderInterface. I think that it was meant this way since the EvalLoader is already existing.