### PR TITLE
[AutoMapper] Add AssignedByReferenceTransformerInterface and implementation

### DIFF
--- a/src/Component/AutoMapper/Generator/Generator.php
+++ b/src/Component/AutoMapper/Generator/Generator.php
@@ -7,6 +7,7 @@ use Jane\Component\AutoMapper\Exception\CompileException;
 use Jane\Component\AutoMapper\GeneratedMapper;
 use Jane\Component\AutoMapper\MapperContext;
 use Jane\Component\AutoMapper\MapperGeneratorMetadataInterface;
+use Jane\Component\AutoMapper\Transformer\AssignedByReferenceTransformerInterface;
 use Jane\Component\AutoMapper\Transformer\DependentTransformerInterface;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -142,7 +143,7 @@ final class Generator
             }
 
             [$output, $propStatements] = $transformer->transform($propertyMapping->getReadAccessor()->getExpression($sourceInput), $result, $propertyMapping, $uniqueVariableScope);
-            $writeExpression = $propertyMapping->getWriteMutator()->getExpression($result, $output, $transformer->assignByRef());
+            $writeExpression = $propertyMapping->getWriteMutator()->getExpression($result, $output, $transformer instanceof AssignedByReferenceTransformerInterface ? $transformer->assignByRef() : false);
 
             if (null === $writeExpression) {
                 continue;

--- a/src/Component/AutoMapper/Tests/Transformer/DateTimeImmutableToMutableTransformerTest.php
+++ b/src/Component/AutoMapper/Tests/Transformer/DateTimeImmutableToMutableTransformerTest.php
@@ -19,11 +19,4 @@ class DateTimeImmutableToMutableTransformerTest extends TestCase
         self::assertInstanceOf(\DateTime::class, $output);
         self::assertSame($date->format(\DateTime::RFC3339), $output->format(\DateTime::RFC3339));
     }
-
-    public function testAssignByRef()
-    {
-        $transformer = new DateTimeImmutableToMutableTransformer();
-
-        self::assertFalse($transformer->assignByRef());
-    }
 }

--- a/src/Component/AutoMapper/Tests/Transformer/DateTimeMutableToImmutableTransformerTest.php
+++ b/src/Component/AutoMapper/Tests/Transformer/DateTimeMutableToImmutableTransformerTest.php
@@ -19,11 +19,4 @@ class DateTimeMutableToImmutableTransformerTest extends TestCase
         self::assertInstanceOf(\DateTimeImmutable::class, $output);
         self::assertSame($date->format(\DateTime::RFC3339), $output->format(\DateTime::RFC3339));
     }
-
-    public function testAssignByRef()
-    {
-        $transformer = new DateTimeMutableToImmutableTransformer();
-
-        self::assertFalse($transformer->assignByRef());
-    }
 }

--- a/src/Component/AutoMapper/Transformer/ArrayTransformer.php
+++ b/src/Component/AutoMapper/Transformer/ArrayTransformer.php
@@ -36,7 +36,7 @@ final class ArrayTransformer implements TransformerInterface, DependentTransform
 
         [$output, $itemStatements] = $this->itemTransformer->transform($loopValueVar, $target, $propertyMapping, $uniqueVariableScope);
 
-        if ($this->itemTransformer->assignByRef()) {
+        if ($this->itemTransformer instanceof AssignedByReferenceTransformerInterface && $this->itemTransformer->assignByRef()) {
             $itemStatements[] = new Stmt\Expression(new Expr\AssignRef(new Expr\ArrayDimFetch($valuesVar), $output));
         } else {
             $itemStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\ArrayDimFetch($valuesVar), $output));
@@ -47,14 +47,6 @@ final class ArrayTransformer implements TransformerInterface, DependentTransform
         ]);
 
         return [$valuesVar, $statements];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assignByRef(): bool
-    {
-        return false;
     }
 
     /**

--- a/src/Component/AutoMapper/Transformer/AssignedByReferenceTransformerInterface.php
+++ b/src/Component/AutoMapper/Transformer/AssignedByReferenceTransformerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Transformer;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+interface AssignedByReferenceTransformerInterface
+{
+    /**
+     * Should the resulting output be assigned by ref.
+     */
+    public function assignByRef(): bool;
+}

--- a/src/Component/AutoMapper/Transformer/BuiltinTransformer.php
+++ b/src/Component/AutoMapper/Transformer/BuiltinTransformer.php
@@ -94,14 +94,6 @@ final class BuiltinTransformer implements TransformerInterface
         return [$input, []];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function assignByRef(): bool
-    {
-        return false;
-    }
-
     private function toArray(Expr $input)
     {
         return new Expr\Array_([new Expr\ArrayItem($input)]);

--- a/src/Component/AutoMapper/Transformer/CallbackTransformer.php
+++ b/src/Component/AutoMapper/Transformer/CallbackTransformer.php
@@ -43,12 +43,4 @@ final class CallbackTransformer implements TransformerInterface
             [],
         ];
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assignByRef(): bool
-    {
-        return false;
-    }
 }

