### PR TITLE
[AutoMapper] Normalize NameConverter configuration

### DIFF
--- a/documentation/components/AutoMapper.rst
+++ b/documentation/components/AutoMapper.rst
@@ -179,14 +179,14 @@ Then configure the bundle to your needs, for example:
 
     jane_auto_mapper:
       normalizer: false
-      nameConverter: ~
+      name_converter: ~
       cache_dir: '%kernel.cache_dir%/automapper'
       date_time_format: !php/const \DateTimeInterface::RFC3339_EXTENDED
 
 Possible fields:
 
 * ``normalizer`` (default: ``false``):  A boolean which indicate if we inject the AutoMapperNormalizer;
-* ``nameConverter`` (default: ``null``): A NameConverter based on your needs;
+* ``name_converter`` (default: ``null``): A NameConverter based on your needs;
 * ``cache_dir`` (default: ``%kernel.cache_dir%/automapper``): This settings allows you to customize the output directory for generated mappers;
 * ``date_time_format``: This option allows you to change the date time format used to transform strings to ``\DateTimeInterface`` (default: ``\DateTimeInterface::RFC3339``).
 

--- a/src/AutoMapper/Bundle/DependencyInjection/Configuration.php
+++ b/src/AutoMapper/Bundle/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->booleanNode('normalizer')->defaultFalse()->end()
-                ->scalarNode('nameConverter')->defaultNull()->end()
+                ->scalarNode('name_converter')->defaultNull()->end()
                 ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/automapper')->end()
                 ->scalarNode('date_time_format')->defaultValue(\DateTime::RFC3339)->end()
                 ->arrayNode('mappings')

--- a/src/AutoMapper/Bundle/DependencyInjection/JaneAutoMapperExtension.php
+++ b/src/AutoMapper/Bundle/DependencyInjection/JaneAutoMapperExtension.php
@@ -46,14 +46,14 @@ class JaneAutoMapperExtension extends Extension
             ;
         }
 
-        if (null !== $config['nameConverter']) {
+        if (null !== $config['name_converter']) {
             $container
                 ->getDefinition(FromTargetMappingExtractor::class)
-                ->addArgument(new Reference($config['nameConverter']));
+                ->addArgument(new Reference($config['name_converter']));
 
             $container
                 ->getDefinition(FromSourceMappingExtractor::class)
-                ->addArgument(new Reference($config['nameConverter']));
+                ->addArgument(new Reference($config['name_converter']));
         }
 
         $container->setParameter('automapper.cache_dir', $config['cache_dir']);

--- a/src/AutoMapper/Bundle/Tests/Resources/app/config.yml
+++ b/src/AutoMapper/Bundle/Tests/Resources/app/config.yml
@@ -5,7 +5,7 @@ framework:
 
 jane_auto_mapper:
     normalizer: true
-    nameConverter: DummyApp\IdNameConverter
+    name_converter: DummyApp\IdNameConverter
     mappings:
         -
             source: Jane\AutoMapper\Bundle\Tests\Fixtures\User


### PR DESCRIPTION
Change `nameConverter` configuration to `name_converter` because we already use snake_case in other parameters.