### PR TITLE
Fix usage of PHP-CS-Fixer

### DIFF
--- a/src/JsonSchema/Printer.php
+++ b/src/JsonSchema/Printer.php
@@ -97,7 +97,6 @@ EOH
         $command = new FixCommand(new ToolInfo());
         $config = [
             'path' => [$path],
-            '--allow-risky' => true,
         ];
 
         if (!empty($this->fixerConfig)) {


### PR DESCRIPTION
Currently, Jane fails when it try to run PHP-CS-Fixer (at least with their v3):

```CI_TEST=1 vendor/bin/jane-openapi generate --config-file=.jane-openapi.php -vvv

In ArrayInput.php line 176:
                                                                
  [Symfony\Component\Console\Exception\InvalidOptionException]  
  The "--allow-risky" option requires a value.                  
                                                                

Exception trace:
  at /home/loick/Work/slack-php-api/vendor/symfony/console/Input/ArrayInput.php:176
 Symfony\Component\Console\Input\ArrayInput->addLongOption() at /home/loick/Work/slack-php-api/vendor/symfony/console/Input/ArrayInput.php:137
 Symfony\Component\Console\Input\ArrayInput->parse() at /home/loick/Work/slack-php-api/vendor/symfony/console/Input/Input.php:55
 Symfony\Component\Console\Input\Input->bind() at /home/loick/Work/slack-php-api/vendor/symfony/console/Input/Input.php:41
 Symfony\Component\Console\Input\Input->__construct() at /home/loick/Work/slack-php-api/vendor/symfony/console/Input/ArrayInput.php:34
 Symfony\Component\Console\Input\ArrayInput->__construct() at /home/loick/Work/slack-php-api/vendor/jane-php/json-schema/Printer.php:109
 Jane\JsonSchema\Printer->fix() at /home/loick/Work/slack-php-api/vendor/jane-php/json-schema/Printer.php:61
 Jane\JsonSchema\Printer->output() at /home/loick/Work/slack-php-api/vendor/jane-php/open-api-common/Console/Command/GenerateCommand.php:62
 Jane\OpenApiCommon\Console\Command\GenerateCommand->execute() at /home/loick/Work/slack-php-api/vendor/symfony/console/Command/Command.php:256
 Symfony\Component\Console\Command\Command->run() at /home/loick/Work/slack-php-api/vendor/symfony/console/Application.php:971
 Symfony\Component\Console\Application->doRunCommand() at /home/loick/Work/slack-php-api/vendor/symfony/console/Application.php:290
 Symfony\Component\Console\Application->doRun() at /home/loick/Work/slack-php-api/vendor/symfony/console/Application.php:166
 Symfony\Component\Console\Application->run() at /home/loick/Work/slack-php-api/vendor/jane-php/open-api-common/bin/jane-openapi:22

generate [-c|--config-file CONFIG-FILE]
```

I suggest to simply remove the option `--allow-risky` from Jane as this option can be defined inside PHP-CS-Fixer's config file