### PR TITLE
Reproduce and fix an issue with referenced response when whitelist is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [JsonSchema] [OpenApi] [GH#587](https://github.com/janephp/janephp/pull/587) Prefix property starting with number with 'n'
 - [OpenApi] [GH#593](https://github.com/janephp/janephp/pull/593) Add type hints to exceptions, cleanup parent constructor call
+- [OpenApi3] [GH#592](https://github.com/janephp/janephp/pull/592) Fix issue in whitelisting when having referenced schema in referenced responses
 
 ## [7.1.6] - 2022-01-27
 - [AutoMapper] [GH#589](https://github.com/janephp/janephp/pull/589) Fix setting properties when using target to populate object

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/.jane-openapi
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ .  '/swagger.json',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'whitelisted-paths' => [
+        '^/test-exception$'
+    ]
+];

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Client.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\TestBadRequestException
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function test(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\Test(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $serializer = new \Symfony\Component\Serializer\Serializer(array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()), array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Endpoint/Test.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Endpoint/Test.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class Test extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/test-exception';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\TestBadRequestException
+     *
+     * @return null
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (is_null($contentType) === false && (400 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\TestBadRequestException($serializer->deserialize($body, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Failure', 'json'));
+        }
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/ApiException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/BadRequestException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class BadRequestException extends \RuntimeException implements ClientException
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 400);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/ClientException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/ServerException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/TestBadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/TestBadRequestException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class TestBadRequestException extends BadRequestException
+{
+    /**
+     * @var \Jane\Component\OpenApi3\Tests\Expected\Model\Failure
+     */
+    private $failure;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Expected\Model\Failure $failure)
+    {
+        parent::__construct('Bad Request');
+        $this->failure = $failure;
+    }
+    public function getFailure() : \Jane\Component\OpenApi3\Tests\Expected\Model\Failure
+    {
+        return $this->failure;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Model/Error.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Model/Error.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class Error
+{
+    /**
+     * An application-specific error code, expressed as a string value.
+     *
+     * @var string
+     */
+    protected $code;
+    /**
+     * A short, human-readable summary of the problem.
+     *
+     * @var string
+     */
+    protected $title;
+    /**
+     * An application-specific error code, expressed as a string value.
+     *
+     * @return string
+     */
+    public function getCode() : string
+    {
+        return $this->code;
+    }
+    /**
+     * An application-specific error code, expressed as a string value.
+     *
+     * @param string $code
+     *
+     * @return self
+     */
+    public function setCode(string $code) : self
+    {
+        $this->code = $code;
+        return $this;
+    }
+    /**
+     * A short, human-readable summary of the problem.
+     *
+     * @return string
+     */
+    public function getTitle() : string
+    {
+        return $this->title;
+    }
+    /**
+     * A short, human-readable summary of the problem.
+     *
+     * @param string $title
+     *
+     * @return self
+     */
+    public function setTitle(string $title) : self
+    {
+        $this->title = $title;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Model/Failure.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Model/Failure.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class Failure
+{
+    /**
+     * 
+     *
+     * @var Error[]
+     */
+    protected $errors;
+    /**
+     * 
+     *
+     * @return Error[]
+     */
+    public function getErrors() : array
+    {
+        return $this->errors;
+    }
+    /**
+     * 
+     *
+     * @param Error[] $errors
+     *
+     * @return self
+     */
+    public function setErrors(array $errors) : self
+    {
+        $this->errors = $errors;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Normalizer/ErrorNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Normalizer/ErrorNormalizer.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    /**
+     * @return bool
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Error';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Error';
+    }
+    /**
+     * @return mixed
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Error();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('code', $data)) {
+            $object->setCode($data['code']);
+        }
+        if (\array_key_exists('title', $data)) {
+            $object->setTitle($data['title']);
+        }
+        return $object;
+    }
+    /**
+     * @return array|string|int|float|bool|\ArrayObject|null
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getCode()) {
+            $data['code'] = $object->getCode();
+        }
+        if (null !== $object->getTitle()) {
+            $data['title'] = $object->getTitle();
+        }
+        return $data;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Normalizer/FailureNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Normalizer/FailureNormalizer.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FailureNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    /**
+     * @return bool
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Failure';
+    }
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Failure';
+    }
+    /**
+     * @return mixed
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Failure();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('errors', $data)) {
+            $values = array();
+            foreach ($data['errors'] as $value) {
+                $values[] = $this->denormalizer->denormalize($value, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Error', 'json', $context);
+            }
+            $object->setErrors($values);
+        }
+        return $object;
+    }
+    /**
+     * @return array|string|int|float|bool|\ArrayObject|null
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        $values = array();
+        foreach ($object->getErrors() as $value) {
+            $values[] = $this->normalizer->normalize($value, 'json', $context);
+        }
+        $data['errors'] = $values;
+        return $data;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    protected $normalizers = array('Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Error' => 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Normalizer\\ErrorNormalizer', 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Failure' => 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Normalizer\\FailureNormalizer', '\\Jane\\Component\\JsonSchemaRuntime\\Reference' => '\\Jane\\Component\\OpenApi3\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    /**
+     * @return bool
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    /**
+     * @return bool
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    /**
+     * @return array|string|int|float|bool|\ArrayObject|null
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    /**
+     * @return mixed
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected $queryParameters = [];
+    protected $headerParameters = [];
+    protected $body;
+    public abstract function getMethod() : string;
+    public abstract function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    public abstract function getUri() : string;
+    public abstract function getAuthenticationScopes() : array;
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders() : array
+    {
+        return [];
+    }
+    public function getQueryString() : string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(function ($value) {
+            return null !== $value ? $value : '';
+        }, $optionsResolved);
+        return http_build_query($optionsResolved, '', '&', PHP_QUERY_RFC3986);
+    }
+    public function getHeaders(array $baseHeaders = []) : array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getHeadersOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody() : array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null) : array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer) : array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    /**
+     * @var ClientInterface
+     */
+    protected $httpClient;
+    /**
+     * @var RequestFactoryInterface
+     */
+    protected $requestFactory;
+    /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+    /**
+     * @var StreamFactoryInterface
+     */
+    protected $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString() : string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri() : string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod() : string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []) : array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes() : array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        if ($fetchMode === Client::FETCH_OBJECT) {
+            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
+        }
+        if ($fetchMode === Client::FETCH_RESPONSE) {
+            return $response;
+        }
+        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array) : bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $object->getReferenceUri();
+        return $ref;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof Reference;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/swagger.json
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/swagger.json
@@ -1,0 +1,79 @@
+{
+    "openapi": "3.0.0",
+    "paths": {
+        "/test-exception": {
+            "get": {
+                "operationId": "Test",
+                "responses": {
+                    "400": {
+                        "$ref": "#/components/responses/400"
+                    }
+                }
+            }
+        }
+    },
+    "servers": [
+        {
+            "url": "/"
+        }
+    ],
+    "info": {
+        "version": "",
+        "title": ""
+    },
+    "components": {
+        "schemas": {
+            "error": {
+                "additionalProperties": false,
+                "properties": {
+                    "code": {
+                        "description": "An application-specific error code, expressed as a string value.",
+                        "type": "string"
+                    },
+                    "title": {
+                        "description": "A short, human-readable summary of the problem.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "failure": {
+                "additionalProperties": false,
+                "properties": {
+                    "errors": {
+                        "items": {
+                            "$ref": "#/components/schemas/error"
+                        },
+                        "type": "array",
+                        "uniqueItems": true
+                    }
+                },
+                "required": [
+                    "errors"
+                ],
+                "type": "object"
+            }
+        },
+        "responses": {
+            "400": {
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "errors": [
+                                {
+                                    "status": "400",
+                                    "title": "Bad Request",
+                                    "description": "Bad parameters for this endpoint."
+                                }
+                            ]
+                        },
+                        "schema": {
+                            "$ref": "#/components/schemas/failure"
+                        }
+                    }
+                },
+                "description": "Bad Request"
+            }
+        }
+    }
+}

--- a/src/Component/OpenApi3/WhitelistedSchema.php
+++ b/src/Component/OpenApi3/WhitelistedSchema.php
@@ -2,6 +2,7 @@
 
 namespace Jane\Component\OpenApi3;
 
+use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi3\JsonSchema\Model\MediaType;
 use Jane\Component\OpenApi3\JsonSchema\Model\Parameter;
 use Jane\Component\OpenApi3\JsonSchema\Model\RequestBody;
@@ -62,6 +63,9 @@ class WhitelistedSchema implements WhitelistFetchInterface
         $responses = $operationGuess->getOperation()->getResponses();
         if (null !== $responses && \count($responses) > 0) {
             foreach ($responses as $response) {
+                if ($response instanceof Reference) {
+                    [$_, $response] = $this->guessClass->resolve($response, Response::class);
+                }
                 if (!($response instanceof Response)) {
                     continue;
                 }


### PR DESCRIPTION
`\Jane\Component\OpenApi3\WhitelistedSchema` fails to correctly resolve the response when we have it referenced from `components/responses`.

In this test, the model for `failure` is not marked as used, because the response is not resolved and therefore not added.

The issue can only be reproduced when having:
1. `whitelisted-paths` active (without it works as expected).
2. We have a `$ref` response (not just a schema ref but the whole response referenced from `#/components/responses/`).
2. The response itself has a `$ref` to a model in the schema (`#/components/schemas/`).

I tried to come up with a fix for this but am unsure if it is the correct way.
