### PR TITLE
[AutoMapper] Add DependentTransformerInterface and implementation

### DIFF
--- a/src/Component/AutoMapper/Generator/Generator.php
+++ b/src/Component/AutoMapper/Generator/Generator.php
@@ -7,6 +7,7 @@ use Jane\Component\AutoMapper\Exception\CompileException;
 use Jane\Component\AutoMapper\GeneratedMapper;
 use Jane\Component\AutoMapper\MapperContext;
 use Jane\Component\AutoMapper\MapperGeneratorMetadataInterface;
+use Jane\Component\AutoMapper\Transformer\DependentTransformerInterface;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
@@ -93,9 +94,11 @@ final class Generator
         ]);
 
         foreach ($propertiesMapping as $propertyMapping) {
-            $transformer = $propertyMapping->getTransformer();
+            if (!$propertyMapping->getTransformer() instanceof DependentTransformerInterface) {
+                continue;
+            }
 
-            foreach ($transformer->getDependencies() as $dependency) {
+            foreach ($propertyMapping->getTransformer()->getDependencies() as $dependency) {
                 if (isset($addedDependencies[$dependency->getName()])) {
                     continue;
                 }

--- a/src/Component/AutoMapper/MapperMetadata.php
+++ b/src/Component/AutoMapper/MapperMetadata.php
@@ -6,6 +6,7 @@ use Jane\Component\AutoMapper\Extractor\MappingExtractorInterface;
 use Jane\Component\AutoMapper\Extractor\PropertyMapping;
 use Jane\Component\AutoMapper\Extractor\ReadAccessor;
 use Jane\Component\AutoMapper\Transformer\CallbackTransformer;
+use Jane\Component\AutoMapper\Transformer\DependentTransformerInterface;
 
 /**
  * Mapper metadata.
@@ -283,6 +284,10 @@ class MapperMetadata implements MapperGeneratorMetadataInterface
     private function checkCircularMapperConfiguration(MapperGeneratorMetadataInterface $configuration, &$checked): bool
     {
         foreach ($configuration->getPropertiesMapping() as $propertyMapping) {
+            if (!$propertyMapping->getTransformer() instanceof DependentTransformerInterface) {
+                continue;
+            }
+
             foreach ($propertyMapping->getTransformer()->getDependencies() as $dependency) {
                 if (isset($checked[$dependency->getName()])) {
                     continue;

--- a/src/Component/AutoMapper/Tests/Transformer/DateTimeImmutableToMutableTransformerTest.php
+++ b/src/Component/AutoMapper/Tests/Transformer/DateTimeImmutableToMutableTransformerTest.php
@@ -26,11 +26,4 @@ class DateTimeImmutableToMutableTransformerTest extends TestCase
 
         self::assertFalse($transformer->assignByRef());
     }
-
-    public function testEmptyDependencies()
-    {
-        $transformer = new DateTimeImmutableToMutableTransformer();
-
-        self::assertEmpty($transformer->getDependencies());
-    }
 }

--- a/src/Component/AutoMapper/Tests/Transformer/DateTimeMutableToImmutableTransformerTest.php
+++ b/src/Component/AutoMapper/Tests/Transformer/DateTimeMutableToImmutableTransformerTest.php
@@ -26,11 +26,4 @@ class DateTimeMutableToImmutableTransformerTest extends TestCase
 
         self::assertFalse($transformer->assignByRef());
     }
-
-    public function testEmptyDependencies()
-    {
-        $transformer = new DateTimeMutableToImmutableTransformer();
-
-        self::assertEmpty($transformer->getDependencies());
-    }
 }

--- a/src/Component/AutoMapper/Transformer/ArrayTransformer.php
+++ b/src/Component/AutoMapper/Transformer/ArrayTransformer.php
@@ -12,7 +12,7 @@ use PhpParser\Node\Stmt;
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class ArrayTransformer implements TransformerInterface
+final class ArrayTransformer implements TransformerInterface, DependentTransformerInterface
 {
     private $itemTransformer;
 

--- a/src/Component/AutoMapper/Transformer/BuiltinTransformer.php
+++ b/src/Component/AutoMapper/Transformer/BuiltinTransformer.php
@@ -97,14 +97,6 @@ final class BuiltinTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function getDependencies(): array
-    {
-        return [];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function assignByRef(): bool
     {
         return false;

--- a/src/Component/AutoMapper/Transformer/CallbackTransformer.php
+++ b/src/Component/AutoMapper/Transformer/CallbackTransformer.php
@@ -47,14 +47,6 @@ final class CallbackTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function getDependencies(): array
-    {
-        return [];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function assignByRef(): bool
     {
         return false;

--- a/src/Component/AutoMapper/Transformer/CopyTransformer.php
+++ b/src/Component/AutoMapper/Transformer/CopyTransformer.php
@@ -24,14 +24,6 @@ final class CopyTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function getDependencies(): array
-    {
-        return [];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function assignByRef(): bool
     {
         return false;

--- a/src/Component/AutoMapper/Transformer/DateTimeImmutableToMutableTransformer.php
+++ b/src/Component/AutoMapper/Transformer/DateTimeImmutableToMutableTransformer.php
@@ -35,14 +35,6 @@ final class DateTimeImmutableToMutableTransformer implements TransformerInterfac
     /**
      * {@inheritdoc}
      */
-    public function getDependencies(): array
-    {
-        return [];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function assignByRef(): bool
     {
         return false;

--- a/src/Component/AutoMapper/Transformer/DateTimeMutableToImmutableTransformer.php
+++ b/src/Component/AutoMapper/Transformer/DateTimeMutableToImmutableTransformer.php
@@ -31,14 +31,6 @@ final class DateTimeMutableToImmutableTransformer implements TransformerInterfac
     /**
      * {@inheritdoc}
      */
-    public function getDependencies(): array
-    {
-        return [];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function assignByRef(): bool
     {
         return false;

--- a/src/Component/AutoMapper/Transformer/DateTimeToStringTransformer.php
+++ b/src/Component/AutoMapper/Transformer/DateTimeToStringTransformer.php
@@ -35,14 +35,6 @@ final class DateTimeToStringTransformer implements TransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function getDependencies(): array
-    {
-        return [];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function assignByRef(): bool
     {
         return false;

--- a/src/Component/AutoMapper/Transformer/DependentTransformerInterface.php
+++ b/src/Component/AutoMapper/Transformer/DependentTransformerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Transformer;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface DependentTransformerInterface
+{
+    /**
+     * Get dependencies for this transformer.
+     *
+     * @return MapperDependency[]
+     */
+    public function getDependencies(): array;
+}

--- a/src/Component/AutoMapper/Transformer/MultipleTransformer.php
+++ b/src/Component/AutoMapper/Transformer/MultipleTransformer.php
@@ -18,7 +18,7 @@ use Symfony\Component\PropertyInfo\Type;
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class MultipleTransformer implements TransformerInterface
+final class MultipleTransformer implements TransformerInterface, DependentTransformerInterface
 {
     private const CONDITION_MAPPING = [
         Type::BUILTIN_TYPE_BOOL => 'is_bool',
@@ -93,7 +93,9 @@ final class MultipleTransformer implements TransformerInterface
         $dependencies = [];
 
         foreach ($this->transformers as $transformerData) {
-            $dependencies = array_merge($dependencies, $transformerData['transformer']->getDependencies());
+            if ($transformerData['transformer'] instanceof DependentTransformerInterface) {
+                $dependencies = array_merge($dependencies, $transformerData['transformer']->getDependencies());
+            }
         }
 
         return $dependencies;

--- a/src/Component/AutoMapper/Transformer/NullableTransformer.php
+++ b/src/Component/AutoMapper/Transformer/NullableTransformer.php
@@ -13,7 +13,7 @@ use PhpParser\Node\Stmt;
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class NullableTransformer implements TransformerInterface
+final class NullableTransformer implements TransformerInterface, DependentTransformerInterface
 {
     private $itemTransformer;
     private $isTargetNullable;
@@ -53,6 +53,10 @@ final class NullableTransformer implements TransformerInterface
      */
     public function getDependencies(): array
     {
+        if (!$this->itemTransformer instanceof DependentTransformerInterface) {
+            return [];
+        }
+
         return $this->itemTransformer->getDependencies();
     }
 

--- a/src/Component/AutoMapper/Transformer/ObjectTransformer.php
+++ b/src/Component/AutoMapper/Transformer/ObjectTransformer.php
@@ -16,7 +16,7 @@ use Symfony\Component\PropertyInfo\Type;
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class ObjectTransformer implements TransformerInterface
+final class ObjectTransformer implements TransformerInterface, DependentTransformerInterface
 {
     private $sourceType;
 

--- a/src/Component/AutoMapper/Transformer/StringToDateTimeTransformer.php
+++ b/src/Component/AutoMapper/Transformer/StringToDateTimeTransformer.php
@@ -46,12 +46,4 @@ final class StringToDateTimeTransformer implements TransformerInterface
     {
         return false;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDependencies(): array
-    {
-        return [];
-    }
 }

--- a/src/Component/AutoMapper/Transformer/TransformerInterface.php
+++ b/src/Component/AutoMapper/Transformer/TransformerInterface.php
@@ -22,13 +22,6 @@ interface TransformerInterface
     public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array;
 
     /**
-     * Get dependencies for this transformer.
-     *
-     * @return MapperDependency[]
-     */
-    public function getDependencies(): array;
-
-    /**
      * Should the resulting output be assigned by ref.
      */
     public function assignByRef(): bool;


### PR DESCRIPTION
Following #449 

This PR will remove the `getDependencies` method from `TransformerInterface` and add `DependentTransformerInterface` interface to handle this behavior when needed, will be skipped if this interface is absent.