### PR TITLE
Relax semver constraints for 7.1 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [Jane] [GH#554](https://github.com/janephp/janephp/pull/554) Relax dependency constraints for 7.1 upgrade
 
 ## [7.1.0] - 2021-06-25
 ### Added

--- a/documentation/components/JsonSchema.rst
+++ b/documentation/components/JsonSchema.rst
@@ -13,7 +13,7 @@ Add this library with composer as a ``dev`` dependency:
 
 .. code-block:: bash
 
-    composer require --dev jane-php/json-schema "~6.3.0"
+    composer require --dev jane-php/json-schema
 
 This library contains a lot of dependencies to be able to generate code which are not needed on runtime. However, the
 generated code depends on other libraries and a few classes that are available through the runtime package. It is
@@ -21,7 +21,7 @@ mandatory to add the runtime dependency as a requirement through composer:
 
 .. code-block:: bash
 
-    composer require jane-php/json-schema-runtime "~6.3.0"
+    composer require jane-php/json-schema-runtime
 
 With Symfony ecosystem, we created a recipe to make it easier to use Jane. You just have to allow contrib recipes before
 installing our packages:

--- a/documentation/components/OpenAPI.rst
+++ b/documentation/components/OpenAPI.rst
@@ -19,12 +19,12 @@ Choose your library depending on OpenAPI version you need (you can even install 
 .. code-block:: bash
 
     # OpenAPI 2
-    composer require --dev jane-php/open-api-2 "~6.3.0"
-    composer require jane-php/open-api-runtime "~6.3.0"
+    composer require --dev jane-php/open-api-2
+    composer require jane-php/open-api-runtime
 
     # OpenAPI 3
-    composer require --dev jane-php/open-api-3 "~6.3.0"
-    composer require jane-php/open-api-runtime "~6.3.0"
+    composer require --dev jane-php/open-api-3
+    composer require jane-php/open-api-runtime
 
 With Symfony ecosystem, we created a recipe to make it easier to use Jane. You just have to allow contrib recipes before
 installing our packages:

--- a/documentation/documentation/JsonSchema.rst
+++ b/documentation/documentation/JsonSchema.rst
@@ -10,7 +10,7 @@ Add this library with composer as a ``dev`` dependency:
 
 .. code-block:: bash
 
-    composer require --dev jane-php/json-schema "~6.3.0"
+    composer require --dev jane-php/json-schema
 
 This library contains a lot of dependencies to be able to generate code which are not needed on runtime. However, the
 generated code depends on other libraries and a few classes that are available through the runtime package. It is highly
@@ -18,7 +18,7 @@ recommended to add the runtime dependency as a requirement through composer:
 
 .. code-block:: bash
 
-    composer require jane-php/json-schema-runtime "~6.3.0"
+    composer require jane-php/json-schema-runtime
 
 With Symfony ecosystem, we created a recipe to make it easier to use Jane. You just have to allow contrib recipes before
 installing our packages:

--- a/documentation/documentation/OpenAPI.rst
+++ b/documentation/documentation/OpenAPI.rst
@@ -31,12 +31,12 @@ requirement. Choose your library depending on OpenAPI version you need (you can 
 .. code-block:: bash
 
     # OpenAPI 2
-    composer require --dev jane-php/open-api-2 "~6.3.0"
-    composer require jane-php/open-api-runtime "~6.3.0"
+    composer require --dev jane-php/open-api-2
+    composer require jane-php/open-api-runtime
 
     # OpenAPI 3
-    composer require --dev jane-php/open-api-3 "~6.3.0"
-    composer require jane-php/open-api-runtime "~6.3.0"
+    composer require --dev jane-php/open-api-3"
+    composer require jane-php/open-api-runtime
 
 With Symfony ecosystem, we created a recipe to make it easier to use Jane. You just have to allow contrib recipes before
 installing our packages:

--- a/src/Bundle/JsonSchemaBundle/composer.json
+++ b/src/Bundle/JsonSchemaBundle/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "jane-php/json-schema": "~7.0"
+        "jane-php/json-schema": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",

--- a/src/Bundle/OpenApiBundle/composer.json
+++ b/src/Bundle/OpenApiBundle/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "jane-php/open-api-common": "~7.0"
+        "jane-php/open-api-common": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",

--- a/src/Component/JsonSchema/composer.json
+++ b/src/Component/JsonSchema/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "doctrine/inflector": "^1.4 || ^2.0",
-        "jane-php/json-schema-runtime": "~7.0.0",
+        "jane-php/json-schema-runtime": "^7.0",
         "nikic/php-parser": "^4.0",
         "symfony/console": "^4.4 || ^5.0",
         "symfony/filesystem": "^4.4 || ^5.0",

--- a/src/Component/OpenApi2/composer.json
+++ b/src/Component/OpenApi2/composer.json
@@ -34,8 +34,8 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
-        "jane-php/json-schema": "~7.0.0",
-        "jane-php/open-api-common": "~7.0.0",
+        "jane-php/json-schema": "^7.0",
+        "jane-php/open-api-common": "^7.0",
         "nikic/php-parser": "^4.0",
         "symfony/serializer": "^4.4 || ^5.0",
         "symfony/yaml": "~4.4.9 || ^5.0"

--- a/src/Component/OpenApi3/composer.json
+++ b/src/Component/OpenApi3/composer.json
@@ -34,8 +34,8 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
-        "jane-php/json-schema": "~7.0.0",
-        "jane-php/open-api-common": "~7.0.0",
+        "jane-php/json-schema": "^7.0",
+        "jane-php/open-api-common": "^7.0",
         "nikic/php-parser": "^4.0",
         "symfony/serializer": "^4.4 || ^5.0",
         "symfony/yaml": "~4.4.9 || ^5.0"

--- a/src/Component/OpenApiCommon/composer.json
+++ b/src/Component/OpenApiCommon/composer.json
@@ -27,8 +27,8 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
-        "jane-php/json-schema": "~7.0.0",
-        "jane-php/open-api-runtime": "~7.0.0",
+        "jane-php/json-schema": "^7.0",
+        "jane-php/open-api-runtime": "^7.0",
         "symfony/console": "^4.4 || ^5.0",
         "symfony/filesystem": "^4.4 || ^5.0",
         "symfony/string": "^5.0",

--- a/src/Component/OpenApiRuntime/composer.json
+++ b/src/Component/OpenApiRuntime/composer.json
@@ -30,7 +30,7 @@
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "symfony/options-resolver": "^4.4 || ^5.0",
-        "jane-php/json-schema-runtime": "~7.0.0"
+        "jane-php/json-schema-runtime": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
Hi, thanks a lot for your work here!

I had some trouble upgrading `jane-php/open-api-runtime` from `7.0` to `7.1`

`composer.json` requirements: 

```json
        [...]
        "jane-php/automapper-bundle": "^7.1",
        "jane-php/open-api-runtime": "^7.1"
        [...]
```


`composer update "jane-php/*" -W` output

> Problem 1
    - jane-php/open-api-3 7.x-dev is an alias of jane-php/open-api-3 dev-next and thus requires it to be installed too.
    - jane-php/open-api-3[dev-next, v7.1.0] require jane-php/open-api-common ~7.0.0 -> satisfiable by jane-php/open-api-common[v7.0.0].
    - jane-php/open-api-common v7.0.0 requires jane-php/open-api-runtime ~7.0.0 -> found jane-php/open-api-runtime[v7.0.0] but it conflicts with your root composer.json require (^7.1).
    - Root composer.json requires jane-php/open-api-3 ^7.1 -> satisfiable by jane-php/open-api-3[v7.1.0, 7.x-dev (alias of dev-next)].

This issue has been described here: https://github.com/janephp/janephp/issues/550

What do you think of relaxing version constraints, using semver `^7.0` instead of the more restrictive `~7.0.0`?