### PR TITLE
Introducing autoregistering of Mapper configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [AutoMapper] [GH#443](https://github.com/janephp/janephp/pull/443) Add configuration to use custom NameConverter
 - [AutoMapper] [GH#446](https://github.com/janephp/janephp/pull/446) Add autoconfigure on TransformerFactoryInterface
+- [AutoMapper] [GH#453](https://github.com/janephp/janephp/pull/453) Introducing autoregistering of custom Mapper configuration
 
 ### Changed
 - [AutoMapper] [GH#431](https://github.com/janephp/janephp/pull/431) Add a second parameter to `forMember` with target object

--- a/documentation/components/AutoMapper.rst
+++ b/documentation/components/AutoMapper.rst
@@ -178,19 +178,16 @@ Then configure the bundle to your needs, for example:
 .. code-block:: yaml
 
     jane_auto_mapper:
-      autoregister: true
+      normalizer: false
+      nameConverter: ~
+      cache_dir: '%kernel.cache_dir%/automapper'
       date_time_format: !php/const \DateTimeInterface::RFC3339_EXTENDED
-      mappings:
-        - source: Jane\AutoMapper\Bundle\Tests\Fixtures\User
-          target: Jane\AutoMapper\Tests\Fixtures\UserDTO
-          pass: DummyApp\UserConfigurationPass
 
 Possible fields:
 
 * ``normalizer`` (default: ``false``):  A boolean which indicate if we inject the AutoMapperNormalizer;
 * ``nameConverter`` (default: ``null``): A NameConverter based on your needs;
 * ``cache_dir`` (default: ``%kernel.cache_dir%/automapper``): This settings allows you to customize the output directory for generated mappers;
-* ``mappings``: This option allows you to customize Mapper metadata, you have to specify ``source`` and ``target`` data types and related configuration using ``pass`` field. This configuration should implements ``Jane\AutoMapper\Bundle\Configuration\ConfigurationPassInterface``.
 * ``date_time_format``: This option allows you to change the date time format used to transform strings to ``\DateTimeInterface`` (default: ``\DateTimeInterface::RFC3339``).
 
 Normalizer Bridge

--- a/src/AutoMapper/Bundle/AutoMapper.php
+++ b/src/AutoMapper/Bundle/AutoMapper.php
@@ -3,25 +3,13 @@
 namespace Jane\AutoMapper\Bundle;
 
 use Jane\AutoMapper\AutoMapper as BaseAutoMapper;
-use Jane\AutoMapper\Bundle\Configuration\ConfigurationPassInterface;
-use Jane\AutoMapper\MapperGeneratorMetadataInterface;
+use Jane\AutoMapper\Bundle\Configuration\MapperConfigurationInterface;
 
 class AutoMapper extends BaseAutoMapper
 {
-    /** @var ConfigurationPassInterface[] */
-    private $configurationPass = [];
-
-    public function addConfigurationPass(ConfigurationPassInterface $configurationPass): void
+    public function addMapperConfiguration(MapperConfigurationInterface $mapperConfiguration): void
     {
-        $this->configurationPass[] = $configurationPass;
-    }
-
-    public function register(MapperGeneratorMetadataInterface $metadata): void
-    {
-        foreach ($this->configurationPass as $configurationPass) {
-            $configurationPass->process($metadata);
-        }
-
-        parent::register($metadata);
+        $metadata = $this->getMetadata($mapperConfiguration->getSource(), $mapperConfiguration->getTarget());
+        $mapperConfiguration->process($metadata);
     }
 }

--- a/src/AutoMapper/Bundle/Configuration/LegacyConfigurationPassDecorator.php
+++ b/src/AutoMapper/Bundle/Configuration/LegacyConfigurationPassDecorator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\AutoMapper\Bundle\Configuration;
+
+use Jane\AutoMapper\MapperGeneratorMetadataInterface;
+
+/**
+ * @deprecated since 6.3, will be removed in 7.0. Please use `Jane\AutoMapper\Bundle\Configuration\MapperConfigurationInterface` instead.
+ */
+class LegacyConfigurationPassDecorator implements MapperConfigurationInterface
+{
+    private $configurationPass;
+    private $source;
+    private $target;
+
+    public function __construct(ConfigurationPassInterface $configurationPass, string $source, string $target)
+    {
+        $this->configurationPass = $configurationPass;
+        $this->source = $source;
+        $this->target = $target;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    public function getTarget(): string
+    {
+        return $this->target;
+    }
+
+    public function process(MapperGeneratorMetadataInterface $metadata): void
+    {
+        $this->configurationPass->process($metadata);
+    }
+}

--- a/src/AutoMapper/Bundle/Configuration/MapperConfigurationInterface.php
+++ b/src/AutoMapper/Bundle/Configuration/MapperConfigurationInterface.php
@@ -4,10 +4,11 @@ namespace Jane\AutoMapper\Bundle\Configuration;
 
 use Jane\AutoMapper\MapperGeneratorMetadataInterface;
 
-/**
- * @deprecated since 6.3, will be removed in 7.0. Please use `Jane\AutoMapper\Bundle\Configuration\MapperConfigurationInterface` instead.
- */
-interface ConfigurationPassInterface
+interface MapperConfigurationInterface
 {
     public function process(MapperGeneratorMetadataInterface $metadata): void;
+
+    public function getSource(): string;
+
+    public function getTarget(): string;
 }

--- a/src/AutoMapper/Bundle/Configuration/RestrictConfigurationPass.php
+++ b/src/AutoMapper/Bundle/Configuration/RestrictConfigurationPass.php
@@ -4,6 +4,9 @@ namespace Jane\AutoMapper\Bundle\Configuration;
 
 use Jane\AutoMapper\MapperGeneratorMetadataInterface;
 
+/**
+ * @deprecated since 6.3, will be removed in 7.0. Please use `Jane\AutoMapper\Bundle\Configuration\MapperConfigurationInterface` instead.
+ */
 class RestrictConfigurationPass implements ConfigurationPassInterface
 {
     private $source;

--- a/src/AutoMapper/Bundle/DependencyInjection/Compiler/MapperConfigurationPass.php
+++ b/src/AutoMapper/Bundle/DependencyInjection/Compiler/MapperConfigurationPass.php
@@ -7,17 +7,16 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class MapperMetadataPass implements CompilerPassInterface
+class MapperConfigurationPass implements CompilerPassInterface
 {
     use PriorityTaggedServiceTrait;
 
     public function process(ContainerBuilder $container)
     {
-        $definition = $container->getDefinition(AutoMapper::class);
-        $services = $this->findAndSortTaggedServices('jane_auto_mapper.mapper_metadata', $container);
+        $autoMapper = $container->getDefinition(AutoMapper::class);
 
-        foreach ($services as $mapper) {
-            $definition->addMethodCall('register', [$mapper]);
+        foreach ($this->findAndSortTaggedServices('jane_auto_mapper.mapper_configuration', $container) as $mapperConfiguration) {
+            $autoMapper->addMethodCall('addMapperConfiguration', [$mapperConfiguration]);
         }
     }
 }

--- a/src/AutoMapper/Bundle/DependencyInjection/Configuration.php
+++ b/src/AutoMapper/Bundle/DependencyInjection/Configuration.php
@@ -19,6 +19,11 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/automapper')->end()
                 ->scalarNode('date_time_format')->defaultValue(\DateTime::RFC3339)->end()
                 ->arrayNode('mappings')
+                    ->setDeprecated(
+                        'jane-php/automapper',
+                        '6.3',
+                        'The "%node%" option is deprecated. Use the new ' . MapperConfigurationInterface::class . ' interface to automatically register your mapper configuration.'
+                    )
                     ->prototype('array')
                     ->children()
                         ->scalarNode('source')->isRequired()->end()

--- a/src/AutoMapper/Bundle/JaneAutoMapperBundle.php
+++ b/src/AutoMapper/Bundle/JaneAutoMapperBundle.php
@@ -2,7 +2,7 @@
 
 namespace Jane\AutoMapper\Bundle;
 
-use Jane\AutoMapper\Bundle\DependencyInjection\Compiler\MapperMetadataPass;
+use Jane\AutoMapper\Bundle\DependencyInjection\Compiler\MapperConfigurationPass;
 use Jane\AutoMapper\Bundle\DependencyInjection\Compiler\TransformerFactoryPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -13,7 +13,7 @@ class JaneAutoMapperBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new MapperMetadataPass());
+        $container->addCompilerPass(new MapperConfigurationPass());
         $container->addCompilerPass(new TransformerFactoryPass());
     }
 }

--- a/src/AutoMapper/Bundle/Tests/Resources/app/AppKernel.php
+++ b/src/AutoMapper/Bundle/Tests/Resources/app/AppKernel.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/Transformer/MoneyToMoneyTransformer.php';
 namespace DummyApp;
 
 use Jane\AutoMapper\Bundle\Configuration\ConfigurationPassInterface;
+use Jane\AutoMapper\Bundle\Configuration\MapperConfigurationInterface;
 use Jane\AutoMapper\Bundle\JaneAutoMapperBundle;
 use Jane\AutoMapper\MapperGeneratorMetadataInterface;
 use Jane\AutoMapper\MapperMetadata;
@@ -63,6 +64,30 @@ class AppKernel extends Kernel
 
 class UserConfigurationPass implements ConfigurationPassInterface
 {
+    public function process(MapperGeneratorMetadataInterface $metadata): void
+    {
+        if (!$metadata instanceof MapperMetadata) {
+            return;
+        }
+
+        $metadata->forMember('email', function (User $user) {
+            return $user->email ?? 'fallback@foobar.org';
+        });
+    }
+}
+
+class UserMapperConfiguration implements MapperConfigurationInterface
+{
+    public function getSource(): string
+    {
+        return \Jane\AutoMapper\Bundle\Tests\Fixtures\User::class;
+    }
+
+    public function getTarget(): string
+    {
+        return \Jane\AutoMapper\Tests\Fixtures\UserDTO::class;
+    }
+
     public function process(MapperGeneratorMetadataInterface $metadata): void
     {
         if (!$metadata instanceof MapperMetadata) {

--- a/src/AutoMapper/Bundle/Tests/Resources/app/config.yml
+++ b/src/AutoMapper/Bundle/Tests/Resources/app/config.yml
@@ -17,5 +17,6 @@ services:
     autoconfigure: true
 
   DummyApp\UserConfigurationPass: ~
+  DummyApp\UserMapperConfiguration: ~
   DummyApp\IdNameConverter: ~
   DummyApp\Transformer\MoneyTransformerFactory: ~

--- a/src/AutoMapper/Bundle/Tests/ServiceInstantiationTest.php
+++ b/src/AutoMapper/Bundle/Tests/ServiceInstantiationTest.php
@@ -38,7 +38,7 @@ class ServiceInstantiationTest extends WebTestCase
         self::assertSame('yolo', $userDto->getName());
         self::assertSame(13, $userDto->age);
         self::assertSame(((int) date('Y')) - 13, $userDto->yearOfBirth);
-        self::assertNull($userDto->email);
+        self::assertSame('fallback@foobar.org', $userDto->email);
         self::assertInstanceOf(AddressDTO::class, $userDto->address);
         self::assertCount(1, $userDto->addresses);
         self::assertInstanceOf(AddressDTO::class, $userDto->addresses[0]);


### PR DESCRIPTION
Fix #450 

This PR keeps the compatibility with existing config, so we don't need to wait for 7.0 to release this feature.
All declared mappings are decorated by a `LegacyConfigurationPassDecorator` which implements the new interface `MapperConfigurationInterface`.

Compatibility with existing configuration is kept **but** the `AutoMapper` (from the bundle) have been changed and the `addConfigurationPass` & `register` methods have been removed. I doubt anyone use them directly, that's why I didn't kept those methods (and also because it requires some work to be 100% compatible).

At the end, the configuration is simplified (a lot)!

I targeted the `next` branch for this PR.
I can target the 6.2 one if you want, otherwise I'll wait for the 6.3 branch to be released.