### PR TITLE
added message to exception UnexpectedStatusCodeException

### DIFF
--- a/src/Component/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -63,9 +63,20 @@ trait GetTransformResponseBodyTrait
 
             $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\UnexpectedStatusCodeException';
             $throwTypes[] = $throwType;
-            $outputStatements = array_merge($outputStatements, [
-                new Stmt\Throw_(new Expr\New_(new Name($throwType), [new Arg(new Node\Expr\Variable('status'))])),
-            ]);
+            $outputStatements = array_merge(
+                $outputStatements,
+                [
+                    new Stmt\Throw_(
+                        new Expr\New_(
+                            new Name($throwType),
+                            [
+                                new Node\Arg(new Node\Expr\Variable('status')),
+                                new Node\Arg(new Node\Expr\Variable('body')),
+                            ]
+                        )
+                    ),
+                ]
+            );
         }
 
         $returnDoc = implode('', array_map(function ($value) {

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Endpoint/TestNoTag.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Endpoint/TestNoTag.php
@@ -29,7 +29,7 @@ class TestNoTag extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\B
         if (200 === $status) {
             return null;
         }
-        throw new \Jane\Component\OpenApi2\Tests\Expected\Exception\UnexpectedStatusCodeException($status);
+        throw new \Jane\Component\OpenApi2\Tests\Expected\Exception\UnexpectedStatusCodeException($status, $body);
     }
     public function getAuthenticationScopes() : array
     {

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -4,8 +4,8 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Exception;
 
 final class UnexpectedStatusCodeException extends \RuntimeException implements ClientException
 {
-    public function __construct($status)
+    public function __construct($status, $message = '')
     {
-        parent::__construct('', $status);
+        parent::__construct($message, $status);
     }
 }

--- a/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -90,9 +90,20 @@ trait GetTransformResponseBodyTrait
 
             $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\UnexpectedStatusCodeException';
             $throwTypes[] = $throwType;
-            $outputStatements = array_merge($outputStatements, [
-                new Stmt\Throw_(new Expr\New_(new Name($throwType), [new Node\Arg(new Node\Expr\Variable('status'))])),
-            ]);
+            $outputStatements = array_merge(
+                $outputStatements,
+                [
+                    new Stmt\Throw_(
+                        new Expr\New_(
+                            new Name($throwType),
+                            [
+                                new Node\Arg(new Node\Expr\Variable('status')),
+                                new Node\Arg(new Node\Expr\Variable('body')),
+                            ]
+                        )
+                    ),
+                ]
+            );
         }
 
         $returnDoc = implode('', array_map(function ($value) {

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Endpoint/PostFoo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Endpoint/PostFoo.php
@@ -41,7 +41,7 @@ class PostFoo extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Bas
         if (200 === $status) {
             return null;
         }
-        throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException($status);
+        throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException($status, $body);
     }
     public function getAuthenticationScopes() : array
     {

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -4,8 +4,8 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
 final class UnexpectedStatusCodeException extends \RuntimeException implements ClientException
 {
-    public function __construct($status)
+    public function __construct($status, $message = '')
     {
-        parent::__construct('', $status);
+        parent::__construct($message, $status);
     }
 }

--- a/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
@@ -183,10 +183,11 @@ class ExceptionGenerator
                                 'type' => Stmt\Class_::MODIFIER_PUBLIC,
                                 'params' => [
                                     new Param(new Expr\Variable('status')),
+                                    new Param(new Expr\Variable('message'), new Scalar\String_('')),
                                 ],
                                 'stmts' => [
                                     new Stmt\Expression(new Expr\StaticCall(new Name('parent'), '__construct', [
-                                        new Node\Arg(new Scalar\String_('')),
+                                        new Node\Arg(new Expr\Variable('message')),
                                         new Node\Arg(new Expr\Variable('status')),
                                     ])),
                                 ],


### PR DESCRIPTION
For the convenience of finding errors in production, I would like to see the response text in the exception.