--- a/src/Component/AutoMapper/Transformer/CopyTransformer.php
+++ b/src/Component/AutoMapper/Transformer/CopyTransformer.php
@@ -20,12 +20,4 @@ final class CopyTransformer implements TransformerInterface
     {
         return [$input, []];
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assignByRef(): bool
-    {
-        return false;
-    }
 }

--- a/src/Component/AutoMapper/Transformer/DateTimeImmutableToMutableTransformer.php
+++ b/src/Component/AutoMapper/Transformer/DateTimeImmutableToMutableTransformer.php
@@ -31,12 +31,4 @@ final class DateTimeImmutableToMutableTransformer implements TransformerInterfac
             [],
         ];
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assignByRef(): bool
-    {
-        return false;
-    }
 }

--- a/src/Component/AutoMapper/Transformer/DateTimeMutableToImmutableTransformer.php
+++ b/src/Component/AutoMapper/Transformer/DateTimeMutableToImmutableTransformer.php
@@ -27,12 +27,4 @@ final class DateTimeMutableToImmutableTransformer implements TransformerInterfac
             [],
         ];
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assignByRef(): bool
-    {
-        return false;
-    }
 }

--- a/src/Component/AutoMapper/Transformer/DateTimeToStringTransformer.php
+++ b/src/Component/AutoMapper/Transformer/DateTimeToStringTransformer.php
@@ -31,12 +31,4 @@ final class DateTimeToStringTransformer implements TransformerInterface
             new Arg(new String_($this->format)),
         ]), []];
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assignByRef(): bool
-    {
-        return false;
-    }
 }

--- a/src/Component/AutoMapper/Transformer/MultipleTransformer.php
+++ b/src/Component/AutoMapper/Transformer/MultipleTransformer.php
@@ -56,7 +56,7 @@ final class MultipleTransformer implements TransformerInterface, DependentTransf
 
             [$transformerOutput, $transformerStatements] = $transformer->transform($input, $target, $propertyMapping, $uniqueVariableScope);
 
-            $assignClass = $transformer->assignByRef() ? Expr\AssignRef::class : Expr\Assign::class;
+            $assignClass = ($transformer instanceof AssignedByReferenceTransformerInterface && $transformer->assignByRef()) ? Expr\AssignRef::class : Expr\Assign::class;
             $statements[] = new Stmt\If_(
                 new Expr\FuncCall(
                     new Name(self::CONDITION_MAPPING[$type->getBuiltinType()]),
@@ -75,14 +75,6 @@ final class MultipleTransformer implements TransformerInterface, DependentTransf
         }
 
         return [$output, $statements];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assignByRef(): bool
-    {
-        return false;
     }
 
     /**

--- a/src/Component/AutoMapper/Transformer/NullableTransformer.php
+++ b/src/Component/AutoMapper/Transformer/NullableTransformer.php
@@ -33,7 +33,7 @@ final class NullableTransformer implements TransformerInterface, DependentTransf
 
         $newOutput = null;
         $statements = [];
-        $assignClass = $this->itemTransformer->assignByRef() ? Expr\AssignRef::class : Expr\Assign::class;
+        $assignClass = ($this->itemTransformer instanceof AssignedByReferenceTransformerInterface && $this->itemTransformer->assignByRef()) ? Expr\AssignRef::class : Expr\Assign::class;
 
         if ($this->isTargetNullable) {
             $newOutput = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
@@ -58,13 +58,5 @@ final class NullableTransformer implements TransformerInterface, DependentTransf
         }
 
         return $this->itemTransformer->getDependencies();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assignByRef(): bool
-    {
-        return false;
     }
 }

--- a/src/Component/AutoMapper/Transformer/ObjectTransformer.php
+++ b/src/Component/AutoMapper/Transformer/ObjectTransformer.php
@@ -16,7 +16,7 @@ use Symfony\Component\PropertyInfo\Type;
  *
  * @author Joel Wurtz <jwurtz@jolicode.com>
  */
-final class ObjectTransformer implements TransformerInterface, DependentTransformerInterface
+final class ObjectTransformer implements TransformerInterface, DependentTransformerInterface, AssignedByReferenceTransformerInterface
 {
     private $sourceType;
 

--- a/src/Component/AutoMapper/Transformer/StringToDateTimeTransformer.php
+++ b/src/Component/AutoMapper/Transformer/StringToDateTimeTransformer.php
@@ -38,12 +38,4 @@ final class StringToDateTimeTransformer implements TransformerInterface
             new Arg($input),
         ]), []];
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function assignByRef(): bool
-    {
-        return false;
-    }
 }

--- a/src/Component/AutoMapper/Transformer/TransformerInterface.php
+++ b/src/Component/AutoMapper/Transformer/TransformerInterface.php
@@ -20,9 +20,4 @@ interface TransformerInterface
      * @return [Expr, Stmt[]] First value is the output expression, second value is an array of stmt needed to get the output
      */
     public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array;
-
-    /**
-     * Should the resulting output be assigned by ref.
-     */
-    public function assignByRef(): bool;
 }


### PR DESCRIPTION
Following #449 

This PR will remove the `assignByRef` method from `TransformerInterface` and add `AssignedByReferenceTransformerInterface` interface to handle this behavior when needed, will be false if this interface is absent.