### PR TITLE
 Fix normalizer mapping for reserved PHP names in JaneObjectNormalizer 

### DIFF
--- a/src/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/JsonSchema/Generator/NormalizerGenerator.php
@@ -119,7 +119,7 @@ class NormalizerGenerator implements GeneratorInterface
 
             $namespace = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Normalizer'), $useStmts);
 
-            $normalizers[$modelFqdn] = $schema->getNamespace() . '\\Normalizer\\' . $class->getName() . 'Normalizer';
+            $normalizers[$modelFqdn] = $schema->getNamespace() . '\\Normalizer\\' . $normalizerClass->name;
 
             $schema->addFile(new File($schema->getDirectory() . '/Normalizer/' . $normalizerClass->name . '.php', $namespace, self::FILE_TYPE_NORMALIZER));
         }

--- a/src/JsonSchema/Tests/fixtures/reserved-words/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/reserved-words/expected/Normalizer/JaneObjectNormalizer.php
@@ -14,7 +14,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
     use CheckArray;
-    protected $normalizers = array('Jane\\JsonSchema\\Tests\\Expected\\Model\\_List' => 'Jane\\JsonSchema\\Tests\\Expected\\Normalizer\\_ListNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchema\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    protected $normalizers = array('Jane\\JsonSchema\\Tests\\Expected\\Model\\_List' => 'Jane\\JsonSchema\\Tests\\Expected\\Normalizer\\ListNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchema\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
     public function supportsDenormalization($data, $type, $format = null)
     {
         return array_key_exists($type, $this->normalizers);


### PR DESCRIPTION
Fixes #520