### PR TITLE
Fixing WriteMutator type in case of adder/remover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - [Jane] [GH#554](https://github.com/janephp/janephp/pull/554) Relax dependency constraints for 7.1 upgrade
+- [AutoMapper] [GH#553](https://github.com/janephp/janephp/pull/553) Fix generated Mappers with adder calls
 
 ## [7.1.0] - 2021-06-25
 ### Added

--- a/src/Component/AutoMapper/Extractor/MappingExtractor.php
+++ b/src/Component/AutoMapper/Extractor/MappingExtractor.php
@@ -88,6 +88,7 @@ abstract class MappingExtractor implements MappingExtractorInterface
         }
 
         if (PropertyWriteInfo::TYPE_ADDER_AND_REMOVER === $writeInfo->getType()) {
+            $type = WriteMutator::TYPE_ADDER_AND_REMOVER;
             $writeInfo = $writeInfo->getAdderInfo();
         }
 

--- a/src/Component/AutoMapper/Extractor/WriteMutator.php
+++ b/src/Component/AutoMapper/Extractor/WriteMutator.php
@@ -21,6 +21,7 @@ final class WriteMutator
     public const TYPE_PROPERTY = 2;
     public const TYPE_ARRAY_DIMENSION = 3;
     public const TYPE_CONSTRUCTOR = 4;
+    public const TYPE_ADDER_AND_REMOVER = 5;
 
     private $type;
     private $name;
@@ -47,7 +48,7 @@ final class WriteMutator
      */
     public function getExpression(Expr\Variable $output, Expr $value, bool $byRef = false): ?Expr
     {
-        if (self::TYPE_METHOD === $this->type) {
+        if (self::TYPE_METHOD === $this->type || self::TYPE_ADDER_AND_REMOVER === $this->type) {
             return new Expr\MethodCall($output, $this->name, [
                 new Arg($value),
             ]);

--- a/src/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -7,6 +7,7 @@ use Jane\Component\AutoMapper\Exception\CircularReferenceException;
 use Jane\Component\AutoMapper\Exception\NoMappingFoundException;
 use Jane\Component\AutoMapper\MapperContext;
 use Jane\Component\AutoMapper\Tests\Fixtures\Order;
+use Jane\Component\AutoMapper\Tests\Fixtures\PetOwner;
 use Jane\Component\AutoMapper\Tests\Fixtures\Transformer\MoneyTransformerFactory;
 use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Uid\Ulid;
@@ -875,5 +876,39 @@ class AutoMapperTest extends AutoMapperBaseTest
         /** @var Fixtures\SkipNullValues\Entity $entity */
         $entity = $this->autoMapper->map($input, $entity, ['skip_null_values' => true]);
         self::assertEquals('foobar', $entity->getName());
+    }
+
+    public function testAdderAndRemover()
+    {
+        $petOwner = [
+            'pets' => [
+                ['type' => 'cat', 'name' => 'Félix'],
+                ['type' => 'dog', 'name' => 'Coco'],
+            ],
+        ];
+
+        $petOwnerData = $this->autoMapper->map($petOwner, PetOwner::class);
+
+        self::assertIsArray($petOwnerData->getPets());
+        self::assertCount(2, $petOwnerData->getPets());
+        self::assertSame('Félix', $petOwnerData->getPets()[0]->name);
+        self::assertSame('cat', $petOwnerData->getPets()[0]->type);
+        self::assertSame('Coco', $petOwnerData->getPets()[1]->name);
+        self::assertSame('dog', $petOwnerData->getPets()[1]->type);
+    }
+
+    public function testAdderAndRemoverWithNull()
+    {
+        $petOwner = [
+            'pets' => [
+                null,
+                null,
+            ],
+        ];
+
+        $petOwnerData = $this->autoMapper->map($petOwner, PetOwner::class);
+
+        self::assertIsArray($petOwnerData->getPets());
+        self::assertCount(0, $petOwnerData->getPets());
     }
 }

--- a/src/Component/AutoMapper/Tests/Fixtures/Pet.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/Pet.php
@@ -14,4 +14,10 @@ class Pet
 {
     /** @var string */
     public $type;
+
+    /** @var string */
+    public $name;
+
+    /** @var PetOwner */
+    public $owner;
 }

--- a/src/Component/AutoMapper/Tests/Fixtures/PetOwner.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/PetOwner.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Tests\Fixtures;
+
+class PetOwner
+{
+    /** @var array<int, Pet> */
+    private $pets;
+
+    public function __construct()
+    {
+        $this->pets = [];
+    }
+
+    /**
+     * @return Pet[]
+     */
+    public function getPets(): array
+    {
+        return $this->pets;
+    }
+
+    public function addPet(Pet $pet): void
+    {
+        $this->pets[] = $pet;
+    }
+
+    public function removePet(Pet $pet): void
+    {
+        $index = array_search($pet, $this->pets);
+
+        if ($index !== false) {
+            unset($this->pets[$index]);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the generated code in case of adder for a property. Previously, WriteMutator for adder methods were processed like properties, so it produces wrong assignment in generated Mapper class.

Now, the adder is known as adder (not property neither method, but real adder) by the WriteMutator itself until the call of the Transformer, then the Transformer can directly call the adder inside the foreach loop.

It also handle null values, in case of serialization with circular reference handler.