### PR TITLE
[OpenAPI] Bring ability skip query / header check

### DIFF
--- a/src/OpenApi2/Generator/Endpoint/GetOptionsResolverMethodTrait.php
+++ b/src/OpenApi2/Generator/Endpoint/GetOptionsResolverMethodTrait.php
@@ -26,6 +26,10 @@ trait GetOptionsResolverMethodTrait
             }
 
             if (is_a($parameter, $class)) {
+                if ($parameter->offsetExists('x-jane-skip-validation') && $parameter->offsetGet('x-jane-skip-validation')) {
+                    continue;
+                }
+
                 $parameters[] = $parameter;
                 if (\in_array($parameter->getName(), $customResolverKeys)) {
                     $queryResolverNormalizerStms[] = $this->generateOptionResolverNormalizationStatement($parameter->getName(), $customResolver[$parameter->getName()]);

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/.jane-openapi
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ .  '/swagger.json',
+    'namespace' => 'Jane\OpenApi2\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'use-fixer' => false,
+];

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Client.php
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Client.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected;
+
+class Client extends \Jane\OpenApi2\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * 
+     *
+     * @param string $testPath 
+     * @param array $testBody 
+     * @param array $queryParameters {
+     *     @var string $testQuery 
+     *     @var string $testQuerySkipped 
+     * }
+     * @param array $headerParameters {
+     *     @var string $testHeader 
+     *     @var string $testHeaderSkipped 
+     * }
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function testGetWithPathParameters(string $testPath, array $testBody, array $queryParameters = array(), array $headerParameters = array(), string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\OpenApi2\Tests\Expected\Endpoint\TestGetWithPathParameters($testPath, $testBody, $queryParameters, $headerParameters), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Endpoint/TestGetWithPathParameters.php
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Endpoint/TestGetWithPathParameters.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Endpoint;
+
+class TestGetWithPathParameters extends \Jane\OpenApi2\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\OpenApi2\Tests\Expected\Runtime\Client\Endpoint
+{
+    protected $testPath;
+    /**
+     * 
+     *
+     * @param string $testPath 
+     * @param array $testBody 
+     * @param array $queryParameters {
+     *     @var string $testQuery 
+     *     @var string $testQuerySkipped 
+     * }
+     * @param array $headerParameters {
+     *     @var string $testHeader 
+     *     @var string $testHeaderSkipped 
+     * }
+     */
+    public function __construct(string $testPath, array $testBody, array $queryParameters = array(), array $headerParameters = array())
+    {
+        $this->testPath = $testPath;
+        $this->body = $testBody;
+        $this->queryParameters = $queryParameters;
+        $this->headerParameters = $headerParameters;
+    }
+    use \Jane\OpenApi2\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return str_replace(array('{testPath}'), array($this->testPath), '/test-path-parameters/{testPath}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return $this->getSerializedBody($serializer);
+    }
+    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(array('testQuery'));
+        $optionsResolver->setRequired(array('testQuery'));
+        $optionsResolver->setDefaults(array());
+        $optionsResolver->setAllowedTypes('testQuery', array('string'));
+        return $optionsResolver;
+    }
+    protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getHeadersOptionsResolver();
+        $optionsResolver->setDefined(array('testHeader'));
+        $optionsResolver->setRequired(array());
+        $optionsResolver->setDefaults(array());
+        $optionsResolver->setAllowedTypes('testHeader', array('string'));
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (200 === $status) {
+            return null;
+        }
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Normalizer;
+
+use Jane\OpenApi2\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\OpenApi2\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected $queryParameters = [];
+    protected $headerParameters = [];
+    protected $body;
+    public abstract function getMethod() : string;
+    public abstract function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    public abstract function getUri() : string;
+    public abstract function getAuthenticationScopes() : array;
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders() : array
+    {
+        return [];
+    }
+    public function getQueryString() : string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(function ($value) {
+            return null !== $value ? $value : '';
+        }, $optionsResolved);
+        return http_build_query($optionsResolved, '', '&', PHP_QUERY_RFC3986);
+    }
+    public function getHeaders(array $baseHeaders = []) : array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getHeadersOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody() : array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null) : array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer) : array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    /**
+     * @var ClientInterface
+     */
+    protected $httpClient;
+    /**
+     * @var RequestFactoryInterface
+     */
+    protected $requestFactory;
+    /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+    /**
+     * @var StreamFactoryInterface
+     */
+    protected $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (is_file($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Endpoint.php
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString() : string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri() : string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod() : string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []) : array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes() : array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        if ($fetchMode === Client::FETCH_OBJECT) {
+            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
+        }
+        if ($fetchMode === Client::FETCH_RESPONSE) {
+            return $response;
+        }
+        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array) : bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jane\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $object->getReferenceUri();
+        return $ref;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof Reference;
+    }
+}

