### PR TITLE
Fix ExceptionGenerator

### DIFF
--- a/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\OpenApi2\Tests\Expected\Exception;
 
-final class UnexpectedStatusCodeException implements ClientException
+final class UnexpectedStatusCodeException extends \RuntimeException implements ClientException
 {
     public function __construct($status)
     {

--- a/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\OpenApi3\Tests\Expected\Exception;
 
-final class UnexpectedStatusCodeException implements ClientException
+final class UnexpectedStatusCodeException extends \RuntimeException implements ClientException
 {
     public function __construct($status)
     {

--- a/src/OpenApiCommon/Generator/ExceptionGenerator.php
+++ b/src/OpenApiCommon/Generator/ExceptionGenerator.php
@@ -178,6 +178,7 @@ class ExceptionGenerator
                         'implements' => [
                             new Name('ClientException'),
                         ],
+                        'extends' => new Name('\\RuntimeException'),
                         'flags' => Stmt\Class_::MODIFIER_FINAL,
                         'stmts' => [
                             new Stmt\ClassMethod('__construct', [


### PR DESCRIPTION
> Cannot use "parent" when current class scope has no parent