### PR TITLE
Fix exception reserved variable keywords

### DIFF
--- a/src/OpenApi3/Tests/fixtures/exceptions/expected/Endpoint/TestNoTag.php
+++ b/src/OpenApi3/Tests/fixtures/exceptions/expected/Endpoint/TestNoTag.php
@@ -34,7 +34,7 @@ class TestNoTag extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoin
     protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
         if (is_null($contentType) === false && (400 === $status && mb_strpos($contentType, 'application/json') !== false)) {
-            throw new \Jane\OpenApi3\Tests\Expected\Exception\TestNoTagBadRequestException($serializer->deserialize($body, 'Jane\\OpenApi3\\Tests\\Expected\\Model\\Error', 'json'));
+            throw new \Jane\OpenApi3\Tests\Expected\Exception\TestNoTagBadRequestException($serializer->deserialize($body, 'Jane\\OpenApi3\\Tests\\Expected\\Model\\Message', 'json'));
         }
         if (404 === $status) {
             throw new \Jane\OpenApi3\Tests\Expected\Exception\TestNoTagNotFoundException();

--- a/src/OpenApi3/Tests/fixtures/exceptions/expected/Exception/TestNoTagBadRequestException.php
+++ b/src/OpenApi3/Tests/fixtures/exceptions/expected/Exception/TestNoTagBadRequestException.php
@@ -4,14 +4,14 @@ namespace Jane\OpenApi3\Tests\Expected\Exception;
 
 class TestNoTagBadRequestException extends BadRequestException
 {
-    private $error;
-    public function __construct(\Jane\OpenApi3\Tests\Expected\Model\Error $error)
+    private $_message;
+    public function __construct(\Jane\OpenApi3\Tests\Expected\Model\Message $message)
     {
         parent::__construct('Bad request on test exception', 400);
-        $this->error = $error;
+        $this->_message = $message;
     }
-    public function getError()
+    public function getMessage()
     {
-        return $this->error;
+        return $this->_message;
     }
 }

--- a/src/OpenApi3/Tests/fixtures/exceptions/expected/Model/Message.php
+++ b/src/OpenApi3/Tests/fixtures/exceptions/expected/Model/Message.php
@@ -2,7 +2,7 @@
 
 namespace Jane\OpenApi3\Tests\Expected\Model;
 
-class Error
+class Message
 {
     /**
      * 

--- a/src/OpenApi3/Tests/fixtures/exceptions/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/exceptions/expected/Normalizer/JaneObjectNormalizer.php
@@ -14,7 +14,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
     use CheckArray;
-    protected $normalizers = array('Jane\\OpenApi3\\Tests\\Expected\\Model\\Error' => 'Jane\\OpenApi3\\Tests\\Expected\\Normalizer\\ErrorNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\OpenApi3\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    protected $normalizers = array('Jane\\OpenApi3\\Tests\\Expected\\Model\\Message' => 'Jane\\OpenApi3\\Tests\\Expected\\Normalizer\\MessageNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\OpenApi3\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
     public function supportsDenormalization($data, $type, $format = null)
     {
         return array_key_exists($type, $this->normalizers);

--- a/src/OpenApi3/Tests/fixtures/exceptions/expected/Normalizer/MessageNormalizer.php
+++ b/src/OpenApi3/Tests/fixtures/exceptions/expected/Normalizer/MessageNormalizer.php
@@ -11,18 +11,18 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class MessageNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
     use CheckArray;
     public function supportsDenormalization($data, $type, $format = null)
     {
-        return $type === 'Jane\\OpenApi3\\Tests\\Expected\\Model\\Error';
+        return $type === 'Jane\\OpenApi3\\Tests\\Expected\\Model\\Message';
     }
     public function supportsNormalization($data, $format = null)
     {
-        return is_object($data) && get_class($data) === 'Jane\\OpenApi3\\Tests\\Expected\\Model\\Error';
+        return is_object($data) && get_class($data) === 'Jane\\OpenApi3\\Tests\\Expected\\Model\\Message';
     }
     public function denormalize($data, $class, $format = null, array $context = array())
     {
@@ -32,7 +32,7 @@ class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, Den
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\OpenApi3\Tests\Expected\Model\Error();
+        $object = new \Jane\OpenApi3\Tests\Expected\Model\Message();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }

--- a/src/OpenApi3/Tests/fixtures/exceptions/swagger.json
+++ b/src/OpenApi3/Tests/fixtures/exceptions/swagger.json
@@ -10,7 +10,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Error"
+                                    "$ref": "#/components/schemas/Message"
                                 }
                             }
                         }
@@ -39,7 +39,7 @@
     },
     "components": {
         "schemas": {
-            "Error": {
+            "Message": {
                 "type": "object",
                 "properties": {
                     "message": {


### PR DESCRIPTION
Avoid to have collision with variable names in exceptions classes since some keywords are reserved for extended `\Exception` class.