### PR TITLE
OpenApi3: Add support for multiple response types using discriminator

### DIFF
--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.json',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Client.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsNoMappingBadRequestException
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsNoMappingNotFoundException
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\ObjectOne|\Jane\Component\OpenApi3\Tests\Expected\Model\ObjectTwo|\Psr\Http\Message\ResponseInterface
+     */
+    public function getObjectsNoMapping(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetObjectsNoMapping(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithMappingBadRequestException
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithMappingNotFoundException
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\ObjectOne|\Jane\Component\OpenApi3\Tests\Expected\Model\ObjectTwo|\Psr\Http\Message\ResponseInterface
+     */
+    public function getObjectsWithMapping(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetObjectsWithMapping(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithAnyOfBadRequestException
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithAnyOfNotFoundException
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function getObjectsWithAnyOf(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetObjectsWithAnyOf(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Endpoint/GetObjectsNoMapping.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Endpoint/GetObjectsNoMapping.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetObjectsNoMapping extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/objects-no-mapping';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsNoMappingBadRequestException
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsNoMappingNotFoundException
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\ObjectOne|\Jane\Component\OpenApi3\Tests\Expected\Model\ObjectTwo
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (is_null($contentType) === false && (200 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            $decoded = $serializer->decode($body, 'json');
+            if (isset($decoded['type']) && $decoded['type'] === 'ObjectOne') {
+                return $serializer->denormalize($decoded, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ObjectOne');
+            }
+            if (isset($decoded['type']) && $decoded['type'] === 'ObjectTwo') {
+                return $serializer->denormalize($decoded, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ObjectTwo');
+            }
+        }
+        if (is_null($contentType) === false && (400 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsNoMappingBadRequestException($serializer->deserialize($body, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ResponseError', 'json'));
+        }
+        if (is_null($contentType) === false && (404 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsNoMappingNotFoundException($serializer->deserialize($body, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ResponseError', 'json'));
+        }
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Endpoint/GetObjectsWithAnyOf.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Endpoint/GetObjectsWithAnyOf.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetObjectsWithAnyOf extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/objects-any-of';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithAnyOfBadRequestException
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithAnyOfNotFoundException
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (is_null($contentType) === false && (200 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            return json_decode($body);
+        }
+        if (is_null($contentType) === false && (400 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithAnyOfBadRequestException($serializer->deserialize($body, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ResponseError', 'json'));
+        }
+        if (is_null($contentType) === false && (404 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithAnyOfNotFoundException($serializer->deserialize($body, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ResponseError', 'json'));
+        }
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Endpoint/GetObjectsWithMapping.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Endpoint/GetObjectsWithMapping.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetObjectsWithMapping extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/objects-with-mapping';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithMappingBadRequestException
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithMappingNotFoundException
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\ObjectOne|\Jane\Component\OpenApi3\Tests\Expected\Model\ObjectTwo
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (is_null($contentType) === false && (200 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            $decoded = $serializer->decode($body, 'json');
+            if (isset($decoded['type']) && $decoded['type'] === 'obj1') {
+                return $serializer->denormalize($decoded, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ObjectOne');
+            }
+            if (isset($decoded['type']) && $decoded['type'] === 'obj2') {
+                return $serializer->denormalize($decoded, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ObjectTwo');
+            }
+        }
+        if (is_null($contentType) === false && (400 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithMappingBadRequestException($serializer->deserialize($body, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ResponseError', 'json'));
+        }
+        if (is_null($contentType) === false && (404 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\GetObjectsWithMappingNotFoundException($serializer->deserialize($body, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ResponseError', 'json'));
+        }
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/ApiException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/ClientException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsNoMappingBadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsNoMappingBadRequestException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class GetObjectsNoMappingBadRequestException extends \RuntimeException implements ClientException
+{
+    private $responseError;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Expected\Model\ResponseError $responseError)
+    {
+        parent::__construct('bad request', 400);
+        $this->responseError = $responseError;
+    }
+    public function getResponseError()
+    {
+        return $this->responseError;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsNoMappingNotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsNoMappingNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class GetObjectsNoMappingNotFoundException extends \RuntimeException implements ClientException
+{
+    private $responseError;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Expected\Model\ResponseError $responseError)
+    {
+        parent::__construct('not found', 404);
+        $this->responseError = $responseError;
+    }
+    public function getResponseError()
+    {
+        return $this->responseError;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsWithAnyOfBadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsWithAnyOfBadRequestException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class GetObjectsWithAnyOfBadRequestException extends \RuntimeException implements ClientException
+{
+    private $responseError;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Expected\Model\ResponseError $responseError)
+    {
+        parent::__construct('bad request', 400);
+        $this->responseError = $responseError;
+    }
+    public function getResponseError()
+    {
+        return $this->responseError;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsWithAnyOfNotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsWithAnyOfNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class GetObjectsWithAnyOfNotFoundException extends \RuntimeException implements ClientException
+{
+    private $responseError;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Expected\Model\ResponseError $responseError)
+    {
+        parent::__construct('not found', 404);
+        $this->responseError = $responseError;
+    }
+    public function getResponseError()
+    {
+        return $this->responseError;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsWithMappingBadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsWithMappingBadRequestException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class GetObjectsWithMappingBadRequestException extends \RuntimeException implements ClientException
+{
+    private $responseError;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Expected\Model\ResponseError $responseError)
+    {
+        parent::__construct('bad request', 400);
+        $this->responseError = $responseError;
+    }
+    public function getResponseError()
+    {
+        return $this->responseError;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsWithMappingNotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/GetObjectsWithMappingNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class GetObjectsWithMappingNotFoundException extends \RuntimeException implements ClientException
+{
+    private $responseError;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Expected\Model\ResponseError $responseError)
+    {
+        parent::__construct('not found', 404);
+        $this->responseError = $responseError;
+    }
+    public function getResponseError()
+    {
+        return $this->responseError;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/ServerException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Model/ObjectOne.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Model/ObjectOne.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class ObjectOne
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $type;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getType() : string
+    {
+        return $this->type;
+    }
+    /**
+     * 
+     *
+     * @param string $type
+     *
+     * @return self
+     */
+    public function setType(string $type) : self
+    {
+        $this->type = $type;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getName() : string
+    {
+        return $this->name;
+    }
+    /**
+     * 
+     *
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name) : self
+    {
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Model/ObjectTwo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Model/ObjectTwo.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class ObjectTwo
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $type;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $name;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getType() : string
+    {
+        return $this->type;
+    }
+    /**
+     * 
+     *
+     * @param string $type
+     *
+     * @return self
+     */
+    public function setType(string $type) : self
+    {
+        $this->type = $type;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getName() : string
+    {
+        return $this->name;
+    }
+    /**
+     * 
+     *
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name) : self
+    {
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Model/ResponseError.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Model/ResponseError.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class ResponseError
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $message;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getMessage() : string
+    {
+        return $this->message;
+    }
+    /**
+     * 
+     *
+     * @param string $message
+     *
+     * @return self
+     */
+    public function setMessage(string $message) : self
+    {
+        $this->message = $message;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ObjectOne' => 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Normalizer\\ObjectOneNormalizer', 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ObjectTwo' => 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Normalizer\\ObjectTwoNormalizer', 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ResponseError' => 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Normalizer\\ResponseErrorNormalizer', '\\Jane\\Component\\JsonSchemaRuntime\\Reference' => '\\Jane\\Component\\OpenApi3\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Normalizer/ObjectOneNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Normalizer/ObjectOneNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ObjectOneNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ObjectOne';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ObjectOne';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ObjectOne();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('type', $data)) {
+            $object->setType($data['type']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        $data['type'] = $object->getType();
+        if (null !== $object->getName()) {
+            $data['name'] = $object->getName();
+        }
+        return $data;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Normalizer/ObjectTwoNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Normalizer/ObjectTwoNormalizer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ObjectTwoNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ObjectTwo';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ObjectTwo';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ObjectTwo();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('type', $data)) {
+            $object->setType($data['type']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        $data['type'] = $object->getType();
+        if (null !== $object->getName()) {
+            $data['name'] = $object->getName();
+        }
+        return $data;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Normalizer/ResponseErrorNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Normalizer/ResponseErrorNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ResponseErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ResponseError';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\ResponseError';
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ResponseError();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('message', $data)) {
+            $object->setMessage($data['message']);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getMessage()) {
+            $data['message'] = $object->getMessage();
+        }
+        return $data;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected $queryParameters = [];
+    protected $headerParameters = [];
+    protected $body;
+    public abstract function getMethod() : string;
+    public abstract function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    public abstract function getUri() : string;
+    public abstract function getAuthenticationScopes() : array;
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders() : array
+    {
+        return [];
+    }
+    public function getQueryString() : string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(function ($value) {
+            return null !== $value ? $value : '';
+        }, $optionsResolved);
+        return http_build_query($optionsResolved, '', '&', PHP_QUERY_RFC3986);
+    }
+    public function getHeaders(array $baseHeaders = []) : array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getHeadersOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody() : array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null) : array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer) : array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Client/Client.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    /**
+     * @var ClientInterface
+     */
+    protected $httpClient;
+    /**
+     * @var RequestFactoryInterface
+     */
+    protected $requestFactory;
+    /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+    /**
+     * @var StreamFactoryInterface
+     */
+    protected $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (is_file($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString() : string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri() : string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod() : string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []) : array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes() : array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        if ($fetchMode === Client::FETCH_OBJECT) {
+            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
+        }
+        if ($fetchMode === Client::FETCH_RESPONSE) {
+            return $response;
+        }
+        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array) : bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $object->getReferenceUri();
+        return $ref;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof Reference;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/swagger.json
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-in-response/swagger.json
@@ -1,0 +1,203 @@
+{
+    "openapi": "3.0.0",
+    "paths": {
+        "/objects-no-mapping": {
+            "get": {
+                "operationId": "Get Objects No Mapping",
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ObjectOne"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/ObjectTwo"
+                                        }
+                                    ],
+                                    "discriminator": {
+                                        "propertyName": "type"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": [
+                    "Objects"
+                ]
+            }
+        },
+        "/objects-with-mapping": {
+            "get": {
+                "operationId": "Get Objects With Mapping",
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ObjectOne"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/ObjectTwo"
+                                        }
+                                    ],
+                                    "discriminator": {
+                                        "propertyName": "type",
+                                        "mapping": {
+                                            "obj1" : "#/components/schemas/ObjectOne",
+                                            "obj2" : "#/components/schemas/ObjectTwo"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": [
+                    "Objects"
+                ]
+            }
+        },
+        "/objects-any-of": {
+            "get": {
+                "operationId": "Get Objects With AnyOf",
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ObjectOne"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/ObjectTwo"
+                                        }
+                                    ],
+                                    "discriminator": {
+                                        "propertyName": "type",
+                                        "mapping": {
+                                            "obj1" : "#/components/schemas/ObjectOne",
+                                            "obj2" : "#/components/schemas/ObjectTwo"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "bad request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ResponseError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": [
+                    "Objects"
+                ]
+            }
+        }
+    },
+    "info": {
+        "version": "",
+        "title": ""
+    },
+    "components": {
+        "schemas": {
+            "ObjectOne": {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ObjectTwo": {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ResponseError": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Overview:

- Add support for discriminator within response https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/.
- Update generation of response to return correct type specified through schema based on data received.
- Related issue/request https://github.com/janephp/janephp/issues/435.

Additional information:

- Support added for `oneOf`, `anyOf` will fallback to previous solution to use `json_decode`.
- When discriminator is used serialization is split into decode and denormalize to be able to decide based on data.
- Supports generation with or without discriminator mapping configuration according to documentation.