### PR TITLE
doc: Fix link to transformers examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Documentation
+- [AutoMapper] [GH#600](https://github.com/janephp/janephp/pull/600) Fixed link to transformer examples
 
 ## [7.2.0] - 2022-02-17
 ### Added

--- a/documentation/components/AutoMapper.rst
+++ b/documentation/components/AutoMapper.rst
@@ -143,7 +143,7 @@ To use a custom TransformerFactory class, you have to do as following::
 With the Symfony bundle, you have to tag your TransformerFactory class with a ``jane_auto_mapper.transformer_factory`` tag.
 This will use automatically the TransformerFactory.
 
-.. _`an example in the AutoMapper tests files`: https://github.com/janephp/janephp/tree/next/src/AutoMapper/Tests/Fixtures/Transformer
+.. _`an example in the AutoMapper tests files`: https://github.com/janephp/janephp/tree/next/src/Component/AutoMapper/Tests/Fixtures/Transformer
 
 Skip null values
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There is a broken link on https://jane.readthedocs.io/en/latest/components/AutoMapper.html