### PR TITLE
Fix fail on generic object without explicit classname

### DIFF
--- a/src/Component/AutoMapper/Tests/Transformer/SymfonyUidTransformerFactoryTest.php
+++ b/src/Component/AutoMapper/Tests/Transformer/SymfonyUidTransformerFactoryTest.php
@@ -3,11 +3,10 @@
 namespace Jane\Component\AutoMapper\Tests\Transformer;
 
 use Jane\Component\AutoMapper\MapperMetadata;
-use Jane\Component\AutoMapper\Transformer\SymfonyUidTransformerFactory;
 use Jane\Component\AutoMapper\Transformer\SymfonyUidCopyTransformer;
+use Jane\Component\AutoMapper\Transformer\SymfonyUidTransformerFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Type;
-use Symfony\Component\Uid\AbstractUid;
 use Symfony\Component\Uid\Ulid;
 
 class SymfonyUidTransformerFactoryTest extends TestCase
@@ -28,8 +27,8 @@ class SymfonyUidTransformerFactoryTest extends TestCase
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
 
         $transformer = $factory->getTransformer(
-            [new Type('object', false, Ulid::class)], 
-            [new Type('object', false, Ulid::class)], 
+            [new Type('object', false, Ulid::class)],
+            [new Type('object', false, Ulid::class)],
             $mapperMetadata
         );
 

--- a/src/Component/AutoMapper/Tests/Transformer/SymfonyUidTransformerTest.php
+++ b/src/Component/AutoMapper/Tests/Transformer/SymfonyUidTransformerTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\Uid\Ulid;
 
 class SymfonyUidTransformerFactoryTest extends TestCase
 {
-    public function testNoTransformer()
+    public function testNoTransformer(): void
     {
         $factory = new SymfonyUidTransformerFactory();
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
@@ -22,7 +22,7 @@ class SymfonyUidTransformerFactoryTest extends TestCase
         self::assertNull($transformer);
     }
 
-    public function testGetUlidCopyTransformer()
+    public function testGetUlidCopyTransformer(): void
     {
         $factory = new SymfonyUidTransformerFactory();
         $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();

--- a/src/Component/AutoMapper/Tests/Transformer/SymfonyUidTransformerTest.php
+++ b/src/Component/AutoMapper/Tests/Transformer/SymfonyUidTransformerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Tests\Transformer;
+
+use Jane\Component\AutoMapper\MapperMetadata;
+use Jane\Component\AutoMapper\Transformer\SymfonyUidTransformerFactory;
+use Jane\Component\AutoMapper\Transformer\SymfonyUidCopyTransformer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
+
+class SymfonyUidTransformerFactoryTest extends TestCase
+{
+    public function testNoTransformer()
+    {
+        $factory = new SymfonyUidTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer([new Type('object', false, null)], [new Type('object', false, null)], $mapperMetadata);
+
+        self::assertNull($transformer);
+    }
+
+    public function testGetUlidCopyTransformer()
+    {
+        $factory = new SymfonyUidTransformerFactory();
+        $mapperMetadata = $this->getMockBuilder(MapperMetadata::class)->disableOriginalConstructor()->getMock();
+
+        $transformer = $factory->getTransformer(
+            [new Type('object', false, Ulid::class)], 
+            [new Type('object', false, Ulid::class)], 
+            $mapperMetadata
+        );
+
+        self::assertNotNull($transformer);
+        self::assertInstanceOf(SymfonyUidCopyTransformer::class, $transformer);
+    }
+}

--- a/src/Component/AutoMapper/Transformer/SymfonyUidTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/SymfonyUidTransformerFactory.php
@@ -46,6 +46,10 @@ final class SymfonyUidTransformerFactory extends AbstractUniqueTypeTransformerFa
             return false;
         }
 
+        if (null === $type->getClassName()) {
+            return false;
+        }
+
         if (!\array_key_exists($type->getClassName(), $this->reflectionCache)) {
             $reflClass = new \ReflectionClass($type->getClassName());
             $this->reflectionCache[$type->getClassName()] = [$reflClass->isSubclassOf(AbstractUid::class), $type->getClassName() === Ulid::class];


### PR DESCRIPTION
Class with comments like this below, that may be generated by Jane
* @var object|null
are causing errors on this uid transformer.