### PR TITLE
Fixed MapperContext::withNewContext `target_to_populate` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [AutoMapper] [GH#564](https://github.com/janephp/janephp/pull/564) Remove deprecations
 
+### Fixed
+- [AutoMapper] [GH#567](https://github.com/janephp/janephp/pull/567) Fix the value of `target_to_populate` on `MapperContext::withNewContext` call
+
 ## [7.1.2] - 2021-10-18
 ### Fixed
 - [AutoMapper] [GH#560](https://github.com/janephp/janephp/pull/560) Fix fail on generic object without explicit classname

--- a/src/Component/AutoMapper/MapperContext.php
+++ b/src/Component/AutoMapper/MapperContext.php
@@ -206,6 +206,8 @@ class MapperContext
      */
     public static function withNewContext(array $context, string $attribute): array
     {
+        $context[self::TARGET_TO_POPULATE] = null;
+
         if (!($context[self::ALLOWED_ATTRIBUTES] ?? false) && !($context[self::IGNORED_ATTRIBUTES] ?? false)) {
             return $context;
         }

--- a/src/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -6,6 +6,7 @@ use Jane\Component\AutoMapper\AutoMapper;
 use Jane\Component\AutoMapper\Exception\CircularReferenceException;
 use Jane\Component\AutoMapper\Exception\NoMappingFoundException;
 use Jane\Component\AutoMapper\MapperContext;
+use Jane\Component\AutoMapper\Tests\Fixtures\Fish;
 use Jane\Component\AutoMapper\Tests\Fixtures\Order;
 use Jane\Component\AutoMapper\Tests\Fixtures\PetOwner;
 use Jane\Component\AutoMapper\Tests\Fixtures\Transformer\MoneyTransformerFactory;
@@ -878,7 +879,7 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertEquals('foobar', $entity->getName());
     }
 
-    public function testAdderAndRemover()
+    public function testAdderAndRemoverWithClass()
     {
         $petOwner = [
             'pets' => [
@@ -895,6 +896,34 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertSame('cat', $petOwnerData->getPets()[0]->type);
         self::assertSame('Coco', $petOwnerData->getPets()[1]->name);
         self::assertSame('dog', $petOwnerData->getPets()[1]->type);
+    }
+
+    public function testAdderAndRemoverWithInstance()
+    {
+        $fish = new Fish();
+        $fish->name = 'Nemo';
+        $fish->type = 'fish';
+
+        $petOwner = new PetOwner();
+        $petOwner->addPet($fish);
+
+        $petOwnerAsArray = [
+            'pets' => [
+                ['type' => 'cat', 'name' => 'Félix'],
+                ['type' => 'dog', 'name' => 'Coco'],
+            ],
+        ];
+
+        $this->autoMapper->map($petOwnerAsArray, $petOwner);
+
+        self::assertIsArray($petOwner->getPets());
+        self::assertCount(3, $petOwner->getPets());
+        self::assertSame('Nemo', $petOwner->getPets()[0]->name);
+        self::assertSame('fish', $petOwner->getPets()[0]->type);
+        self::assertSame('Félix', $petOwner->getPets()[1]->name);
+        self::assertSame('cat', $petOwner->getPets()[1]->type);
+        self::assertSame('Coco', $petOwner->getPets()[2]->name);
+        self::assertSame('dog', $petOwner->getPets()[2]->type);
     }
 
     public function testAdderAndRemoverWithNull()

--- a/src/Component/AutoMapper/Tests/Fixtures/Fish.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/Fish.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Tests\Fixtures;
+
+class Fish extends Pet
+{
+}

--- a/src/Component/AutoMapper/Tests/Fixtures/Pet.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/Pet.php
@@ -7,10 +7,11 @@ use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
 /**
  * @DiscriminatorMap(typeProperty="type", mapping={
  *    "cat"="Jane\Component\AutoMapper\Tests\Fixtures\Cat",
- *    "dog"="Jane\Component\AutoMapper\Tests\Fixtures\Dog"
+ *    "dog"="Jane\Component\AutoMapper\Tests\Fixtures\Dog",
+ *    "fish"="Jane\Component\AutoMapper\Tests\Fixtures\Fish"
  * })
  */
-class Pet
+abstract class Pet
 {
     /** @var string */
     public $type;

--- a/src/Component/AutoMapper/Transformer/AbstractArrayTransformer.php
+++ b/src/Component/AutoMapper/Transformer/AbstractArrayTransformer.php
@@ -36,7 +36,7 @@ abstract class AbstractArrayTransformer implements TransformerInterface, Depende
         $loopValueVar = new Expr\Variable($uniqueVariableScope->getUniqueName('value'));
         $loopKeyVar = new Expr\Variable($uniqueVariableScope->getUniqueName('key'));
 
-        $assignByRef = $this->itemTransformer instanceof AssignedByReferenceTransformerInterface ? $this->itemTransformer->assignByRef() : false;
+        $assignByRef = $this->itemTransformer instanceof AssignedByReferenceTransformerInterface && $this->itemTransformer->assignByRef();
 
         [$output, $itemStatements] = $this->itemTransformer->transform($loopValueVar, $target, $propertyMapping, $uniqueVariableScope);
 


### PR DESCRIPTION
Resetting `target_to_populate` value when calling `MapperContext::withNewContext` to avoid try to map into the parent target, especially if it is a existing instance of the root target class.

Test case has been added to cover this case.