### PR TITLE
[OpenAPI] Make a new method to get an endpoint raw response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - [JsonSchema] [GH#632](https://github.com/janephp/janephp/pull/632) Validation - Check for nullable field values
+- [OpenApi] [GH#634](https://github.com/janephp/janephp/pull/634) Make a new method to get an endpoint raw response
+
+### Deprecated
+- [OpenApi] [GH#634](https://github.com/janephp/janephp/pull/634) Using Client::executeEndpoint method with $fetch parameter equals to response is deprecated, use Client::executeRawEndpoint instead.
 
 ### Removed
 - [OpenApi] [GH#635](https://github.com/janephp/janephp/pull/635) Remove symfony/translation-contracts dependency
 
 ### Fixed
 - [JsonSchema] [GH#629](https://github.com/janephp/janephp/pull/629) Handle validation when fields has no validation guess
-- [OpenApi2] [OpenApi3] [GH#633](https://github.com/janephp/janephp/pull/633) Remove `null` from endpoint `@return` statement if unexpected status code is to be thrown.
+- [OpenApi] [GH#633](https://github.com/janephp/janephp/pull/633) Remove `null` from endpoint `@return` statement if unexpected status code is to be thrown.
 
 ## [7.2.5] - 2022-07-01
 ### Added
@@ -77,7 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.1.3] - 2021-11-12
 ### Added
- - Run test suite with PHP 8.1
+- Run test suite with PHP 8.1
 
 ### Changed
 - [AutoMapper] [GH#564](https://github.com/janephp/janephp/pull/564) Remove deprecations
@@ -516,100 +520,100 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
- * [JsonSchema] [GH#109](https://github.com/janephp/janephp/pull/109) Support for default value for array type
- * [OpenAPI] [GH#115](https://github.com/janephp/janephp/pull/115) Fix Content-Type comparison in generated endpoints
+* [JsonSchema] [GH#109](https://github.com/janephp/janephp/pull/109) Support for default value for array type
+* [OpenAPI] [GH#115](https://github.com/janephp/janephp/pull/115) Fix Content-Type comparison in generated endpoints
 
 ## [5.0.0] - 2019-09-11
 
 ### Added
 
- * **BC-BREAK** All libraries now use php-parser v4
- * [OpenAPI] **BC-BREAK** Use the openapi v3 specification (v2 is no longer supported)
- * [OpenAPI] **BC-BREAK** No more asynchronous code generation (sync and async api can be the same on php 7.3 by using ext-async)
- * Composer upgrade  (PHP version to 7.2 and dependencies)
+* **BC-BREAK** All libraries now use php-parser v4
+* [OpenAPI] **BC-BREAK** Use the openapi v3 specification (v2 is no longer supported)
+* [OpenAPI] **BC-BREAK** No more asynchronous code generation (sync and async api can be the same on php 7.3 by using ext-async)
+* Composer upgrade  (PHP version to 7.2 and dependencies)
 
 ### Fixed
 
- * [OpenAPI] GH#101 Remove warning when using Generate command
+* [OpenAPI] GH#101 Remove warning when using Generate command
 
 ## [4.4.0] - 2019-06-17
 
 ### Added
 
- * [Jane] nullable properties
- * [Jane] add null type to PHPDoc for getters/setters
- * [Jane] checking if helper function exists before creating it (php-parser 3.x / 4.x compatibility)
+* [Jane] nullable properties
+* [Jane] add null type to PHPDoc for getters/setters
+* [Jane] checking if helper function exists before creating it (php-parser 3.x / 4.x compatibility)
 
 ## [4.3.0] - 2019-05-31
 
- * [OpenAPI] Discriminator support
- * [Jane] php-parser 4.x compatibility
+* [OpenAPI] Discriminator support
+* [Jane] php-parser 4.x compatibility
 
 ## [4.2.0] - 2019-08-03
 
- * [Jane] Add support for default value in model (only scalar)
- * [OpenAPI] Add support for httplug 2.0
+* [Jane] Add support for default value in model (only scalar)
+* [OpenAPI] Add support for httplug 2.0
 
 ## [4.1.0] - 2019-01-24
 
- * [Jane] Added `use-cacheable-supports-method` option to add CacheableSupportsMethodInterface to your Normalizers.
+* [Jane] Added `use-cacheable-supports-method` option to add CacheableSupportsMethodInterface to your Normalizers.
 
 ## [4.0.4] - 2018-10-19
 
- * [OpenAPI] Fix items object generation for json schema and openapi #29
- * [OpenAPI] Fix bad parameter generation #41 #18
- * [Jane] Fix properties having the same name #25
- * [Jane] Fix bad normalizer on reserved keywords #16
+* [OpenAPI] Fix items object generation for json schema and openapi #29
+* [OpenAPI] Fix bad parameter generation #41 #18
+* [Jane] Fix properties having the same name #25
+* [Jane] Fix bad normalizer on reserved keywords #16
 
 ## [4.0.1] - 2018-02-22
 
 ### Fixed
 
- * [JsonSchema Runtime] Fix composer dependency to allow symfony 4
- * [OpenAPI] Be less restrictive to detect schema serializable
+* [JsonSchema Runtime] Fix composer dependency to allow symfony 4
+* [OpenAPI] Be less restrictive to detect schema serializable
 
 ## [4.0.0] - 2018-02-12
 
 ### Added
 
- * **BC-BREAK** New namespace and repository name due to using a new monolith repository
- * **BC-BREAK** JanePHP now require and generate code for PHP 7.1
- * **BC-BREAK** Config file is now mandatory, console client does not provide anymore options
- * **BC-BREAK** There is no more Resource file, all calls are now done in an unique Client class
- * [OpenAPI] **BC-BREAK** Arguments for each endpoint may be different, they are now split between query, form and headers.
- * [OpenAPI] **BC-BREAK** Response with 400 to 599 status code will know throw custom generated exception instead of
- returning an object
- * [OpenAPI] **BC-BREAK** Base path is no more present in the url as you can use a HTTPlug plugin for that
- * [OpenAPI] New documentation available at [https://jane.readthedocs.io/en/latest/](https://jane.readthedocs.io/en/latest/)
- * [OpenAPI] Add Optional Asynchronous Client Generation (through async option)
- * [OpenAPI] Add support for file in form parameters which will create a multipart stream
- * [OpenAPI] Better method naming when dealing with special characters thanks to @pyrech
- * [OpenAPI] New class `Client` generated which will contains all endpoints of the API
- * [OpenAPI] New factory method for the client which provide better DX to start using a Generated Client
- * [OpenAPI] Add support for global parameters
- * [OpenAPI] Support Symfony 4
- * [OpenAPI] Each endpoint have its own class, this helps extending a generated Client.
- * [OpenAPI] Add support for binary format
- * [Jane] Add a not strict mode, which generate more permissive normalizers (allowing null / not
- defined properties in several places)
- * [Jane] Add property description in doc block comment
- * [Jane] Add support for additionalProperties / patternProperties with existing properties
+* **BC-BREAK** New namespace and repository name due to using a new monolith repository
+* **BC-BREAK** JanePHP now require and generate code for PHP 7.1
+* **BC-BREAK** Config file is now mandatory, console client does not provide anymore options
+* **BC-BREAK** There is no more Resource file, all calls are now done in an unique Client class
+* [OpenAPI] **BC-BREAK** Arguments for each endpoint may be different, they are now split between query, form and headers.
+* [OpenAPI] **BC-BREAK** Response with 400 to 599 status code will know throw custom generated exception instead of
+  returning an object
+* [OpenAPI] **BC-BREAK** Base path is no more present in the url as you can use a HTTPlug plugin for that
+* [OpenAPI] New documentation available at [https://jane.readthedocs.io/en/latest/](https://jane.readthedocs.io/en/latest/)
+* [OpenAPI] Add Optional Asynchronous Client Generation (through async option)
+* [OpenAPI] Add support for file in form parameters which will create a multipart stream
+* [OpenAPI] Better method naming when dealing with special characters thanks to @pyrech
+* [OpenAPI] New class `Client` generated which will contains all endpoints of the API
+* [OpenAPI] New factory method for the client which provide better DX to start using a Generated Client
+* [OpenAPI] Add support for global parameters
+* [OpenAPI] Support Symfony 4
+* [OpenAPI] Each endpoint have its own class, this helps extending a generated Client.
+* [OpenAPI] Add support for binary format
+* [Jane] Add a not strict mode, which generate more permissive normalizers (allowing null / not
+  defined properties in several places)
+* [Jane] Add property description in doc block comment
+* [Jane] Add support for additionalProperties / patternProperties with existing properties
 
 ### Fixed
 
- * [OpenAPI] When a response does have a Schema which is not an object, it will not return the json_decoded value of the data
- instead of null
- * [OpenAPI] Remove base path from method name
- * [OpenAPI] Fix references having a space in the name
- * [OpenAPI] Fix `Content-Type` and `Accept` headers
- * [Jane] Fix all-of not merging properties with the same name
+* [OpenAPI] When a response does have a Schema which is not an object, it will not return the json_decoded value of the data
+  instead of null
+* [OpenAPI] Remove base path from method name
+* [OpenAPI] Fix references having a space in the name
+* [OpenAPI] Fix `Content-Type` and `Accept` headers
+* [Jane] Fix all-of not merging properties with the same name
 
 ## Older versions
 
 See :
 
- * https://github.com/janephp/jane/releases
- * https://github.com/janephp/openapi/releases
+* https://github.com/janephp/jane/releases
+* https://github.com/janephp/openapi/releases
 
 [Unreleased]: https://github.com/janephp/janephp/compare/v7.2.5...HEAD
 [7.2.5]: https://github.com/janephp/janephp/compare/v7.2.4...v7.2.5

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Docker\Api\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Docker\Api\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\One\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Two\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Api1\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Api2\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace ApiPlatform\Demo\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace ApiPlatform\Demo\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\One\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Two\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Github\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Github\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace CreditSafe\API\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace CreditSafe\API\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Gounlaf\JanephpBug\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Gounlaf\JanephpBug\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace PicturePark\API\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace PicturePark\API\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Api1\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Api2\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -64,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/EndpointTrait.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
@@ -10,13 +9,7 @@ trait EndpointTrait
     protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApiCommon/Generator/Runtime/data/Client/Client.php
+++ b/src/Component/OpenApiCommon/Generator/Runtime/data/Client/Client.php
@@ -3,6 +3,7 @@
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -42,6 +43,22 @@ abstract class Client
 
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+
+            return $this->executeRawEndpoint($endpoint);
+        }
+
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -72,6 +89,6 @@ abstract class Client
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
 
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApiCommon/Generator/Runtime/data/Client/EndpointTrait.php
+++ b/src/Component/OpenApiCommon/Generator/Runtime/data/Client/EndpointTrait.php
@@ -1,6 +1,5 @@
 <?php
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -10,16 +9,8 @@ trait EndpointTrait
 
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
 
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
     }
 }


### PR DESCRIPTION
Refers #620 

This will introduce `Client::executeRawEndpoint` to get the raw response from a given endpoint instead of an object.
It also introduces a deprecation on using `Client::executeEndpoint` with `$fetch` parameter equals to `response`, which should be done with the new method I talked about before.