### PR TITLE
[AutoMapper] Add `skip_null_values` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [AutoMapper] [GH#433](https://github.com/janephp/janephp/pull/433) Handle dictionaries with ArrayTransformer
 - [AutoMapper] [GH#432](https://github.com/janephp/janephp/pull/432) Ignore API Platform resources when using AutoMapper normalizer
 - [AutoMapper] [GH#495](https://github.com/janephp/janephp/pull/495) Add Symfony Uid transformers #495
+- [AutoMapper] [GH#507](https://github.com/janephp/janephp/pull/507) Add `skip_null_values` feature
 
 ### Changed
 - [Jane] [GH#464](https://github.com/janephp/janephp/pull/464) Update version deps for 7-dev

--- a/src/Component/AutoMapper/Generator/Generator.php
+++ b/src/Component/AutoMapper/Generator/Generator.php
@@ -142,7 +142,8 @@ final class Generator
                 continue;
             }
 
-            [$output, $propStatements] = $transformer->transform($propertyMapping->getReadAccessor()->getExpression($sourceInput), $result, $propertyMapping, $uniqueVariableScope);
+            $sourcePropertyAccessor = $propertyMapping->getReadAccessor()->getExpression($sourceInput);
+            [$output, $propStatements] = $transformer->transform($sourcePropertyAccessor, $result, $propertyMapping, $uniqueVariableScope);
             $writeExpression = $propertyMapping->getWriteMutator()->getExpression($result, $output, $transformer instanceof AssignedByReferenceTransformerInterface ? $transformer->assignByRef() : false);
 
             if (null === $writeExpression) {
@@ -189,6 +190,7 @@ final class Generator
                 $conditions[] = new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'isAllowedAttribute', [
                     new Arg($contextVariable),
                     new Arg(new Scalar\String_($propertyMapping->getProperty())),
+                    new Arg($sourcePropertyAccessor),
                 ]);
             }
 

--- a/src/Component/AutoMapper/MapperContext.php
+++ b/src/Component/AutoMapper/MapperContext.php
@@ -23,6 +23,7 @@ class MapperContext
     public const DEPTH = 'depth';
     public const TARGET_TO_POPULATE = 'target_to_populate';
     public const CONSTRUCTOR_ARGUMENTS = 'constructor_arguments';
+    public const SKIP_NULL_VALUES = 'skip_null_values';
 
     private $context = [
         self::DEPTH => 0,
@@ -156,8 +157,12 @@ class MapperContext
     /**
      * Check whether an attribute is allowed to be mapped.
      */
-    public static function isAllowedAttribute(array $context, string $attribute): bool
+    public static function isAllowedAttribute(array $context, string $attribute, $value): bool
     {
+        if (($context[self::SKIP_NULL_VALUES] ?? false) && null === $value) {
+            return false;
+        }
+
         if (($context[self::IGNORED_ATTRIBUTES] ?? false) && \in_array($attribute, $context[self::IGNORED_ATTRIBUTES], true)) {
             return false;
         }

--- a/src/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -850,4 +850,15 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertEquals($uuidV4->toRfc4122(), $newUser->getUuid()->toRfc4122());
         self::assertEquals('Grégoire Pineau', $newUser->name);
     }
+
+    public function testSkipNullValues(): void
+    {
+        $entity = new Fixtures\SkipNullValues\Entity();
+        $entity->setName('foobar');
+        $input = new Fixtures\SkipNullValues\Input();
+
+        /** @var Fixtures\SkipNullValues\Entity $entity */
+        $entity = $this->autoMapper->map($input, $entity, ['skip_null_values' => true]);
+        self::assertEquals('foobar', $entity->getName());
+    }
 }

--- a/src/Component/AutoMapper/Tests/Fixtures/SkipNullValues/Entity.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/SkipNullValues/Entity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Tests\Fixtures\SkipNullValues;
+
+class Entity
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Component/AutoMapper/Tests/Fixtures/SkipNullValues/Input.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/SkipNullValues/Input.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Tests\Fixtures\SkipNullValues;
+
+class Input
+{
+    /**
+     * @var string|null
+     */
+    public $name = null;
+}

--- a/src/Component/AutoMapper/Tests/MapperContextTest.php
+++ b/src/Component/AutoMapper/Tests/MapperContextTest.php
@@ -17,9 +17,9 @@ class MapperContextTest extends TestCase
         $context->setAllowedAttributes(['id', 'age']);
         $context->setIgnoredAttributes(['age']);
 
-        self::assertTrue(MapperContext::isAllowedAttribute($context->toArray(), 'id'));
-        self::assertFalse(MapperContext::isAllowedAttribute($context->toArray(), 'age'));
-        self::assertFalse(MapperContext::isAllowedAttribute($context->toArray(), 'name'));
+        self::assertTrue(MapperContext::isAllowedAttribute($context->toArray(), 'id', 1));
+        self::assertFalse(MapperContext::isAllowedAttribute($context->toArray(), 'age', 29));
+        self::assertFalse(MapperContext::isAllowedAttribute($context->toArray(), 'name', 'Baptiste'));
     }
 
     public function testCircularReferenceLimit(): void
@@ -128,5 +128,11 @@ class MapperContextTest extends TestCase
         $newContext = MapperContext::withNewContext($context, 'foo');
 
         self::assertEquals(['bar'], $newContext[MapperContext::ALLOWED_ATTRIBUTES]);
+    }
+
+    public function testSkipNullValues(): void
+    {
+        $context = [MapperContext::SKIP_NULL_VALUES => true];
+        self::assertFalse(MapperContext::isAllowedAttribute($context, 'id', null));
     }
 }


### PR DESCRIPTION
Fixes #434

Will add a new context option: `skip_null_values`, that will skip automapping when the value is `null`.
With this feature all already generated should be removed since `\Jane\Component\AutoMapper\MapperContext::isAllowedAttribute` method has changed.