### PR TITLE
[Jane] Fix gitsplit

### DIFF
--- a/.github/workflows/gitsplit.yml
+++ b/.github/workflows/gitsplit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        run: git clone https://github.com/janephp/janephp /home/runner/work/janephp/janephp && cd /home/runner/work/janephp/janephp
+        uses: actions/checkout@master
       - name: gitsplit
         run: docker run --rm -t -e GH_TOKEN -v /cache/gitsplit:/cache/gitsplit -v ${PWD}:/srv jderusse/gitsplit gitsplit
         env:

--- a/.gitsplit.yml
+++ b/.gitsplit.yml
@@ -6,23 +6,44 @@ splits:
   -
     prefix: "src/Component/AutoMapper"
     target: "https://${GH_TOKEN}@github.com/janephp/automapper.git"
+  - # to remove after v5 / v6 support is dropped
+    prefix: "src/AutoMapper"
+    target: "https://${GH_TOKEN}@github.com/janephp/automapper.git"
   -
     prefix: "src/Component/JsonSchema"
+    target: "https://${GH_TOKEN}@github.com/janephp/json-schema.git"
+  - # to remove after v5 / v6 support is dropped
+    prefix: "src/JsonSchema"
     target: "https://${GH_TOKEN}@github.com/janephp/json-schema.git"
   -
     prefix: "src/Component/JsonSchemaRuntime"
     target: "https://${GH_TOKEN}@github.com/janephp/json-schema-runtime.git"
+  - # to remove after v5 / v6 support is dropped
+    prefix: "src/JsonSchemaRuntime"
+    target: "https://${GH_TOKEN}@github.com/janephp/json-schema-runtime.git"
   -
     prefix: "src/Component/OpenApiCommon"
+    target: "https://${GH_TOKEN}@github.com/janephp/open-api-common.git"
+  - # to remove after v5 / v6 support is dropped
+    prefix: "src/OpenApiCommon"
     target: "https://${GH_TOKEN}@github.com/janephp/open-api-common.git"
   -
     prefix: "src/Component/OpenApi2"
     target: "https://${GH_TOKEN}@github.com/janephp/open-api-2.git"
+  - # to remove after v5 / v6 support is dropped
+    prefix: "src/OpenApi2"
+    target: "https://${GH_TOKEN}@github.com/janephp/open-api-2.git"
   -
     prefix: "src/Component/OpenApi3"
     target: "https://${GH_TOKEN}@github.com/janephp/open-api-3.git"
+  - # to remove after v5 / v6 support is dropped
+    prefix: "src/OpenApi3"
+    target: "https://${GH_TOKEN}@github.com/janephp/open-api-3.git"
   -
     prefix: "src/Component/OpenApiRuntime"
+    target: "https://${GH_TOKEN}@github.com/janephp/open-api-runtime.git"
+  - # to remove after v5 / v6 support is dropped
+    prefix: "src/OpenApiRuntime"
     target: "https://${GH_TOKEN}@github.com/janephp/open-api-runtime.git"
   -
     prefix: "documentation"


### PR DESCRIPTION
Component split was broken because it takes the file on `next` branch to split every branch or tag.
Since I changed the directory structure on `next` branch, we have to split on both old and new structure.

Related to https://github.com/janephp/janephp/pull/463#issuecomment-734229438