--- a/src/OpenApi2/Tests/fixtures/skip-parameter-check/swagger.json
+++ b/src/OpenApi2/Tests/fixtures/skip-parameter-check/swagger.json
@@ -1,0 +1,72 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Skip parameter check",
+        "version": "1.0.0"
+    },
+    "parameters": {
+        "testPath": {
+            "name": "testPath",
+            "in": "path",
+            "type": "string",
+            "required": true
+        }
+    },
+    "paths": {
+        "/test-path-parameters/{testPath}": {
+            "parameters": [
+                {
+                    "name": "testBody",
+                    "in": "body",
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/parameters/testPath"
+                },
+                {
+                    "name": "testQuery",
+                    "in": "query",
+                    "type": "string",
+                    "required": true
+                },
+                {
+                    "name": "testQuerySkipped",
+                    "in": "query",
+                    "type": "string",
+                    "required": true,
+                    "x-jane-skip-validation": true
+                },
+                {
+                    "name": "testHeader",
+                    "in": "header",
+                    "type": "string"
+                },
+                {
+                    "name": "testHeaderSkipped",
+                    "in": "header",
+                    "type": "string",
+                    "x-jane-skip-validation": true
+                }
+            ],
+            "get": {
+                "operationId": "testGetWithPathParameters",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Test"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/OpenApi3/Generator/Endpoint/GetGetOptionsResolverTrait.php
+++ b/src/OpenApi3/Generator/Endpoint/GetGetOptionsResolverTrait.php
@@ -26,6 +26,10 @@ trait GetGetOptionsResolverTrait
             }
 
             if ($parameter instanceof Parameter && $parameterIn === $parameter->getIn()) {
+                if ($parameter->offsetExists('x-jane-skip-validation') && $parameter->offsetGet('x-jane-skip-validation')) {
+                    continue;
+                }
+
                 $parameters[] = $parameter;
                 if (\in_array($parameter->getName(), $customResolverKeys)) {
                     $queryResolverNormalizerStms[] = $this->generateOptionResolverNormalizationStatement($parameter->getName(), $customResolver[$parameter->getName()]);

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/.jane-openapi
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ .  '/swagger.json',
+    'namespace' => 'Jane\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Client.php
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Client.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * 
+     *
+     * @param string $testPath 
+     * @param array $queryParameters {
+     *     @var string $testQuery 
+     *     @var string $testQuerySkipped 
+     * }
+     * @param array $headerParameters {
+     *     @var string $testHeader 
+     *     @var string $testHeaderSkipped 
+     * }
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function testGetWithPathParameters(string $testPath, array $queryParameters = array(), array $headerParameters = array(), string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\OpenApi3\Tests\Expected\Endpoint\TestGetWithPathParameters($testPath, $queryParameters, $headerParameters), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Endpoint/TestGetWithPathParameters.php
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Endpoint/TestGetWithPathParameters.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Endpoint;
+
+class TestGetWithPathParameters extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    protected $testPath;
+    /**
+     * 
+     *
+     * @param string $testPath 
+     * @param array $queryParameters {
+     *     @var string $testQuery 
+     *     @var string $testQuerySkipped 
+     * }
+     * @param array $headerParameters {
+     *     @var string $testHeader 
+     *     @var string $testHeaderSkipped 
+     * }
+     */
+    public function __construct(string $testPath, array $queryParameters = array(), array $headerParameters = array())
+    {
+        $this->testPath = $testPath;
+        $this->queryParameters = $queryParameters;
+        $this->headerParameters = $headerParameters;
+    }
+    use \Jane\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return str_replace(array('{testPath}'), array($this->testPath), '/test-path-parameters/{testPath}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(array('testQuery'));
+        $optionsResolver->setRequired(array('testQuery'));
+        $optionsResolver->setDefaults(array());
+        $optionsResolver->setAllowedTypes('testQuery', array('string'));
+        return $optionsResolver;
+    }
+    protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getHeadersOptionsResolver();
+        $optionsResolver->setDefined(array('testHeader'));
+        $optionsResolver->setRequired(array('testHeader'));
+        $optionsResolver->setDefaults(array());
+        $optionsResolver->setAllowedTypes('testHeader', array('string'));
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        return null;
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\OpenApi3\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected $queryParameters = [];
+    protected $headerParameters = [];
+    protected $body;
+    public abstract function getMethod() : string;
+    public abstract function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    public abstract function getUri() : string;
+    public abstract function getAuthenticationScopes() : array;
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders() : array
+    {
+        return [];
+    }
+    public function getQueryString() : string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(function ($value) {
+            return null !== $value ? $value : '';
+        }, $optionsResolved);
+        return http_build_query($optionsResolved, '', '&', PHP_QUERY_RFC3986);
+    }
+    public function getHeaders(array $baseHeaders = []) : array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getHeadersOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody() : array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null) : array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer) : array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    /**
+     * @var ClientInterface
+     */
+    protected $httpClient;
+    /**
+     * @var RequestFactoryInterface
+     */
+    protected $requestFactory;
+    /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+    /**
+     * @var StreamFactoryInterface
+     */
+    protected $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (is_file($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Endpoint.php
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString() : string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri() : string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod() : string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []) : array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes() : array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        if ($fetchMode === Client::FETCH_OBJECT) {
+            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
+        }
+        if ($fetchMode === Client::FETCH_RESPONSE) {
+            return $response;
+        }
+        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array) : bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $object->getReferenceUri();
+        return $ref;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof Reference;
+    }
+}

