### PR TITLE
[JsonSchema] Handle $defs field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [JsonSchema] [GH#556](https://github.com/janephp/janephp/pull/556) Support for $defs field
 
 ## [6.3.8] - 2021-05-10
 ### Changed

--- a/src/JsonSchema/Guesser/JsonSchema/DefinitionGuesser.php
+++ b/src/JsonSchema/Guesser/JsonSchema/DefinitionGuesser.php
@@ -15,6 +15,8 @@ class DefinitionGuesser implements ChainGuesserAwareInterface, GuesserInterface,
 
     /**
      * {@inheritdoc}
+     *
+     * @param JsonSchema $object
      */
     public function guessClass($object, string $name, string $reference, Registry $registry): void
     {
@@ -22,7 +24,14 @@ class DefinitionGuesser implements ChainGuesserAwareInterface, GuesserInterface,
          * @var string
          * @var JsonSchema $definition
          */
-        foreach ($object->getDefinitions() as $key => $definition) {
+        foreach ($object->getDefinitions() ?? [] as $key => $definition) {
+            $this->chainGuesser->guessClass($definition, $key, $reference . '/definitions/' . $key, $registry);
+        }
+        /**
+         * @var string
+         * @var JsonSchema $definition
+         */
+        foreach ($object->getDollarDefs() ?? [] as $key => $definition) {
             $this->chainGuesser->guessClass($definition, $key, $reference . '/definitions/' . $key, $registry);
         }
     }
@@ -32,7 +41,11 @@ class DefinitionGuesser implements ChainGuesserAwareInterface, GuesserInterface,
      */
     public function supportObject($object): bool
     {
-        return ($object instanceof JsonSchema) && null !== $object->getDefinitions() && \count($object->getDefinitions()) > 0;
+        return ($object instanceof JsonSchema) &&
+            (
+                (null !== $object->getDefinitions() && \count($object->getDefinitions()) > 0) ||
+                (null !== $object->getDollarDefs() && \count($object->getDollarDefs()) > 0)
+            );
     }
 
     protected function getSchemaClass(): string

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/.jane
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/.jane
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'json-schema-file' => __DIR__ . '/schema.json',
+    'root-class' => 'Test',
+    'namespace' => 'Jane\JsonSchema\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Model/BarItem.php
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Model/BarItem.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Model;
+
+class BarItem
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $bar;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getBar() : string
+    {
+        return $this->bar;
+    }
+    /**
+     * 
+     *
+     * @param string $bar
+     *
+     * @return self
+     */
+    public function setBar(string $bar) : self
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Model/Foo.php
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Model/Foo.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Model;
+
+class Foo
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $foo;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+    /**
+     * 
+     *
+     * @param string $foo
+     *
+     * @return self
+     */
+    public function setFoo(string $foo) : self
+    {
+        $this->foo = $foo;
+        return $this;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Model/HelloWorld.php
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Model/HelloWorld.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Model;
+
+class HelloWorld
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $foo;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getFoo() : string
+    {
+        return $this->foo;
+    }
+    /**
+     * 
+     *
+     * @param string $foo
+     *
+     * @return self
+     */
+    public function setFoo(string $foo) : self
+    {
+        $this->foo = $foo;
+        return $this;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Normalizer/BarItemNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Normalizer/BarItemNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class BarItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\JsonSchema\\Tests\\Expected\\Model\\BarItem';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\JsonSchema\Tests\Expected\Model\BarItem;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\JsonSchema\Tests\Expected\Model\BarItem();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('bar', $data)) {
+            $object->setBar($data['bar']);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getBar()) {
+            $data['bar'] = $object->getBar();
+        }
+        return $data;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Normalizer/FooNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Normalizer/FooNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FooNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\JsonSchema\\Tests\\Expected\\Model\\Foo';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\JsonSchema\Tests\Expected\Model\Foo;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\JsonSchema\Tests\Expected\Model\Foo();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('foo', $data)) {
+            $object->setFoo($data['foo']);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getFoo()) {
+            $data['foo'] = $object->getFoo();
+        }
+        return $data;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Normalizer/HelloWorldNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Normalizer/HelloWorldNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class HelloWorldNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\JsonSchema\\Tests\\Expected\\Model\\HelloWorld';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof \Jane\JsonSchema\Tests\Expected\Model\HelloWorld;
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\JsonSchema\Tests\Expected\Model\HelloWorld();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('foo', $data)) {
+            $object->setFoo($data['foo']);
+        }
+        return $object;
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getFoo()) {
+            $data['foo'] = $object->getFoo();
+        }
+        return $data;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('Jane\\JsonSchema\\Tests\\Expected\\Model\\Foo' => 'Jane\\JsonSchema\\Tests\\Expected\\Normalizer\\FooNormalizer', 'Jane\\JsonSchema\\Tests\\Expected\\Model\\BarItem' => 'Jane\\JsonSchema\\Tests\\Expected\\Normalizer\\BarItemNormalizer', 'Jane\\JsonSchema\\Tests\\Expected\\Model\\HelloWorld' => 'Jane\\JsonSchema\\Tests\\Expected\\Normalizer\\HelloWorldNormalizer', '\\Jane\\JsonSchemaRuntime\\Reference' => '\\Jane\\JsonSchema\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array) : bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Runtime\Normalizer;
+
+use Jane\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $object->getReferenceUri();
+        return $ref;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof Reference;
+    }
+}

--- a/src/JsonSchema/Tests/fixtures/dollarDefs/schema.json
+++ b/src/JsonSchema/Tests/fixtures/dollarDefs/schema.json
@@ -1,0 +1,34 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Schema with definitions",
+    "$defs": {
+        "Foo": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "string"
+                }
+            }
+        },
+        "Bar": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "bar": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "hello.world": {
+            "type": "object",
+            "properties": {
+                "foo": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #524 

We now support both `definitions` and `$defs` fields for JSON Schema definitions 