### PR TITLE
[next] Fixing a whitelisted_paths notation in OpenAPI 2 and 3 guessers

### DIFF
--- a/src/Component/OpenApi2/Guesser/OpenApiSchema/OpenApiGuesser.php
+++ b/src/Component/OpenApi2/Guesser/OpenApiSchema/OpenApiGuesser.php
@@ -137,11 +137,13 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
                     OperationGuess::PUT,
                 ];
             } elseif (\is_array($data) && 2 === \count($data)) {
-                $whitelistedPath = $data[0];
                 $whitelistedMethods = $data[1];
                 if (\is_string($whitelistedMethods)) {
                     $whitelistedMethods = [$whitelistedMethods];
                 }
+            }
+            if (\is_array($data)) {
+                $whitelistedPath = $data[0];
             }
 
             if (preg_match(sprintf('#%s#', $whitelistedPath), $path)) {

--- a/src/Component/OpenApi3/Guesser/OpenApiSchema/OpenApiGuesser.php
+++ b/src/Component/OpenApi3/Guesser/OpenApiSchema/OpenApiGuesser.php
@@ -154,11 +154,13 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
                     OperationGuess::PUT,
                 ];
             } elseif (\is_array($data) && 2 === \count($data)) {
-                $whitelistedPath = $data[0];
                 $whitelistedMethods = $data[1];
                 if (\is_string($whitelistedMethods)) {
                     $whitelistedMethods = [$whitelistedMethods];
                 }
+            }
+            if (\is_array($data)) {
+                $whitelistedPath = $data[0];
             }
 
             if (preg_match(sprintf('#%s#', $whitelistedPath), $path)) {


### PR DESCRIPTION
The `whitelisted_paths` option  with the `['\/foo\/(bar|baz)']` notation, as described in the docs, did not work.

https://jane.readthedocs.io/en/latest/components/OpenAPI.html