### PR TITLE
Can not call getName when type is adders/removers

### DIFF
--- a/src/Component/AutoMapper/Extractor/MappingExtractor.php
+++ b/src/Component/AutoMapper/Extractor/MappingExtractor.php
@@ -87,6 +87,10 @@ abstract class MappingExtractor implements MappingExtractorInterface
             $type = WriteMutator::TYPE_METHOD;
         }
 
+        if (PropertyWriteInfo::TYPE_ADDER_AND_REMOVER === $writeInfo->getType()) {
+            $writeInfo = $writeInfo->getAdderInfo();
+        }
+
         return new WriteMutator(
             $type,
             $writeInfo->getName(),


### PR DESCRIPTION
I'm not sure how I can add a test for this though. 

This happened when using the AutoMapper to map an array to a class that had adders/removers (generated by doctrine on a toMany relation inverse side).