### PR TITLE
[AutoMapper] Add PrioritizedTransformerFactoryInterface and implementation

### DIFF
--- a/src/Component/AutoMapper/Bundle/Tests/Resources/app/Transformer/MoneyTransformerFactory.php
+++ b/src/Component/AutoMapper/Bundle/Tests/Resources/app/Transformer/MoneyTransformerFactory.php
@@ -4,6 +4,7 @@ namespace DummyApp\Transformer;
 
 use Jane\Component\AutoMapper\MapperMetadataInterface;
 use Jane\Component\AutoMapper\Transformer\AbstractUniqueTypeTransformerFactory;
+use Jane\Component\AutoMapper\Transformer\PrioritizedTransformerFactoryInterface;
 use Jane\Component\AutoMapper\Transformer\TransformerInterface;
 use Money\Money;
 use Symfony\Component\PropertyInfo\Type;
@@ -70,13 +71,5 @@ final class MoneyTransformerFactory extends AbstractUniqueTypeTransformerFactory
         }
 
         return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getPriority(): int
-    {
-        return 3;
     }
 }

--- a/src/Component/AutoMapper/Tests/Fixtures/Transformer/MoneyTransformerFactory.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/Transformer/MoneyTransformerFactory.php
@@ -71,12 +71,4 @@ final class MoneyTransformerFactory extends AbstractUniqueTypeTransformerFactory
 
         return true;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getPriority(): int
-    {
-        return 3;
-    }
 }

--- a/src/Component/AutoMapper/Transformer/ArrayTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/ArrayTransformerFactory.php
@@ -10,7 +10,7 @@ use Symfony\Component\PropertyInfo\Type;
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class ArrayTransformerFactory extends AbstractUniqueTypeTransformerFactory
+final class ArrayTransformerFactory extends AbstractUniqueTypeTransformerFactory implements PrioritizedTransformerFactoryInterface
 {
     private $chainTransformerFactory;
 

--- a/src/Component/AutoMapper/Transformer/BuiltinTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/BuiltinTransformerFactory.php
@@ -8,7 +8,7 @@ use Symfony\Component\PropertyInfo\Type;
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class BuiltinTransformerFactory implements TransformerFactoryInterface
+final class BuiltinTransformerFactory implements TransformerFactoryInterface, PrioritizedTransformerFactoryInterface
 {
     private const BUILTIN = [
         Type::BUILTIN_TYPE_BOOL,

--- a/src/Component/AutoMapper/Transformer/DateTimeTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/DateTimeTransformerFactory.php
@@ -8,7 +8,7 @@ use Symfony\Component\PropertyInfo\Type;
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class DateTimeTransformerFactory extends AbstractUniqueTypeTransformerFactory
+final class DateTimeTransformerFactory extends AbstractUniqueTypeTransformerFactory implements PrioritizedTransformerFactoryInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Component/AutoMapper/Transformer/MultipleTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/MultipleTransformerFactory.php
@@ -7,7 +7,7 @@ use Jane\Component\AutoMapper\MapperMetadataInterface;
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class MultipleTransformerFactory implements TransformerFactoryInterface
+final class MultipleTransformerFactory implements TransformerFactoryInterface, PrioritizedTransformerFactoryInterface
 {
     private $chainTransformerFactory;
 

--- a/src/Component/AutoMapper/Transformer/NullableTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/NullableTransformerFactory.php
@@ -8,7 +8,7 @@ use Symfony\Component\PropertyInfo\Type;
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class NullableTransformerFactory implements TransformerFactoryInterface
+final class NullableTransformerFactory implements TransformerFactoryInterface, PrioritizedTransformerFactoryInterface
 {
     private $chainTransformerFactory;
 

--- a/src/Component/AutoMapper/Transformer/ObjectTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/ObjectTransformerFactory.php
@@ -9,7 +9,7 @@ use Symfony\Component\PropertyInfo\Type;
 /**
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class ObjectTransformerFactory extends AbstractUniqueTypeTransformerFactory
+final class ObjectTransformerFactory extends AbstractUniqueTypeTransformerFactory implements PrioritizedTransformerFactoryInterface
 {
     private $autoMapper;
 

--- a/src/Component/AutoMapper/Transformer/PrioritizedTransformerFactoryInterface.php
+++ b/src/Component/AutoMapper/Transformer/PrioritizedTransformerFactoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Transformer;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface PrioritizedTransformerFactoryInterface
+{
+    /**
+     * TransformerFactory priority.
+     */
+    public function getPriority(): int;
+}

--- a/src/Component/AutoMapper/Transformer/TransformerFactoryInterface.php
+++ b/src/Component/AutoMapper/Transformer/TransformerFactoryInterface.php
@@ -19,9 +19,4 @@ interface TransformerFactoryInterface
      * @param Type[] $targetTypes
      */
     public function getTransformer(?array $sourcesTypes, ?array $targetTypes, MapperMetadataInterface $mapperMetadata): ?TransformerInterface;
-
-    /**
-     * TransformerFactory priority.
-     */
-    public function getPriority(): int;
 }

--- a/src/Component/AutoMapper/Transformer/UniqueTypeTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/UniqueTypeTransformerFactory.php
@@ -9,7 +9,7 @@ use Jane\Component\AutoMapper\MapperMetadataInterface;
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class UniqueTypeTransformerFactory implements TransformerFactoryInterface
+final class UniqueTypeTransformerFactory implements TransformerFactoryInterface, PrioritizedTransformerFactoryInterface
 {
     private $chainTransformerFactory;
 


### PR DESCRIPTION
Following #449 

This PR will remove the `getPriority` method from `TransformerFactoryInterface`, default priority will be 256 for all classes that implements `TransformerFactoryInterface` without the `PrioritizedTransformerFactoryInterface` interface.