### PR TITLE
read-only action should use pull_request_target event

### DIFF
--- a/src/Bridge/ApiPlatform/.github/workflows/read-only.yml
+++ b/src/Bridge/ApiPlatform/.github/workflows/read-only.yml
@@ -1,5 +1,5 @@
 name: read-only
-on: pull_request
+on: pull_request_target
 jobs:
   write_message:
     runs-on: ubuntu-latest

--- a/src/Bundle/AutoMapperBundle/.github/workflows/read-only.yml
+++ b/src/Bundle/AutoMapperBundle/.github/workflows/read-only.yml
@@ -1,5 +1,5 @@
 name: read-only
-on: pull_request
+on: pull_request_target
 jobs:
   write_message:
     runs-on: ubuntu-latest

--- a/src/Component/AutoMapper/.github/workflows/read-only.yml
+++ b/src/Component/AutoMapper/.github/workflows/read-only.yml
@@ -1,5 +1,5 @@
 name: read-only
-on: pull_request
+on: pull_request_target
 jobs:
   write_message:
     runs-on: ubuntu-latest

--- a/src/Component/JsonSchema/.github/workflows/read-only.yml
+++ b/src/Component/JsonSchema/.github/workflows/read-only.yml
@@ -1,5 +1,5 @@
 name: read-only
-on: pull_request
+on: pull_request_target
 jobs:
   write_message:
     runs-on: ubuntu-latest

--- a/src/Component/JsonSchemaRuntime/.github/workflows/read-only.yml
+++ b/src/Component/JsonSchemaRuntime/.github/workflows/read-only.yml
@@ -1,5 +1,5 @@
 name: read-only
-on: pull_request
+on: pull_request_target
 jobs:
   write_message:
     runs-on: ubuntu-latest

--- a/src/Component/OpenApi2/.github/workflows/read-only.yml
+++ b/src/Component/OpenApi2/.github/workflows/read-only.yml
@@ -1,5 +1,5 @@
 name: read-only
-on: pull_request
+on: pull_request_target
 jobs:
   write_message:
     runs-on: ubuntu-latest

--- a/src/Component/OpenApi3/.github/workflows/read-only.yml
+++ b/src/Component/OpenApi3/.github/workflows/read-only.yml
@@ -1,5 +1,5 @@
 name: read-only
-on: pull_request
+on: pull_request_target
 jobs:
   write_message:
     runs-on: ubuntu-latest

--- a/src/Component/OpenApiCommon/.github/workflows/read-only.yml
+++ b/src/Component/OpenApiCommon/.github/workflows/read-only.yml
@@ -1,5 +1,5 @@
 name: read-only
-on: pull_request
+on: pull_request_target
 jobs:
   write_message:
     runs-on: ubuntu-latest

--- a/src/Component/OpenApiRuntime/.github/workflows/read-only.yml
+++ b/src/Component/OpenApiRuntime/.github/workflows/read-only.yml
@@ -1,5 +1,5 @@
 name: read-only
-on: pull_request
+on: pull_request_target
 jobs:
   write_message:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `pull_request_target` event is the same as `pull_request` but in the root repository context so it does permit to write a comment on PR and more ~