### PR TITLE
Fix link in external_client.rst documentation file

### DIFF
--- a/documentation/guides/external_client.rst
+++ b/documentation/guides/external_client.rst
@@ -4,7 +4,9 @@ External API Client
 Here is a demo Symfony application of Jane with an external API integration.
 We will see a working example of OpenApi v3 client onto a simple API that gives facts about cats and
 comment it. You can find this API documentation on following url:
-[https://alexwohlbruck.github.io/cat-facts/](https://alexwohlbruck.github.io/cat-facts/).
+`https://alexwohlbruck.github.io/cat-facts/`_.
+
+.. _`https://alexwohlbruck.github.io/cat-facts/`: https://alexwohlbruck.github.io/cat-facts/
 
 You can find the fully working example on this repository: `janephp/demo-external-api`_.
 


### PR DESCRIPTION
Link wasn't clickable.

Before
![image](https://user-images.githubusercontent.com/9253091/147559583-5188ccb1-0766-40db-850c-f812e9403a81.png)

After 
![image](https://user-images.githubusercontent.com/9253091/147559624-e5cc5e92-99a0-457e-8acc-1ba7bf921990.png)