--- a/src/OpenApi3/Tests/fixtures/skip-parameter-check/swagger.json
+++ b/src/OpenApi3/Tests/fixtures/skip-parameter-check/swagger.json
@@ -1,0 +1,73 @@
+{
+    "openapi": "3.0.0",
+    "paths": {
+        "/test-path-parameters/{testPath}": {
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/testPath"
+                },
+                {
+                    "name": "testQuery",
+                    "in": "query",
+                    "schema": {
+                        "type": "string"
+                    },
+                    "required": true
+                },
+                {
+                    "name": "testQuerySkipped",
+                    "in": "query",
+                    "schema": {
+                        "type": "string"
+                    },
+                    "required": true,
+                    "x-jane-skip-validation": true
+                },
+                {
+                    "name": "testHeader",
+                    "in": "header",
+                    "schema": {
+                        "type": "string"
+                    },
+                    "required": true
+                },
+                {
+                    "name": "testHeaderSkipped",
+                    "in": "header",
+                    "schema": {
+                        "type": "string"
+                    },
+                    "required": true,
+                    "x-jane-skip-validation": true
+                }
+            ],
+            "get": {
+                "operationId": "testGetWithPathParameters",
+                "tags": [
+                    "Test"
+                ],
+                "responses": {
+                    "default": {
+                        "description": "Default response"
+                    }
+                }
+            }
+        }
+    },
+    "info": {
+        "version": "3.0.3",
+        "title": ""
+    },
+    "components": {
+        "parameters": {
+            "testPath": {
+                "name": "testPath",
+                "in": "path",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
After #311 which was kind of a fail to solve this issue, I'm back with a simpler alternative !
This PR will fix #278 since it brings a new configuration parameter: `x-jane-skip-validation`.

If you have a parameter (query or header) that you can't validate because your HTTP Client is a stack of proxies that don't know what it contains below him this new config parameter if for you !

Quick example with OpenAPI 3:
```yaml
parameters:
  - name: testQuery
    in: query
    schema:
      type: string
    required: true
  - name: testQuerySkipped
    in: query
    schema:
      type: string
    required: true
    x-jane-skip-validation: true
```

In this example, first parameter "testQuery" will be checked when using this endpoint, but second parameter "testQuerySkipped" won't be checked !
This option is really usefull for parameters you put on low-level HTTP Clients such as Bearer headers or context query parameters.