### PR TITLE
Ensure nullable properties are handled

### DIFF
--- a/src/Component/OpenApi2/Guesser/OpenApiSchema/SchemaGuesser.php
+++ b/src/Component/OpenApi2/Guesser/OpenApiSchema/SchemaGuesser.php
@@ -23,7 +23,19 @@ class SchemaGuesser extends ObjectGuesser
      */
     protected function isPropertyNullable($property): bool
     {
-        return $property->offsetExists('x-nullable') && \is_bool($property->offsetGet('x-nullable')) && $property->offsetGet('x-nullable');
+        return
+            (
+                $property->offsetExists('x-nullable') &&
+                \is_bool($property->offsetGet('x-nullable')) &&
+                $property->offsetGet('x-nullable')
+            ) || (
+                null !== $property->getAdditionalProperties() &&
+                Schema::class === \get_class($property->getAdditionalProperties()) &&
+                $property->getAdditionalProperties()->offsetExists('x-nullable') &&
+                \is_bool($property->getAdditionalProperties()->offsetGet('x-nullable')) &&
+                $property->getAdditionalProperties()->offsetGet('x-nullable')
+            )
+        ;
     }
 
     /**


### PR DESCRIPTION
This is a first try at fixing #559. It may not even be the right fix, but I want to help fix it :)

I'm pretty sure that it's missing things like:
1. Instead of adding a pre-condition to *every* foreach, it should only be applied to props that are nullable;
2. Instead of having the pre-condition in `ArrayType`, it could be moved to `MapType`;

I need advice/guidance in how to properly approach this.

The effect this change does is, for example, from this:
```php
if (\array_key_exists('Ports', $data) && $data['Ports'] !== null) {
    $values = new \ArrayObject(array(), \ArrayObject::ARRAY_AS_PROPS);
    foreach ($data['Ports'] as $key => $value) {
        $values_1 = array();
        foreach ($value as $value_1) {
            $values_1[] = $this->denormalizer->denormalize($value_1, 'Docker\\API\\Model\\PortBinding', 'json', $context);
        }
        $values[$key] = $values_1;
    }
    $object->setPorts($values);
}
```

To this:
```php
if (\array_key_exists('Ports', $data) && $data['Ports'] !== null) {
    $values = new \ArrayObject(array(), \ArrayObject::ARRAY_AS_PROPS);
    foreach ($data['Ports'] as $key => $value) {
        if ($value === null) {
            $values[$key] = null;
            continue;
        }
        $values_1 = array();
        foreach ($value as $value_1) {
            $values_1[] = $this->denormalizer->denormalize($value_1, 'Docker\\API\\Model\\PortBinding', 'json', $context);
        }
        $values[$key] = $values_1;
    }
    $object->setPorts($values);
}
```