### PR TITLE
[RFC] Fixing issue with http_query_build and QS array variables.

### DIFF
--- a/src/Component/OpenApi2/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi2/Generator/Parameter/NonBodyParameterGenerator.php
@@ -55,7 +55,7 @@ class NonBodyParameterGenerator extends ParameterGenerator
                 $parameterName = substr($parameterName, 0, -2);
             }
 
-            if (!array_key_exists($parameterName, $defined)) {
+            if (!\array_key_exists($parameterName, $defined)) {
                 $defined[$parameterName] = new Expr\ArrayItem(new Scalar\String_($parameterName));
             }
 

--- a/src/Component/OpenApi2/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi2/Generator/Parameter/NonBodyParameterGenerator.php
@@ -50,10 +50,17 @@ class NonBodyParameterGenerator extends ParameterGenerator
         $genericResolverKeys = array_keys($genericResolver);
 
         foreach ($parameters as $parameter) {
-            $defined[] = new Expr\ArrayItem(new Scalar\String_($parameter->getName()));
+            $parameterName = $parameter->getName();
+            if (str_contains($parameterName, '[]')) {
+                $parameterName = substr($parameterName, 0, -2);
+            }
+
+            if (!array_key_exists($parameterName, $defined)) {
+                $defined[$parameterName] = new Expr\ArrayItem(new Scalar\String_($parameterName));
+            }
 
             if ($parameter->getRequired() && null === $parameter->getDefault()) {
-                $required[] = new Expr\ArrayItem(new Scalar\String_($parameter->getName()));
+                $required[] = new Expr\ArrayItem(new Scalar\String_($parameterName));
             }
 
             $matchGenericResolver = null;
@@ -68,24 +75,24 @@ class NonBodyParameterGenerator extends ParameterGenerator
                     $types[] = new Expr\ArrayItem(new Scalar\String_($typeString));
                 }
 
-                $allowedTypes[] = new Node\Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'setAllowedTypes', [
-                    new Node\Arg(new Scalar\String_($parameter->getName())),
+                $allowedTypes[] = new Node\Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'addAllowedTypes', [
+                    new Node\Arg(new Scalar\String_($parameterName)),
                     new Node\Arg(new Expr\Array_($types)),
                 ]));
             }
 
             if (!$parameter->getRequired() && null !== $parameter->getDefault()) {
-                $defaults[] = new Expr\ArrayItem($this->getDefaultAsExpr($parameter), new Scalar\String_($parameter->getName()));
+                $defaults[] = new Expr\ArrayItem($this->getDefaultAsExpr($parameter), new Scalar\String_($parameterName));
             }
 
             if (null !== $matchGenericResolver) {
-                $allowedTypes[] = $this->generateOptionResolverNormalizationStatement($parameter->getName(), $genericResolver[$matchGenericResolver]);
+                $allowedTypes[] = $this->generateOptionResolverNormalizationStatement($parameterName, $genericResolver[$matchGenericResolver]);
             }
         }
 
         return array_merge([
             new Node\Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'setDefined', [
-                new Node\Arg(new Expr\Array_($defined)),
+                new Node\Arg(new Expr\Array_(array_values($defined))),
             ])),
             new Node\Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'setRequired', [
                 new Node\Arg(new Expr\Array_($required)),

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Endpoint/GetFoo.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Endpoint/GetFoo.php
@@ -34,7 +34,7 @@ class GetFoo extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Base
         $optionsResolver->setDefined(array('testBoolean'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testBoolean', array('bool'));
+        $optionsResolver->addAllowedTypes('testBoolean', array('bool'));
         $optionsResolver->setNormalizer('testBoolean', \Closure::fromCallable(array(new \Jane\Component\OpenApi2\Tests\Expected\AllBooleanQueryResolver\BooleanCustomQueryResolver(), '__invoke')));
         return $optionsResolver;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Endpoint/GetFoo.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Endpoint/GetFoo.php
@@ -34,7 +34,7 @@ class GetFoo extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Base
         $optionsResolver->setDefined(array('testBoolean'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testBoolean', array('bool'));
+        $optionsResolver->addAllowedTypes('testBoolean', array('bool'));
         $optionsResolver->setNormalizer('testBoolean', \Closure::fromCallable(array(new \Jane\Component\OpenApi2\Tests\Expected\BooleanQueryResolver\BooleanCustomQueryResolver(), '__invoke')));
         return $optionsResolver;
     }

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/BuildPrune.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/BuildPrune.php
@@ -53,9 +53,9 @@ class BuildPrune extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('keep-storage', 'all', 'filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('keep-storage', array('int'));
-        $optionsResolver->setAllowedTypes('all', array('bool'));
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('keep-storage', array('int'));
+        $optionsResolver->addAllowedTypes('all', array('bool'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ConfigList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ConfigList.php
@@ -47,7 +47,7 @@ class ConfigList extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ConfigUpdate.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ConfigUpdate.php
@@ -48,7 +48,7 @@ class ConfigUpdate extends \Docker\Api\Runtime\Client\BaseEndpoint implements \D
         $optionsResolver->setDefined(array('version'));
         $optionsResolver->setRequired(array('version'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('version', array('int'));
+        $optionsResolver->addAllowedTypes('version', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerArchive.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerArchive.php
@@ -41,7 +41,7 @@ class ContainerArchive extends \Docker\Api\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('path'));
         $optionsResolver->setRequired(array('path'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('path', array('string'));
+        $optionsResolver->addAllowedTypes('path', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerArchiveInfo.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerArchiveInfo.php
@@ -44,7 +44,7 @@ class ContainerArchiveInfo extends \Docker\Api\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('path'));
         $optionsResolver->setRequired(array('path'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('path', array('string'));
+        $optionsResolver->addAllowedTypes('path', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerAttach.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerAttach.php
@@ -151,12 +151,12 @@ class ContainerAttach extends \Docker\Api\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('detachKeys', 'logs', 'stream', 'stdin', 'stdout', 'stderr'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('logs' => false, 'stream' => false, 'stdin' => false, 'stdout' => false, 'stderr' => false));
-        $optionsResolver->setAllowedTypes('detachKeys', array('string'));
-        $optionsResolver->setAllowedTypes('logs', array('bool'));
-        $optionsResolver->setAllowedTypes('stream', array('bool'));
-        $optionsResolver->setAllowedTypes('stdin', array('bool'));
-        $optionsResolver->setAllowedTypes('stdout', array('bool'));
-        $optionsResolver->setAllowedTypes('stderr', array('bool'));
+        $optionsResolver->addAllowedTypes('detachKeys', array('string'));
+        $optionsResolver->addAllowedTypes('logs', array('bool'));
+        $optionsResolver->addAllowedTypes('stream', array('bool'));
+        $optionsResolver->addAllowedTypes('stdin', array('bool'));
+        $optionsResolver->addAllowedTypes('stdout', array('bool'));
+        $optionsResolver->addAllowedTypes('stderr', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerAttachWebsocket.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerAttachWebsocket.php
@@ -49,12 +49,12 @@ class ContainerAttachWebsocket extends \Docker\Api\Runtime\Client\BaseEndpoint i
         $optionsResolver->setDefined(array('detachKeys', 'logs', 'stream', 'stdin', 'stdout', 'stderr'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('logs' => false, 'stream' => false, 'stdin' => false, 'stdout' => false, 'stderr' => false));
-        $optionsResolver->setAllowedTypes('detachKeys', array('string'));
-        $optionsResolver->setAllowedTypes('logs', array('bool'));
-        $optionsResolver->setAllowedTypes('stream', array('bool'));
-        $optionsResolver->setAllowedTypes('stdin', array('bool'));
-        $optionsResolver->setAllowedTypes('stdout', array('bool'));
-        $optionsResolver->setAllowedTypes('stderr', array('bool'));
+        $optionsResolver->addAllowedTypes('detachKeys', array('string'));
+        $optionsResolver->addAllowedTypes('logs', array('bool'));
+        $optionsResolver->addAllowedTypes('stream', array('bool'));
+        $optionsResolver->addAllowedTypes('stdin', array('bool'));
+        $optionsResolver->addAllowedTypes('stdout', array('bool'));
+        $optionsResolver->addAllowedTypes('stderr', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerCreate.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerCreate.php
@@ -42,7 +42,7 @@ class ContainerCreate extends \Docker\Api\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('name'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('name', array('string'));
+        $optionsResolver->addAllowedTypes('name', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerDelete.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerDelete.php
@@ -43,9 +43,9 @@ class ContainerDelete extends \Docker\Api\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('v', 'force', 'link'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('v' => false, 'force' => false, 'link' => false));
-        $optionsResolver->setAllowedTypes('v', array('bool'));
-        $optionsResolver->setAllowedTypes('force', array('bool'));
-        $optionsResolver->setAllowedTypes('link', array('bool'));
+        $optionsResolver->addAllowedTypes('v', array('bool'));
+        $optionsResolver->addAllowedTypes('force', array('bool'));
+        $optionsResolver->addAllowedTypes('link', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerInspect.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerInspect.php
@@ -41,7 +41,7 @@ class ContainerInspect extends \Docker\Api\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('size'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('size' => false));
-        $optionsResolver->setAllowedTypes('size', array('bool'));
+        $optionsResolver->addAllowedTypes('size', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerKill.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerKill.php
@@ -43,7 +43,7 @@ class ContainerKill extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('signal'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('signal' => 'SIGKILL'));
-        $optionsResolver->setAllowedTypes('signal', array('string'));
+        $optionsResolver->addAllowedTypes('signal', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerList.php
@@ -72,10 +72,10 @@ class ContainerList extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('all', 'limit', 'size', 'filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('all' => false, 'size' => false));
-        $optionsResolver->setAllowedTypes('all', array('bool'));
-        $optionsResolver->setAllowedTypes('limit', array('int'));
-        $optionsResolver->setAllowedTypes('size', array('bool'));
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('all', array('bool'));
+        $optionsResolver->addAllowedTypes('limit', array('int'));
+        $optionsResolver->addAllowedTypes('size', array('bool'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerLogs.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerLogs.php
@@ -53,13 +53,13 @@ class ContainerLogs extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('follow', 'stdout', 'stderr', 'since', 'until', 'timestamps', 'tail'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('follow' => false, 'stdout' => false, 'stderr' => false, 'since' => 0, 'until' => 0, 'timestamps' => false, 'tail' => 'all'));
-        $optionsResolver->setAllowedTypes('follow', array('bool'));
-        $optionsResolver->setAllowedTypes('stdout', array('bool'));
-        $optionsResolver->setAllowedTypes('stderr', array('bool'));
-        $optionsResolver->setAllowedTypes('since', array('int'));
-        $optionsResolver->setAllowedTypes('until', array('int'));
-        $optionsResolver->setAllowedTypes('timestamps', array('bool'));
-        $optionsResolver->setAllowedTypes('tail', array('string'));
+        $optionsResolver->addAllowedTypes('follow', array('bool'));
+        $optionsResolver->addAllowedTypes('stdout', array('bool'));
+        $optionsResolver->addAllowedTypes('stderr', array('bool'));
+        $optionsResolver->addAllowedTypes('since', array('int'));
+        $optionsResolver->addAllowedTypes('until', array('int'));
+        $optionsResolver->addAllowedTypes('timestamps', array('bool'));
+        $optionsResolver->addAllowedTypes('tail', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerPrune.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerPrune.php
@@ -43,7 +43,7 @@ class ContainerPrune extends \Docker\Api\Runtime\Client\BaseEndpoint implements 
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerRename.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerRename.php
@@ -41,7 +41,7 @@ class ContainerRename extends \Docker\Api\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('name'));
         $optionsResolver->setRequired(array('name'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('name', array('string'));
+        $optionsResolver->addAllowedTypes('name', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerResize.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerResize.php
@@ -42,8 +42,8 @@ class ContainerResize extends \Docker\Api\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('h', 'w'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('h', array('int'));
-        $optionsResolver->setAllowedTypes('w', array('int'));
+        $optionsResolver->addAllowedTypes('h', array('int'));
+        $optionsResolver->addAllowedTypes('w', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerRestart.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerRestart.php
@@ -41,7 +41,7 @@ class ContainerRestart extends \Docker\Api\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('t'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('t', array('int'));
+        $optionsResolver->addAllowedTypes('t', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerStart.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerStart.php
@@ -44,7 +44,7 @@ class ContainerStart extends \Docker\Api\Runtime\Client\BaseEndpoint implements 
         $optionsResolver->setDefined(array('detachKeys'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('detachKeys', array('string'));
+        $optionsResolver->addAllowedTypes('detachKeys', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerStats.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerStats.php
@@ -72,8 +72,8 @@ class ContainerStats extends \Docker\Api\Runtime\Client\BaseEndpoint implements 
         $optionsResolver->setDefined(array('stream', 'one-shot'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('stream' => true, 'one-shot' => false));
-        $optionsResolver->setAllowedTypes('stream', array('bool'));
-        $optionsResolver->setAllowedTypes('one-shot', array('bool'));
+        $optionsResolver->addAllowedTypes('stream', array('bool'));
+        $optionsResolver->addAllowedTypes('one-shot', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerStop.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerStop.php
@@ -41,7 +41,7 @@ class ContainerStop extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('t'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('t', array('int'));
+        $optionsResolver->addAllowedTypes('t', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerTop.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerTop.php
@@ -43,7 +43,7 @@ class ContainerTop extends \Docker\Api\Runtime\Client\BaseEndpoint implements \D
         $optionsResolver->setDefined(array('ps_args'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('ps_args' => '-ef'));
-        $optionsResolver->setAllowedTypes('ps_args', array('string'));
+        $optionsResolver->addAllowedTypes('ps_args', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerWait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerWait.php
@@ -43,7 +43,7 @@ class ContainerWait extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('condition'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('condition' => 'not-running'));
-        $optionsResolver->setAllowedTypes('condition', array('string'));
+        $optionsResolver->addAllowedTypes('condition', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ExecResize.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ExecResize.php
@@ -44,8 +44,8 @@ class ExecResize extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('h', 'w'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('h', array('int'));
-        $optionsResolver->setAllowedTypes('w', array('int'));
+        $optionsResolver->addAllowedTypes('h', array('int'));
+        $optionsResolver->addAllowedTypes('w', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/GetPluginPrivileges.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/GetPluginPrivileges.php
@@ -40,7 +40,7 @@ class GetPluginPrivileges extends \Docker\Api\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('remote'));
         $optionsResolver->setRequired(array('remote'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('remote', array('string'));
+        $optionsResolver->addAllowedTypes('remote', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageBuild.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageBuild.php
@@ -102,30 +102,30 @@ class ImageBuild extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('dockerfile', 't', 'extrahosts', 'remote', 'q', 'nocache', 'cachefrom', 'pull', 'rm', 'forcerm', 'memory', 'memswap', 'cpushares', 'cpusetcpus', 'cpuperiod', 'cpuquota', 'buildargs', 'shmsize', 'squash', 'labels', 'networkmode', 'platform', 'target', 'outputs'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('dockerfile' => 'Dockerfile', 'q' => false, 'nocache' => false, 'rm' => true, 'forcerm' => false, 'platform' => '', 'target' => '', 'outputs' => ''));
-        $optionsResolver->setAllowedTypes('dockerfile', array('string'));
-        $optionsResolver->setAllowedTypes('t', array('string'));
-        $optionsResolver->setAllowedTypes('extrahosts', array('string'));
-        $optionsResolver->setAllowedTypes('remote', array('string'));
-        $optionsResolver->setAllowedTypes('q', array('bool'));
-        $optionsResolver->setAllowedTypes('nocache', array('bool'));
-        $optionsResolver->setAllowedTypes('cachefrom', array('string'));
-        $optionsResolver->setAllowedTypes('pull', array('string'));
-        $optionsResolver->setAllowedTypes('rm', array('bool'));
-        $optionsResolver->setAllowedTypes('forcerm', array('bool'));
-        $optionsResolver->setAllowedTypes('memory', array('int'));
-        $optionsResolver->setAllowedTypes('memswap', array('int'));
-        $optionsResolver->setAllowedTypes('cpushares', array('int'));
-        $optionsResolver->setAllowedTypes('cpusetcpus', array('string'));
-        $optionsResolver->setAllowedTypes('cpuperiod', array('int'));
-        $optionsResolver->setAllowedTypes('cpuquota', array('int'));
-        $optionsResolver->setAllowedTypes('buildargs', array('string'));
-        $optionsResolver->setAllowedTypes('shmsize', array('int'));
-        $optionsResolver->setAllowedTypes('squash', array('bool'));
-        $optionsResolver->setAllowedTypes('labels', array('string'));
-        $optionsResolver->setAllowedTypes('networkmode', array('string'));
-        $optionsResolver->setAllowedTypes('platform', array('string'));
-        $optionsResolver->setAllowedTypes('target', array('string'));
-        $optionsResolver->setAllowedTypes('outputs', array('string'));
+        $optionsResolver->addAllowedTypes('dockerfile', array('string'));
+        $optionsResolver->addAllowedTypes('t', array('string'));
+        $optionsResolver->addAllowedTypes('extrahosts', array('string'));
+        $optionsResolver->addAllowedTypes('remote', array('string'));
+        $optionsResolver->addAllowedTypes('q', array('bool'));
+        $optionsResolver->addAllowedTypes('nocache', array('bool'));
+        $optionsResolver->addAllowedTypes('cachefrom', array('string'));
+        $optionsResolver->addAllowedTypes('pull', array('string'));
+        $optionsResolver->addAllowedTypes('rm', array('bool'));
+        $optionsResolver->addAllowedTypes('forcerm', array('bool'));
+        $optionsResolver->addAllowedTypes('memory', array('int'));
+        $optionsResolver->addAllowedTypes('memswap', array('int'));
+        $optionsResolver->addAllowedTypes('cpushares', array('int'));
+        $optionsResolver->addAllowedTypes('cpusetcpus', array('string'));
+        $optionsResolver->addAllowedTypes('cpuperiod', array('int'));
+        $optionsResolver->addAllowedTypes('cpuquota', array('int'));
+        $optionsResolver->addAllowedTypes('buildargs', array('string'));
+        $optionsResolver->addAllowedTypes('shmsize', array('int'));
+        $optionsResolver->addAllowedTypes('squash', array('bool'));
+        $optionsResolver->addAllowedTypes('labels', array('string'));
+        $optionsResolver->addAllowedTypes('networkmode', array('string'));
+        $optionsResolver->addAllowedTypes('platform', array('string'));
+        $optionsResolver->addAllowedTypes('target', array('string'));
+        $optionsResolver->addAllowedTypes('outputs', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -134,8 +134,8 @@ class ImageBuild extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('Content-type', 'X-Registry-Config'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('Content-type' => 'application/x-tar'));
-        $optionsResolver->setAllowedTypes('Content-type', array('string'));
-        $optionsResolver->setAllowedTypes('X-Registry-Config', array('string'));
+        $optionsResolver->addAllowedTypes('Content-type', array('string'));
+        $optionsResolver->addAllowedTypes('X-Registry-Config', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageCommit.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageCommit.php
@@ -46,13 +46,13 @@ class ImageCommit extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('container', 'repo', 'tag', 'comment', 'author', 'pause', 'changes'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('pause' => true));
-        $optionsResolver->setAllowedTypes('container', array('string'));
-        $optionsResolver->setAllowedTypes('repo', array('string'));
-        $optionsResolver->setAllowedTypes('tag', array('string'));
-        $optionsResolver->setAllowedTypes('comment', array('string'));
-        $optionsResolver->setAllowedTypes('author', array('string'));
-        $optionsResolver->setAllowedTypes('pause', array('bool'));
-        $optionsResolver->setAllowedTypes('changes', array('string'));
+        $optionsResolver->addAllowedTypes('container', array('string'));
+        $optionsResolver->addAllowedTypes('repo', array('string'));
+        $optionsResolver->addAllowedTypes('tag', array('string'));
+        $optionsResolver->addAllowedTypes('comment', array('string'));
+        $optionsResolver->addAllowedTypes('author', array('string'));
+        $optionsResolver->addAllowedTypes('pause', array('bool'));
+        $optionsResolver->addAllowedTypes('changes', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageCreate.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageCreate.php
@@ -60,13 +60,13 @@ class ImageCreate extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('fromImage', 'fromSrc', 'repo', 'tag', 'message', 'changes', 'platform'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('platform' => ''));
-        $optionsResolver->setAllowedTypes('fromImage', array('string'));
-        $optionsResolver->setAllowedTypes('fromSrc', array('string'));
-        $optionsResolver->setAllowedTypes('repo', array('string'));
-        $optionsResolver->setAllowedTypes('tag', array('string'));
-        $optionsResolver->setAllowedTypes('message', array('string'));
-        $optionsResolver->setAllowedTypes('changes', array('array'));
-        $optionsResolver->setAllowedTypes('platform', array('string'));
+        $optionsResolver->addAllowedTypes('fromImage', array('string'));
+        $optionsResolver->addAllowedTypes('fromSrc', array('string'));
+        $optionsResolver->addAllowedTypes('repo', array('string'));
+        $optionsResolver->addAllowedTypes('tag', array('string'));
+        $optionsResolver->addAllowedTypes('message', array('string'));
+        $optionsResolver->addAllowedTypes('changes', array('array'));
+        $optionsResolver->addAllowedTypes('platform', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -75,7 +75,7 @@ class ImageCreate extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('X-Registry-Auth'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('X-Registry-Auth', array('string'));
+        $optionsResolver->addAllowedTypes('X-Registry-Auth', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageDelete.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageDelete.php
@@ -47,8 +47,8 @@ class ImageDelete extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('force', 'noprune'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('force' => false, 'noprune' => false));
-        $optionsResolver->setAllowedTypes('force', array('bool'));
-        $optionsResolver->setAllowedTypes('noprune', array('bool'));
+        $optionsResolver->addAllowedTypes('force', array('bool'));
+        $optionsResolver->addAllowedTypes('noprune', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageGetAll.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageGetAll.php
@@ -48,7 +48,7 @@ class ImageGetAll extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('names'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('names', array('array'));
+        $optionsResolver->addAllowedTypes('names', array('array'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageList.php
@@ -50,9 +50,9 @@ class ImageList extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Dock
         $optionsResolver->setDefined(array('all', 'filters', 'digests'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('all' => false, 'digests' => false));
-        $optionsResolver->setAllowedTypes('all', array('bool'));
-        $optionsResolver->setAllowedTypes('filters', array('string'));
-        $optionsResolver->setAllowedTypes('digests', array('bool'));
+        $optionsResolver->addAllowedTypes('all', array('bool'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('digests', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageLoad.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageLoad.php
@@ -43,7 +43,7 @@ class ImageLoad extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Dock
         $optionsResolver->setDefined(array('quiet'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('quiet' => false));
-        $optionsResolver->setAllowedTypes('quiet', array('bool'));
+        $optionsResolver->addAllowedTypes('quiet', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImagePrune.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImagePrune.php
@@ -45,7 +45,7 @@ class ImagePrune extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImagePush.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImagePush.php
@@ -56,7 +56,7 @@ class ImagePush extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Dock
         $optionsResolver->setDefined(array('tag'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('tag', array('string'));
+        $optionsResolver->addAllowedTypes('tag', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -65,7 +65,7 @@ class ImagePush extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Dock
         $optionsResolver->setDefined(array('X-Registry-Auth'));
         $optionsResolver->setRequired(array('X-Registry-Auth'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('X-Registry-Auth', array('string'));
+        $optionsResolver->addAllowedTypes('X-Registry-Auth', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageSearch.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageSearch.php
@@ -45,9 +45,9 @@ class ImageSearch extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('term', 'limit', 'filters'));
         $optionsResolver->setRequired(array('term'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('term', array('string'));
-        $optionsResolver->setAllowedTypes('limit', array('int'));
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('term', array('string'));
+        $optionsResolver->addAllowedTypes('limit', array('int'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageTag.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageTag.php
@@ -42,8 +42,8 @@ class ImageTag extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Docke
         $optionsResolver->setDefined(array('repo', 'tag'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('repo', array('string'));
-        $optionsResolver->setAllowedTypes('tag', array('string'));
+        $optionsResolver->addAllowedTypes('repo', array('string'));
+        $optionsResolver->addAllowedTypes('tag', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NetworkInspect.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NetworkInspect.php
@@ -42,8 +42,8 @@ class NetworkInspect extends \Docker\Api\Runtime\Client\BaseEndpoint implements 
         $optionsResolver->setDefined(array('verbose', 'scope'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('verbose' => false));
-        $optionsResolver->setAllowedTypes('verbose', array('bool'));
-        $optionsResolver->setAllowedTypes('scope', array('string'));
+        $optionsResolver->addAllowedTypes('verbose', array('bool'));
+        $optionsResolver->addAllowedTypes('scope', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NetworkList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NetworkList.php
@@ -59,7 +59,7 @@ class NetworkList extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NetworkPrune.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NetworkPrune.php
@@ -43,7 +43,7 @@ class NetworkPrune extends \Docker\Api\Runtime\Client\BaseEndpoint implements \D
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NodeDelete.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NodeDelete.php
@@ -41,7 +41,7 @@ class NodeDelete extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('force'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('force' => false));
-        $optionsResolver->setAllowedTypes('force', array('bool'));
+        $optionsResolver->addAllowedTypes('force', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NodeList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NodeList.php
@@ -47,7 +47,7 @@ class NodeList extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Docke
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NodeUpdate.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/NodeUpdate.php
@@ -45,7 +45,7 @@ class NodeUpdate extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('version'));
         $optionsResolver->setRequired(array('version'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('version', array('int'));
+        $optionsResolver->addAllowedTypes('version', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginCreate.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginCreate.php
@@ -42,7 +42,7 @@ class PluginCreate extends \Docker\Api\Runtime\Client\BaseEndpoint implements \D
         $optionsResolver->setDefined(array('name'));
         $optionsResolver->setRequired(array('name'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('name', array('string'));
+        $optionsResolver->addAllowedTypes('name', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginDelete.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginDelete.php
@@ -45,7 +45,7 @@ class PluginDelete extends \Docker\Api\Runtime\Client\BaseEndpoint implements \D
         $optionsResolver->setDefined(array('force'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('force' => false));
-        $optionsResolver->setAllowedTypes('force', array('bool'));
+        $optionsResolver->addAllowedTypes('force', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginEnable.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginEnable.php
@@ -43,7 +43,7 @@ class PluginEnable extends \Docker\Api\Runtime\Client\BaseEndpoint implements \D
         $optionsResolver->setDefined(array('timeout'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('timeout' => 0));
-        $optionsResolver->setAllowedTypes('timeout', array('int'));
+        $optionsResolver->addAllowedTypes('timeout', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginList.php
@@ -45,7 +45,7 @@ class PluginList extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginPull.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginPull.php
@@ -58,8 +58,8 @@ class PluginPull extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('remote', 'name'));
         $optionsResolver->setRequired(array('remote'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('remote', array('string'));
-        $optionsResolver->setAllowedTypes('name', array('string'));
+        $optionsResolver->addAllowedTypes('remote', array('string'));
+        $optionsResolver->addAllowedTypes('name', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -68,7 +68,7 @@ class PluginPull extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('X-Registry-Auth'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('X-Registry-Auth', array('string'));
+        $optionsResolver->addAllowedTypes('X-Registry-Auth', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginUpgrade.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PluginUpgrade.php
@@ -57,7 +57,7 @@ class PluginUpgrade extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('remote'));
         $optionsResolver->setRequired(array('remote'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('remote', array('string'));
+        $optionsResolver->addAllowedTypes('remote', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -66,7 +66,7 @@ class PluginUpgrade extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('X-Registry-Auth'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('X-Registry-Auth', array('string'));
+        $optionsResolver->addAllowedTypes('X-Registry-Auth', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PutContainerArchive.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/PutContainerArchive.php
@@ -53,9 +53,9 @@ class PutContainerArchive extends \Docker\Api\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('path', 'noOverwriteDirNonDir', 'copyUIDGID'));
         $optionsResolver->setRequired(array('path'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('path', array('string'));
-        $optionsResolver->setAllowedTypes('noOverwriteDirNonDir', array('string'));
-        $optionsResolver->setAllowedTypes('copyUIDGID', array('string'));
+        $optionsResolver->addAllowedTypes('path', array('string'));
+        $optionsResolver->addAllowedTypes('noOverwriteDirNonDir', array('string'));
+        $optionsResolver->addAllowedTypes('copyUIDGID', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SecretList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SecretList.php
@@ -47,7 +47,7 @@ class SecretList extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SecretUpdate.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SecretUpdate.php
@@ -48,7 +48,7 @@ class SecretUpdate extends \Docker\Api\Runtime\Client\BaseEndpoint implements \D
         $optionsResolver->setDefined(array('version'));
         $optionsResolver->setRequired(array('version'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('version', array('int'));
+        $optionsResolver->addAllowedTypes('version', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceCreate.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceCreate.php
@@ -45,7 +45,7 @@ class ServiceCreate extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('X-Registry-Auth'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('X-Registry-Auth', array('string'));
+        $optionsResolver->addAllowedTypes('X-Registry-Auth', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceInspect.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceInspect.php
@@ -41,7 +41,7 @@ class ServiceInspect extends \Docker\Api\Runtime\Client\BaseEndpoint implements 
         $optionsResolver->setDefined(array('insertDefaults'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('insertDefaults' => false));
-        $optionsResolver->setAllowedTypes('insertDefaults', array('bool'));
+        $optionsResolver->addAllowedTypes('insertDefaults', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceList.php
@@ -49,8 +49,8 @@ class ServiceList extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('filters', 'status'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
-        $optionsResolver->setAllowedTypes('status', array('bool'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('status', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceLogs.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceLogs.php
@@ -54,13 +54,13 @@ class ServiceLogs extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('details', 'follow', 'stdout', 'stderr', 'since', 'timestamps', 'tail'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('details' => false, 'follow' => false, 'stdout' => false, 'stderr' => false, 'since' => 0, 'timestamps' => false, 'tail' => 'all'));
-        $optionsResolver->setAllowedTypes('details', array('bool'));
-        $optionsResolver->setAllowedTypes('follow', array('bool'));
-        $optionsResolver->setAllowedTypes('stdout', array('bool'));
-        $optionsResolver->setAllowedTypes('stderr', array('bool'));
-        $optionsResolver->setAllowedTypes('since', array('int'));
-        $optionsResolver->setAllowedTypes('timestamps', array('bool'));
-        $optionsResolver->setAllowedTypes('tail', array('string'));
+        $optionsResolver->addAllowedTypes('details', array('bool'));
+        $optionsResolver->addAllowedTypes('follow', array('bool'));
+        $optionsResolver->addAllowedTypes('stdout', array('bool'));
+        $optionsResolver->addAllowedTypes('stderr', array('bool'));
+        $optionsResolver->addAllowedTypes('since', array('int'));
+        $optionsResolver->addAllowedTypes('timestamps', array('bool'));
+        $optionsResolver->addAllowedTypes('tail', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceUpdate.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceUpdate.php
@@ -64,9 +64,9 @@ class ServiceUpdate extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('version', 'registryAuthFrom', 'rollback'));
         $optionsResolver->setRequired(array('version'));
         $optionsResolver->setDefaults(array('registryAuthFrom' => 'spec'));
-        $optionsResolver->setAllowedTypes('version', array('int'));
-        $optionsResolver->setAllowedTypes('registryAuthFrom', array('string'));
-        $optionsResolver->setAllowedTypes('rollback', array('string'));
+        $optionsResolver->addAllowedTypes('version', array('int'));
+        $optionsResolver->addAllowedTypes('registryAuthFrom', array('string'));
+        $optionsResolver->addAllowedTypes('rollback', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -75,7 +75,7 @@ class ServiceUpdate extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('X-Registry-Auth'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('X-Registry-Auth', array('string'));
+        $optionsResolver->addAllowedTypes('X-Registry-Auth', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SwarmLeave.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SwarmLeave.php
@@ -40,7 +40,7 @@ class SwarmLeave extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('force'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('force' => false));
-        $optionsResolver->setAllowedTypes('force', array('bool'));
+        $optionsResolver->addAllowedTypes('force', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SwarmUpdate.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SwarmUpdate.php
@@ -45,10 +45,10 @@ class SwarmUpdate extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('version', 'rotateWorkerToken', 'rotateManagerToken', 'rotateManagerUnlockKey'));
         $optionsResolver->setRequired(array('version'));
         $optionsResolver->setDefaults(array('rotateWorkerToken' => false, 'rotateManagerToken' => false, 'rotateManagerUnlockKey' => false));
-        $optionsResolver->setAllowedTypes('version', array('int'));
-        $optionsResolver->setAllowedTypes('rotateWorkerToken', array('bool'));
-        $optionsResolver->setAllowedTypes('rotateManagerToken', array('bool'));
-        $optionsResolver->setAllowedTypes('rotateManagerUnlockKey', array('bool'));
+        $optionsResolver->addAllowedTypes('version', array('int'));
+        $optionsResolver->addAllowedTypes('rotateWorkerToken', array('bool'));
+        $optionsResolver->addAllowedTypes('rotateManagerToken', array('bool'));
+        $optionsResolver->addAllowedTypes('rotateManagerUnlockKey', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SystemEvents.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SystemEvents.php
@@ -79,9 +79,9 @@ class SystemEvents extends \Docker\Api\Runtime\Client\BaseEndpoint implements \D
         $optionsResolver->setDefined(array('since', 'until', 'filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('until', array('string'));
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('until', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/TaskList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/TaskList.php
@@ -49,7 +49,7 @@ class TaskList extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Docke
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/TaskLogs.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/TaskLogs.php
@@ -54,13 +54,13 @@ class TaskLogs extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Docke
         $optionsResolver->setDefined(array('details', 'follow', 'stdout', 'stderr', 'since', 'timestamps', 'tail'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('details' => false, 'follow' => false, 'stdout' => false, 'stderr' => false, 'since' => 0, 'timestamps' => false, 'tail' => 'all'));
-        $optionsResolver->setAllowedTypes('details', array('bool'));
-        $optionsResolver->setAllowedTypes('follow', array('bool'));
-        $optionsResolver->setAllowedTypes('stdout', array('bool'));
-        $optionsResolver->setAllowedTypes('stderr', array('bool'));
-        $optionsResolver->setAllowedTypes('since', array('int'));
-        $optionsResolver->setAllowedTypes('timestamps', array('bool'));
-        $optionsResolver->setAllowedTypes('tail', array('string'));
+        $optionsResolver->addAllowedTypes('details', array('bool'));
+        $optionsResolver->addAllowedTypes('follow', array('bool'));
+        $optionsResolver->addAllowedTypes('stdout', array('bool'));
+        $optionsResolver->addAllowedTypes('stderr', array('bool'));
+        $optionsResolver->addAllowedTypes('since', array('int'));
+        $optionsResolver->addAllowedTypes('timestamps', array('bool'));
+        $optionsResolver->addAllowedTypes('tail', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/VolumeDelete.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/VolumeDelete.php
@@ -41,7 +41,7 @@ class VolumeDelete extends \Docker\Api\Runtime\Client\BaseEndpoint implements \D
         $optionsResolver->setDefined(array('force'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('force' => false));
-        $optionsResolver->setAllowedTypes('force', array('bool'));
+        $optionsResolver->addAllowedTypes('force', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/VolumeList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/VolumeList.php
@@ -49,7 +49,7 @@ class VolumeList extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/VolumePrune.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/VolumePrune.php
@@ -42,7 +42,7 @@ class VolumePrune extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
         $optionsResolver->setDefined(array('filters'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('filters', array('string'));
+        $optionsResolver->addAllowedTypes('filters', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
@@ -38,7 +38,7 @@ class ListPets extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Ba
         $optionsResolver->setDefined(array('limit'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('limit', array('int'));
+        $optionsResolver->addAllowedTypes('limit', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestFormFileParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestFormFileParameters.php
@@ -34,7 +34,7 @@ class TestFormFileParameters extends \Jane\Component\OpenApi2\Tests\Expected\Run
         $optionsResolver->setDefined(array('testFile'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testFile', array('string', 'resource', '\\Psr\\Http\\Message\\StreamInterface'));
+        $optionsResolver->addAllowedTypes('testFile', array('string', 'resource', '\\Psr\\Http\\Message\\StreamInterface'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestFormParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestFormParameters.php
@@ -39,12 +39,12 @@ class TestFormParameters extends \Jane\Component\OpenApi2\Tests\Expected\Runtime
         $optionsResolver->setDefined(array('testString', 'testInteger', 'testFloat', 'testArray', 'testRequired', 'testDefault'));
         $optionsResolver->setRequired(array('testRequired'));
         $optionsResolver->setDefaults(array('testDefault' => 'test'));
-        $optionsResolver->setAllowedTypes('testString', array('string'));
-        $optionsResolver->setAllowedTypes('testInteger', array('int'));
-        $optionsResolver->setAllowedTypes('testFloat', array('float'));
-        $optionsResolver->setAllowedTypes('testArray', array('array'));
-        $optionsResolver->setAllowedTypes('testRequired', array('string'));
-        $optionsResolver->setAllowedTypes('testDefault', array('string'));
+        $optionsResolver->addAllowedTypes('testString', array('string'));
+        $optionsResolver->addAllowedTypes('testInteger', array('int'));
+        $optionsResolver->addAllowedTypes('testFloat', array('float'));
+        $optionsResolver->addAllowedTypes('testArray', array('array'));
+        $optionsResolver->addAllowedTypes('testRequired', array('string'));
+        $optionsResolver->addAllowedTypes('testDefault', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestGetWithPathParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestGetWithPathParameters.php
@@ -40,7 +40,7 @@ class TestGetWithPathParameters extends \Jane\Component\OpenApi2\Tests\Expected\
         $optionsResolver->setDefined(array('testQuery'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testQuery', array('string'));
+        $optionsResolver->addAllowedTypes('testQuery', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -49,7 +49,7 @@ class TestGetWithPathParameters extends \Jane\Component\OpenApi2\Tests\Expected\
         $optionsResolver->setDefined(array('testHeader'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testHeader', array('string'));
+        $optionsResolver->addAllowedTypes('testHeader', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
@@ -39,12 +39,12 @@ class TestHeaderParameters extends \Jane\Component\OpenApi2\Tests\Expected\Runti
         $optionsResolver->setDefined(array('testString', 'testInteger', 'testFloat', 'testArray', 'testRequired', 'testDefault'));
         $optionsResolver->setRequired(array('testRequired'));
         $optionsResolver->setDefaults(array('testDefault' => 'test'));
-        $optionsResolver->setAllowedTypes('testString', array('string'));
-        $optionsResolver->setAllowedTypes('testInteger', array('int'));
-        $optionsResolver->setAllowedTypes('testFloat', array('float'));
-        $optionsResolver->setAllowedTypes('testArray', array('array'));
-        $optionsResolver->setAllowedTypes('testRequired', array('string'));
-        $optionsResolver->setAllowedTypes('testDefault', array('string'));
+        $optionsResolver->addAllowedTypes('testString', array('string'));
+        $optionsResolver->addAllowedTypes('testInteger', array('int'));
+        $optionsResolver->addAllowedTypes('testFloat', array('float'));
+        $optionsResolver->addAllowedTypes('testArray', array('array'));
+        $optionsResolver->addAllowedTypes('testRequired', array('string'));
+        $optionsResolver->addAllowedTypes('testDefault', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestPostWithPathParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestPostWithPathParameters.php
@@ -40,7 +40,7 @@ class TestPostWithPathParameters extends \Jane\Component\OpenApi2\Tests\Expected
         $optionsResolver->setDefined(array('testQuery'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testQuery', array('string'));
+        $optionsResolver->addAllowedTypes('testQuery', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -49,7 +49,7 @@ class TestPostWithPathParameters extends \Jane\Component\OpenApi2\Tests\Expected
         $optionsResolver->setDefined(array('testHeader'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testHeader', array('string'));
+        $optionsResolver->addAllowedTypes('testHeader', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
@@ -39,12 +39,12 @@ class TestQueryParameters extends \Jane\Component\OpenApi2\Tests\Expected\Runtim
         $optionsResolver->setDefined(array('testString', 'testInteger', 'testFloat', 'testArray', 'testRequired', 'testDefault'));
         $optionsResolver->setRequired(array('testRequired'));
         $optionsResolver->setDefaults(array('testDefault' => 'test'));
-        $optionsResolver->setAllowedTypes('testString', array('string'));
-        $optionsResolver->setAllowedTypes('testInteger', array('int'));
-        $optionsResolver->setAllowedTypes('testFloat', array('float'));
-        $optionsResolver->setAllowedTypes('testArray', array('array'));
-        $optionsResolver->setAllowedTypes('testRequired', array('string'));
-        $optionsResolver->setAllowedTypes('testDefault', array('string'));
+        $optionsResolver->addAllowedTypes('testString', array('string'));
+        $optionsResolver->addAllowedTypes('testInteger', array('int'));
+        $optionsResolver->addAllowedTypes('testFloat', array('float'));
+        $optionsResolver->addAllowedTypes('testArray', array('array'));
+        $optionsResolver->addAllowedTypes('testRequired', array('string'));
+        $optionsResolver->addAllowedTypes('testDefault', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Endpoint/TestGetWithPathParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Endpoint/TestGetWithPathParameters.php
@@ -45,7 +45,7 @@ class TestGetWithPathParameters extends \Jane\OpenApi2\Tests\Expected\Runtime\Cl
         $optionsResolver->setDefined(array('testQuery'));
         $optionsResolver->setRequired(array('testQuery'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testQuery', array('string'));
+        $optionsResolver->addAllowedTypes('testQuery', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -54,7 +54,7 @@ class TestGetWithPathParameters extends \Jane\OpenApi2\Tests\Expected\Runtime\Cl
         $optionsResolver->setDefined(array('testHeader'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testHeader', array('string'));
+        $optionsResolver->addAllowedTypes('testHeader', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/ListProjects.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/ListProjects.php
@@ -40,11 +40,11 @@ class ListProjects extends \Jane\OpenApi2\Tests\Expected\Runtime\Client\BaseEndp
         $optionsResolver->setDefined(array('is_active', 'client_id', 'updated_since', 'page', 'per_page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('is_active', array('bool'));
-        $optionsResolver->setAllowedTypes('client_id', array('int'));
-        $optionsResolver->setAllowedTypes('updated_since', array('string'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('is_active', array('bool'));
+        $optionsResolver->addAllowedTypes('client_id', array('int'));
+        $optionsResolver->addAllowedTypes('updated_since', array('string'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Endpoint/ListProjects.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Endpoint/ListProjects.php
@@ -40,11 +40,11 @@ class ListProjects extends \Jane\OpenApi2\Tests\Expected\Runtime\Client\BaseEndp
         $optionsResolver->setDefined(array('is_active', 'client_id', 'updated_since', 'page', 'per_page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('is_active', array('bool'));
-        $optionsResolver->setAllowedTypes('client_id', array('int'));
-        $optionsResolver->setAllowedTypes('updated_since', array('string'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('is_active', array('bool'));
+        $optionsResolver->addAllowedTypes('client_id', array('int'));
+        $optionsResolver->addAllowedTypes('updated_since', array('string'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
@@ -68,10 +68,10 @@ class NonBodyParameterGenerator extends ParameterGenerator
         foreach ($parameters as $parameter) {
             $parameterName = $parameter->getName();
             if (str_contains($parameterName, '[]')) {
-                $parameterName = substr($parameterName, 0,-2);
+                $parameterName = substr($parameterName, 0, -2);
             }
 
-            if (!array_key_exists($parameterName, $defined)) {
+            if (!\array_key_exists($parameterName, $defined)) {
                 $defined[$parameterName] = new Expr\ArrayItem(new Scalar\String_($parameterName));
             }
 

--- a/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
@@ -66,7 +66,15 @@ class NonBodyParameterGenerator extends ParameterGenerator
         $genericResolverKeys = array_keys($genericResolver);
 
         foreach ($parameters as $parameter) {
-            $defined[] = new Expr\ArrayItem(new Scalar\String_($parameter->getName()));
+            $parameterName = $parameter->getName();
+            if (str_contains($parameterName, '[]')) {
+                $parameterName = substr($parameterName, 0,-2);
+            }
+
+            if (!array_key_exists($parameterName, $defined)) {
+                $defined[$parameterName] = new Expr\ArrayItem(new Scalar\String_($parameterName));
+            }
+
             $schema = $parameter->getSchema();
 
             if ($schema instanceof Reference) {
@@ -74,7 +82,7 @@ class NonBodyParameterGenerator extends ParameterGenerator
             }
 
             if ($parameter->getRequired() && (null !== $schema && null === $schema->getDefault())) {
-                $required[] = new Expr\ArrayItem(new Scalar\String_($parameter->getName()));
+                $required[] = new Expr\ArrayItem(new Scalar\String_($parameterName));
             }
 
             $matchGenericResolver = null;
@@ -93,24 +101,24 @@ class NonBodyParameterGenerator extends ParameterGenerator
                     $types[] = new Expr\ArrayItem(new Scalar\String_('null'));
                 }
 
-                $allowedTypes[] = new Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'setAllowedTypes', [
-                    new Node\Arg(new Scalar\String_($parameter->getName())),
+                $allowedTypes[] = new Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'addAllowedTypes', [
+                    new Node\Arg(new Scalar\String_($parameterName)),
                     new Node\Arg(new Expr\Array_($types)),
                 ]));
             }
 
             if (!$parameter->getRequired() && null !== $schema && null !== $schema->getDefault()) {
-                $defaults[] = new Expr\ArrayItem($this->getDefaultAsExpr($parameter), new Scalar\String_($parameter->getName()));
+                $defaults[] = new Expr\ArrayItem($this->getDefaultAsExpr($parameter), new Scalar\String_($parameterName));
             }
 
             if (null !== $matchGenericResolver) {
-                $allowedTypes[] = $this->generateOptionResolverNormalizationStatement($parameter->getName(), $genericResolver[$matchGenericResolver]);
+                $allowedTypes[] = $this->generateOptionResolverNormalizationStatement($parameterName, $genericResolver[$matchGenericResolver]);
             }
         }
 
         return array_merge([
             new Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'setDefined', [
-                new Node\Arg(new Expr\Array_($defined)),
+                new Node\Arg(new Expr\Array_(array_values($defined))),
             ])),
             new Stmt\Expression(new Expr\MethodCall($optionsResolverVariable, 'setRequired', [
                 new Node\Arg(new Expr\Array_($required)),

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Endpoint/GetFoo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Endpoint/GetFoo.php
@@ -34,7 +34,7 @@ class GetFoo extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Base
         $optionsResolver->setDefined(array('testBoolean'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testBoolean', array('bool'));
+        $optionsResolver->addAllowedTypes('testBoolean', array('bool'));
         $optionsResolver->setNormalizer('testBoolean', \Closure::fromCallable(array(new \Jane\Component\OpenApi3\Tests\Expected\AllBooleanQueryResolver\BooleanCustomQueryResolver(), '__invoke')));
         return $optionsResolver;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiBooksReviewsGetSubresource.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiBooksReviewsGetSubresource.php
@@ -6,14 +6,14 @@ class ApiBooksReviewsGetSubresource extends \ApiPlatform\Demo\Runtime\Client\Bas
 {
     protected $id;
     /**
-     * 
      *
-     * @param string $id 
+     *
+     * @param string $id
      * @param array $queryParameters {
-     *     @var string $order[id] 
-     *     @var string $order[publicationDate] 
-     *     @var string $book 
-     *     @var array $book[] 
+     *     @var string $order[id]
+     *     @var string $order[publicationDate]
+     *     @var string $book
+     *     @var array $book[]
      *     @var int $page The collection page number
      * }
      */
@@ -42,14 +42,14 @@ class ApiBooksReviewsGetSubresource extends \ApiPlatform\Demo\Runtime\Client\Bas
     protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
-        $optionsResolver->setDefined(array('order[id]', 'order[publicationDate]', 'book', 'book[]', 'page'));
+        $optionsResolver->setDefined(array('order[id]', 'order[publicationDate]', 'book', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('page' => 1));
-        $optionsResolver->setAllowedTypes('order[id]', array('string'));
-        $optionsResolver->setAllowedTypes('order[publicationDate]', array('string'));
-        $optionsResolver->setAllowedTypes('book', array('string'));
-        $optionsResolver->setAllowedTypes('book[]', array('array'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('order[id]', array('string'));
+        $optionsResolver->addAllowedTypes('order[publicationDate]', array('string'));
+        $optionsResolver->addAllowedTypes('book', array('string'));
+        $optionsResolver->addAllowedTypes('book', array('array'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiBooksReviewsGetSubresource.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiBooksReviewsGetSubresource.php
@@ -6,14 +6,14 @@ class ApiBooksReviewsGetSubresource extends \ApiPlatform\Demo\Runtime\Client\Bas
 {
     protected $id;
     /**
+     * 
      *
-     *
-     * @param string $id
+     * @param string $id 
      * @param array $queryParameters {
-     *     @var string $order[id]
-     *     @var string $order[publicationDate]
-     *     @var string $book
-     *     @var array $book[]
+     *     @var string $order[id] 
+     *     @var string $order[publicationDate] 
+     *     @var string $book 
+     *     @var array $book[] 
      *     @var int $page The collection page number
      * }
      */

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetBookCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetBookCollection.php
@@ -46,15 +46,15 @@ class GetBookCollection extends \ApiPlatform\Demo\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('properties[]', 'order[id]', 'order[title]', 'order[author]', 'order[isbn]', 'order[publicationDate]', 'title', 'author', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('page' => 1));
-        $optionsResolver->setAllowedTypes('properties[]', array('array'));
-        $optionsResolver->setAllowedTypes('order[id]', array('string'));
-        $optionsResolver->setAllowedTypes('order[title]', array('string'));
-        $optionsResolver->setAllowedTypes('order[author]', array('string'));
-        $optionsResolver->setAllowedTypes('order[isbn]', array('string'));
-        $optionsResolver->setAllowedTypes('order[publicationDate]', array('string'));
-        $optionsResolver->setAllowedTypes('title', array('string'));
-        $optionsResolver->setAllowedTypes('author', array('string'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('properties[]', array('array'));
+        $optionsResolver->addAllowedTypes('order[id]', array('string'));
+        $optionsResolver->addAllowedTypes('order[title]', array('string'));
+        $optionsResolver->addAllowedTypes('order[author]', array('string'));
+        $optionsResolver->addAllowedTypes('order[isbn]', array('string'));
+        $optionsResolver->addAllowedTypes('order[publicationDate]', array('string'));
+        $optionsResolver->addAllowedTypes('title', array('string'));
+        $optionsResolver->addAllowedTypes('author', array('string'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetBookCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetBookCollection.php
@@ -43,10 +43,10 @@ class GetBookCollection extends \ApiPlatform\Demo\Runtime\Client\BaseEndpoint im
     protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
-        $optionsResolver->setDefined(array('properties[]', 'order[id]', 'order[title]', 'order[author]', 'order[isbn]', 'order[publicationDate]', 'title', 'author', 'page'));
+        $optionsResolver->setDefined(array('properties', 'order[id]', 'order[title]', 'order[author]', 'order[isbn]', 'order[publicationDate]', 'title', 'author', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('page' => 1));
-        $optionsResolver->addAllowedTypes('properties[]', array('array'));
+        $optionsResolver->addAllowedTypes('properties', array('array'));
         $optionsResolver->addAllowedTypes('order[id]', array('string'));
         $optionsResolver->addAllowedTypes('order[title]', array('string'));
         $optionsResolver->addAllowedTypes('order[author]', array('string'));

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetParchmentCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetParchmentCollection.php
@@ -38,7 +38,7 @@ class GetParchmentCollection extends \ApiPlatform\Demo\Runtime\Client\BaseEndpoi
         $optionsResolver->setDefined(array('page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('page' => 1));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetReviewCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetReviewCollection.php
@@ -5,13 +5,13 @@ namespace ApiPlatform\Demo\Endpoint;
 class GetReviewCollection extends \ApiPlatform\Demo\Runtime\Client\BaseEndpoint implements \ApiPlatform\Demo\Runtime\Client\Endpoint
 {
     /**
-     *
+     * 
      *
      * @param array $queryParameters {
-     *     @var string $order[id]
-     *     @var string $order[publicationDate]
-     *     @var string $book
-     *     @var array $book[]
+     *     @var string $order[id] 
+     *     @var string $order[publicationDate] 
+     *     @var string $book 
+     *     @var array $book[] 
      *     @var int $page The collection page number
      * }
      */

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetReviewCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetReviewCollection.php
@@ -39,14 +39,14 @@ class GetReviewCollection extends \ApiPlatform\Demo\Runtime\Client\BaseEndpoint 
     protected function getQueryOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
-        $optionsResolver->setDefined(array('order[id]', 'order[publicationDate]', 'book', 'book[]', 'page'));
+        $optionsResolver->setDefined(array('order[id]', 'order[publicationDate]', 'book', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('page' => 1));
-        $optionsResolver->setAllowedTypes('order[id]', array('string'));
-        $optionsResolver->setAllowedTypes('order[publicationDate]', array('string'));
-        $optionsResolver->setAllowedTypes('book', array('string'));
-        $optionsResolver->setAllowedTypes('book[]', array('array'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('order[id]', array('string'));
+        $optionsResolver->addAllowedTypes('order[publicationDate]', array('string'));
+        $optionsResolver->addAllowedTypes('book', array('string'));
+        $optionsResolver->addAllowedTypes('book', array('array'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetReviewCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/GetReviewCollection.php
@@ -5,13 +5,13 @@ namespace ApiPlatform\Demo\Endpoint;
 class GetReviewCollection extends \ApiPlatform\Demo\Runtime\Client\BaseEndpoint implements \ApiPlatform\Demo\Runtime\Client\Endpoint
 {
     /**
-     * 
+     *
      *
      * @param array $queryParameters {
-     *     @var string $order[id] 
-     *     @var string $order[publicationDate] 
-     *     @var string $book 
-     *     @var array $book[] 
+     *     @var string $order[id]
+     *     @var string $order[publicationDate]
+     *     @var string $book
+     *     @var array $book[]
      *     @var int $page The collection page number
      * }
      */

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Endpoint/GetFoo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Endpoint/GetFoo.php
@@ -34,7 +34,7 @@ class GetFoo extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Base
         $optionsResolver->setDefined(array('testBoolean'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testBoolean', array('bool'));
+        $optionsResolver->addAllowedTypes('testBoolean', array('bool'));
         $optionsResolver->setNormalizer('testBoolean', \Closure::fromCallable(array(new \Jane\Component\OpenApi3\Tests\Expected\BooleanQueryResolver\BooleanCustomQueryResolver(), '__invoke')));
         return $optionsResolver;
     }

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Endpoint/ListPets.php
@@ -38,7 +38,7 @@ class ListPets extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Ba
         $optionsResolver->setDefined(array('limit'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('limit', array('int'));
+        $optionsResolver->addAllowedTypes('limit', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListArtifactsForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListArtifactsForRepo.php
@@ -45,8 +45,8 @@ class ActionsListArtifactsForRepo extends \Github\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListJobsForWorkflowRun.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListJobsForWorkflowRun.php
@@ -51,9 +51,9 @@ class ActionsListJobsForWorkflowRun extends \Github\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('filter', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('filter' => 'latest', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('filter', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('filter', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListOrgSecrets.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListOrgSecrets.php
@@ -42,8 +42,8 @@ class ActionsListOrgSecrets extends \Github\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListRepoSecrets.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListRepoSecrets.php
@@ -45,8 +45,8 @@ class ActionsListRepoSecrets extends \Github\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListRepoWorkflows.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListRepoWorkflows.php
@@ -45,8 +45,8 @@ class ActionsListRepoWorkflows extends \Github\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListSelfHostedRunnersForOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListSelfHostedRunnersForOrg.php
@@ -44,8 +44,8 @@ class ActionsListSelfHostedRunnersForOrg extends \Github\Runtime\Client\BaseEndp
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListSelfHostedRunnersForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListSelfHostedRunnersForRepo.php
@@ -45,8 +45,8 @@ class ActionsListSelfHostedRunnersForRepo extends \Github\Runtime\Client\BaseEnd
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListWorkflowRunArtifacts.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListWorkflowRunArtifacts.php
@@ -48,8 +48,8 @@ class ActionsListWorkflowRunArtifacts extends \Github\Runtime\Client\BaseEndpoin
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListWorkflowRuns.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListWorkflowRuns.php
@@ -54,12 +54,12 @@ class ActionsListWorkflowRuns extends \Github\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('actor', 'branch', 'event', 'status', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('actor', array('string'));
-        $optionsResolver->setAllowedTypes('branch', array('string'));
-        $optionsResolver->setAllowedTypes('event', array('string'));
-        $optionsResolver->setAllowedTypes('status', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('actor', array('string'));
+        $optionsResolver->addAllowedTypes('branch', array('string'));
+        $optionsResolver->addAllowedTypes('event', array('string'));
+        $optionsResolver->addAllowedTypes('status', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListWorkflowRunsForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActionsListWorkflowRunsForRepo.php
@@ -51,12 +51,12 @@ class ActionsListWorkflowRunsForRepo extends \Github\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('actor', 'branch', 'event', 'status', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('actor', array('string'));
-        $optionsResolver->setAllowedTypes('branch', array('string'));
-        $optionsResolver->setAllowedTypes('event', array('string'));
-        $optionsResolver->setAllowedTypes('status', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('actor', array('string'));
+        $optionsResolver->addAllowedTypes('branch', array('string'));
+        $optionsResolver->addAllowedTypes('event', array('string'));
+        $optionsResolver->addAllowedTypes('status', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListEventsForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListEventsForAuthenticatedUser.php
@@ -42,8 +42,8 @@ class ActivityListEventsForAuthenticatedUser extends \Github\Runtime\Client\Base
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListNotificationsForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListNotificationsForAuthenticatedUser.php
@@ -43,12 +43,12 @@ class ActivityListNotificationsForAuthenticatedUser extends \Github\Runtime\Clie
         $optionsResolver->setDefined(array('all', 'participating', 'since', 'before', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('all' => false, 'participating' => false, 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('all', array('bool'));
-        $optionsResolver->setAllowedTypes('participating', array('bool'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('before', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('all', array('bool'));
+        $optionsResolver->addAllowedTypes('participating', array('bool'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('before', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListOrgEventsForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListOrgEventsForAuthenticatedUser.php
@@ -45,8 +45,8 @@ class ActivityListOrgEventsForAuthenticatedUser extends \Github\Runtime\Client\B
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListPublicEvents.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListPublicEvents.php
@@ -39,8 +39,8 @@ class ActivityListPublicEvents extends \Github\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListPublicEventsForRepoNetwork.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListPublicEventsForRepoNetwork.php
@@ -45,8 +45,8 @@ class ActivityListPublicEventsForRepoNetwork extends \Github\Runtime\Client\Base
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListPublicEventsForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListPublicEventsForUser.php
@@ -42,8 +42,8 @@ class ActivityListPublicEventsForUser extends \Github\Runtime\Client\BaseEndpoin
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListPublicOrgEvents.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListPublicOrgEvents.php
@@ -42,8 +42,8 @@ class ActivityListPublicOrgEvents extends \Github\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListReceivedEventsForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListReceivedEventsForUser.php
@@ -42,8 +42,8 @@ class ActivityListReceivedEventsForUser extends \Github\Runtime\Client\BaseEndpo
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListReceivedPublicEventsForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListReceivedPublicEventsForUser.php
@@ -42,8 +42,8 @@ class ActivityListReceivedPublicEventsForUser extends \Github\Runtime\Client\Bas
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListRepoEvents.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListRepoEvents.php
@@ -45,8 +45,8 @@ class ActivityListRepoEvents extends \Github\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListRepoNotificationsForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListRepoNotificationsForAuthenticatedUser.php
@@ -49,12 +49,12 @@ class ActivityListRepoNotificationsForAuthenticatedUser extends \Github\Runtime\
         $optionsResolver->setDefined(array('all', 'participating', 'since', 'before', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('all' => false, 'participating' => false, 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('all', array('bool'));
-        $optionsResolver->setAllowedTypes('participating', array('bool'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('before', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('all', array('bool'));
+        $optionsResolver->addAllowedTypes('participating', array('bool'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('before', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListReposStarredByAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListReposStarredByAuthenticatedUser.php
@@ -43,10 +43,10 @@ class ActivityListReposStarredByAuthenticatedUser extends \Github\Runtime\Client
         $optionsResolver->setDefined(array('sort', 'direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sort' => 'created', 'direction' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListReposStarredByUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListReposStarredByUser.php
@@ -46,10 +46,10 @@ class ActivityListReposStarredByUser extends \Github\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('sort', 'direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sort' => 'created', 'direction' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListReposWatchedByUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListReposWatchedByUser.php
@@ -42,8 +42,8 @@ class ActivityListReposWatchedByUser extends \Github\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListStargazersForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListStargazersForRepo.php
@@ -47,8 +47,8 @@ class ActivityListStargazersForRepo extends \Github\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListWatchedReposForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListWatchedReposForAuthenticatedUser.php
@@ -39,8 +39,8 @@ class ActivityListWatchedReposForAuthenticatedUser extends \Github\Runtime\Clien
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListWatchersForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ActivityListWatchersForRepo.php
@@ -45,8 +45,8 @@ class ActivityListWatchersForRepo extends \Github\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListAccountsForPlan.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListAccountsForPlan.php
@@ -46,10 +46,10 @@ class AppsListAccountsForPlan extends \Github\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('sort', 'direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sort' => 'created', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListAccountsForPlanStubbed.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListAccountsForPlanStubbed.php
@@ -46,10 +46,10 @@ class AppsListAccountsForPlanStubbed extends \Github\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('sort', 'direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sort' => 'created', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListInstallationReposForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListInstallationReposForAuthenticatedUser.php
@@ -48,8 +48,8 @@ class AppsListInstallationReposForAuthenticatedUser extends \Github\Runtime\Clie
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListInstallations.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListInstallations.php
@@ -43,10 +43,10 @@ class AppsListInstallations extends \Github\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('per_page', 'page', 'since', 'outdated'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('outdated', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('outdated', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListInstallationsForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListInstallationsForAuthenticatedUser.php
@@ -45,8 +45,8 @@ class AppsListInstallationsForAuthenticatedUser extends \Github\Runtime\Client\B
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListPlans.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListPlans.php
@@ -41,8 +41,8 @@ class AppsListPlans extends \Github\Runtime\Client\BaseEndpoint implements \Gith
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListPlansStubbed.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListPlansStubbed.php
@@ -41,8 +41,8 @@ class AppsListPlansStubbed extends \Github\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListReposAccessibleToInstallation.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListReposAccessibleToInstallation.php
@@ -41,8 +41,8 @@ class AppsListReposAccessibleToInstallation extends \Github\Runtime\Client\BaseE
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListSubscriptionsForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListSubscriptionsForAuthenticatedUser.php
@@ -39,8 +39,8 @@ class AppsListSubscriptionsForAuthenticatedUser extends \Github\Runtime\Client\B
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListSubscriptionsForAuthenticatedUserStubbed.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/AppsListSubscriptionsForAuthenticatedUserStubbed.php
@@ -39,8 +39,8 @@ class AppsListSubscriptionsForAuthenticatedUserStubbed extends \Github\Runtime\C
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ChecksListAnnotations.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ChecksListAnnotations.php
@@ -48,8 +48,8 @@ class ChecksListAnnotations extends \Github\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ChecksListForRef.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ChecksListForRef.php
@@ -53,11 +53,11 @@ class ChecksListForRef extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('check_name', 'status', 'filter', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('filter' => 'latest', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('check_name', array('string'));
-        $optionsResolver->setAllowedTypes('status', array('string'));
-        $optionsResolver->setAllowedTypes('filter', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('check_name', array('string'));
+        $optionsResolver->addAllowedTypes('status', array('string'));
+        $optionsResolver->addAllowedTypes('filter', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ChecksListForSuite.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ChecksListForSuite.php
@@ -53,11 +53,11 @@ class ChecksListForSuite extends \Github\Runtime\Client\BaseEndpoint implements 
         $optionsResolver->setDefined(array('check_name', 'status', 'filter', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('filter' => 'latest', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('check_name', array('string'));
-        $optionsResolver->setAllowedTypes('status', array('string'));
-        $optionsResolver->setAllowedTypes('filter', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('check_name', array('string'));
+        $optionsResolver->addAllowedTypes('status', array('string'));
+        $optionsResolver->addAllowedTypes('filter', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ChecksListSuitesForRef.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ChecksListSuitesForRef.php
@@ -52,10 +52,10 @@ class ChecksListSuitesForRef extends \Github\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('app_id', 'check_name', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('app_id', array('int'));
-        $optionsResolver->setAllowedTypes('check_name', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('app_id', array('int'));
+        $optionsResolver->addAllowedTypes('check_name', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/CodeScanningListAlertsForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/CodeScanningListAlertsForRepo.php
@@ -45,8 +45,8 @@ class CodeScanningListAlertsForRepo extends \Github\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('state', 'ref'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('state' => 'open'));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('ref', array('string'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('ref', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsList.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsList.php
@@ -40,9 +40,9 @@ class GistsList extends \Github\Runtime\Client\BaseEndpoint implements \Github\R
         $optionsResolver->setDefined(array('since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListComments.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListComments.php
@@ -42,8 +42,8 @@ class GistsListComments extends \Github\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListCommits.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListCommits.php
@@ -42,8 +42,8 @@ class GistsListCommits extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListForUser.php
@@ -43,9 +43,9 @@ class GistsListForUser extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListForks.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListForks.php
@@ -42,8 +42,8 @@ class GistsListForks extends \Github\Runtime\Client\BaseEndpoint implements \Git
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListPublic.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListPublic.php
@@ -42,9 +42,9 @@ class GistsListPublic extends \Github\Runtime\Client\BaseEndpoint implements \Gi
         $optionsResolver->setDefined(array('since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListStarred.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GistsListStarred.php
@@ -40,9 +40,9 @@ class GistsListStarred extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GitGetTree.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GitGetTree.php
@@ -49,7 +49,7 @@ class GitGetTree extends \Github\Runtime\Client\BaseEndpoint implements \Github\
         $optionsResolver->setDefined(array('recursive'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('recursive', array('string'));
+        $optionsResolver->addAllowedTypes('recursive', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GitListMatchingRefs.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GitListMatchingRefs.php
@@ -54,8 +54,8 @@ class GitListMatchingRefs extends \Github\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesList.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesList.php
@@ -63,18 +63,18 @@ class IssuesList extends \Github\Runtime\Client\BaseEndpoint implements \Github\
         $optionsResolver->setDefined(array('filter', 'state', 'labels', 'sort', 'direction', 'since', 'collab', 'orgs', 'owned', 'pulls', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('filter' => 'assigned', 'state' => 'open', 'sort' => 'created', 'direction' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('filter', array('string'));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('labels', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('collab', array('bool'));
-        $optionsResolver->setAllowedTypes('orgs', array('bool'));
-        $optionsResolver->setAllowedTypes('owned', array('bool'));
-        $optionsResolver->setAllowedTypes('pulls', array('bool'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('filter', array('string'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('labels', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('collab', array('bool'));
+        $optionsResolver->addAllowedTypes('orgs', array('bool'));
+        $optionsResolver->addAllowedTypes('owned', array('bool'));
+        $optionsResolver->addAllowedTypes('pulls', array('bool'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListAssignees.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListAssignees.php
@@ -45,8 +45,8 @@ class IssuesListAssignees extends \Github\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListComments.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListComments.php
@@ -49,9 +49,9 @@ class IssuesListComments extends \Github\Runtime\Client\BaseEndpoint implements 
         $optionsResolver->setDefined(array('since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListCommentsForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListCommentsForRepo.php
@@ -48,11 +48,11 @@ class IssuesListCommentsForRepo extends \Github\Runtime\Client\BaseEndpoint impl
         $optionsResolver->setDefined(array('sort', 'direction', 'since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sort' => 'created', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListEvents.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListEvents.php
@@ -48,8 +48,8 @@ class IssuesListEvents extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListEventsForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListEventsForRepo.php
@@ -45,8 +45,8 @@ class IssuesListEventsForRepo extends \Github\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListEventsForTimeline.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListEventsForTimeline.php
@@ -48,8 +48,8 @@ class IssuesListEventsForTimeline extends \Github\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListForAuthenticatedUser.php
@@ -55,14 +55,14 @@ class IssuesListForAuthenticatedUser extends \Github\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('filter', 'state', 'labels', 'sort', 'direction', 'since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('filter' => 'assigned', 'state' => 'open', 'sort' => 'created', 'direction' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('filter', array('string'));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('labels', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('filter', array('string'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('labels', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListForOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListForOrg.php
@@ -58,14 +58,14 @@ class IssuesListForOrg extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('filter', 'state', 'labels', 'sort', 'direction', 'since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('filter' => 'assigned', 'state' => 'open', 'sort' => 'created', 'direction' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('filter', array('string'));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('labels', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('filter', array('string'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('labels', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListForRepo.php
@@ -59,17 +59,17 @@ class IssuesListForRepo extends \Github\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('milestone', 'state', 'assignee', 'creator', 'mentioned', 'labels', 'sort', 'direction', 'since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('state' => 'open', 'sort' => 'created', 'direction' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('milestone', array('string'));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('assignee', array('string'));
-        $optionsResolver->setAllowedTypes('creator', array('string'));
-        $optionsResolver->setAllowedTypes('mentioned', array('string'));
-        $optionsResolver->setAllowedTypes('labels', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('milestone', array('string'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('assignee', array('string'));
+        $optionsResolver->addAllowedTypes('creator', array('string'));
+        $optionsResolver->addAllowedTypes('mentioned', array('string'));
+        $optionsResolver->addAllowedTypes('labels', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListLabelsForMilestone.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListLabelsForMilestone.php
@@ -48,8 +48,8 @@ class IssuesListLabelsForMilestone extends \Github\Runtime\Client\BaseEndpoint i
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListLabelsForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListLabelsForRepo.php
@@ -45,8 +45,8 @@ class IssuesListLabelsForRepo extends \Github\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListLabelsOnIssue.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListLabelsOnIssue.php
@@ -48,8 +48,8 @@ class IssuesListLabelsOnIssue extends \Github\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListMilestones.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/IssuesListMilestones.php
@@ -48,11 +48,11 @@ class IssuesListMilestones extends \Github\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('state', 'sort', 'direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('state' => 'open', 'sort' => 'due_on', 'direction' => 'asc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/LicensesGetAllCommonlyUsed.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/LicensesGetAllCommonlyUsed.php
@@ -39,8 +39,8 @@ class LicensesGetAllCommonlyUsed extends \Github\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('featured', 'per_page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30));
-        $optionsResolver->setAllowedTypes('featured', array('bool'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('featured', array('bool'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MetaGetOctocat.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MetaGetOctocat.php
@@ -34,7 +34,7 @@ class MetaGetOctocat extends \Github\Runtime\Client\BaseEndpoint implements \Git
         $optionsResolver->setDefined(array('s'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('s', array('string'));
+        $optionsResolver->addAllowedTypes('s', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsGetCommitAuthors.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsGetCommitAuthors.php
@@ -46,7 +46,7 @@ class MigrationsGetCommitAuthors extends \Github\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('since'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsGetStatusForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsGetStatusForAuthenticatedUser.php
@@ -48,7 +48,7 @@ class MigrationsGetStatusForAuthenticatedUser extends \Github\Runtime\Client\Bas
         $optionsResolver->setDefined(array('exclude'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('exclude', array('array'));
+        $optionsResolver->addAllowedTypes('exclude', array('array'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsListForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsListForAuthenticatedUser.php
@@ -39,8 +39,8 @@ class MigrationsListForAuthenticatedUser extends \Github\Runtime\Client\BaseEndp
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsListForOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsListForOrg.php
@@ -42,8 +42,8 @@ class MigrationsListForOrg extends \Github\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsListReposForOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsListReposForOrg.php
@@ -45,8 +45,8 @@ class MigrationsListReposForOrg extends \Github\Runtime\Client\BaseEndpoint impl
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsListReposForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsListReposForUser.php
@@ -42,8 +42,8 @@ class MigrationsListReposForUser extends \Github\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OauthAuthorizationsListAuthorizations.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OauthAuthorizationsListAuthorizations.php
@@ -39,8 +39,8 @@ class OauthAuthorizationsListAuthorizations extends \Github\Runtime\Client\BaseE
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OauthAuthorizationsListGrants.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OauthAuthorizationsListGrants.php
@@ -41,8 +41,8 @@ class OauthAuthorizationsListGrants extends \Github\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsList.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsList.php
@@ -40,8 +40,8 @@ class OrgsList extends \Github\Runtime\Client\BaseEndpoint implements \Github\Ru
         $optionsResolver->setDefined(array('since', 'per_page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListAppInstallations.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListAppInstallations.php
@@ -42,8 +42,8 @@ class OrgsListAppInstallations extends \Github\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListForAuthenticatedUser.php
@@ -43,8 +43,8 @@ class OrgsListForAuthenticatedUser extends \Github\Runtime\Client\BaseEndpoint i
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListForUser.php
@@ -44,8 +44,8 @@ class OrgsListForUser extends \Github\Runtime\Client\BaseEndpoint implements \Gi
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListInvitationTeams.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListInvitationTeams.php
@@ -45,8 +45,8 @@ class OrgsListInvitationTeams extends \Github\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListMembers.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListMembers.php
@@ -49,10 +49,10 @@ class OrgsListMembers extends \Github\Runtime\Client\BaseEndpoint implements \Gi
         $optionsResolver->setDefined(array('filter', 'role', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('filter' => 'all', 'role' => 'all', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('filter', array('string'));
-        $optionsResolver->setAllowedTypes('role', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('filter', array('string'));
+        $optionsResolver->addAllowedTypes('role', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListMembershipsForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListMembershipsForAuthenticatedUser.php
@@ -40,9 +40,9 @@ class OrgsListMembershipsForAuthenticatedUser extends \Github\Runtime\Client\Bas
         $optionsResolver->setDefined(array('state', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListOutsideCollaborators.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListOutsideCollaborators.php
@@ -45,9 +45,9 @@ class OrgsListOutsideCollaborators extends \Github\Runtime\Client\BaseEndpoint i
         $optionsResolver->setDefined(array('filter', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('filter' => 'all', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('filter', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('filter', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListPendingInvitations.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListPendingInvitations.php
@@ -42,8 +42,8 @@ class OrgsListPendingInvitations extends \Github\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListPublicMembers.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListPublicMembers.php
@@ -42,8 +42,8 @@ class OrgsListPublicMembers extends \Github\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListWebhooks.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/OrgsListWebhooks.php
@@ -42,8 +42,8 @@ class OrgsListWebhooks extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListCards.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListCards.php
@@ -43,9 +43,9 @@ class ProjectsListCards extends \Github\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('archived_state', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('archived_state' => 'not_archived', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('archived_state', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('archived_state', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListCollaborators.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListCollaborators.php
@@ -46,9 +46,9 @@ class ProjectsListCollaborators extends \Github\Runtime\Client\BaseEndpoint impl
         $optionsResolver->setDefined(array('affiliation', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('affiliation' => 'all', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('affiliation', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('affiliation', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListColumns.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListColumns.php
@@ -42,8 +42,8 @@ class ProjectsListColumns extends \Github\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListForOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListForOrg.php
@@ -43,9 +43,9 @@ class ProjectsListForOrg extends \Github\Runtime\Client\BaseEndpoint implements 
         $optionsResolver->setDefined(array('state', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('state' => 'open', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListForRepo.php
@@ -46,9 +46,9 @@ class ProjectsListForRepo extends \Github\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('state', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('state' => 'open', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsListForUser.php
@@ -43,9 +43,9 @@ class ProjectsListForUser extends \Github\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('state', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('state' => 'open', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsList.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsList.php
@@ -50,13 +50,13 @@ class PullsList extends \Github\Runtime\Client\BaseEndpoint implements \Github\R
         $optionsResolver->setDefined(array('state', 'head', 'base', 'sort', 'direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('state' => 'open', 'sort' => 'created', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('state', array('string'));
-        $optionsResolver->setAllowedTypes('head', array('string'));
-        $optionsResolver->setAllowedTypes('base', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('state', array('string'));
+        $optionsResolver->addAllowedTypes('head', array('string'));
+        $optionsResolver->addAllowedTypes('base', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListCommentsForReview.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListCommentsForReview.php
@@ -51,8 +51,8 @@ class PullsListCommentsForReview extends \Github\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListCommits.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListCommits.php
@@ -48,8 +48,8 @@ class PullsListCommits extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListFiles.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListFiles.php
@@ -48,8 +48,8 @@ class PullsListFiles extends \Github\Runtime\Client\BaseEndpoint implements \Git
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListRequestedReviewers.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListRequestedReviewers.php
@@ -48,8 +48,8 @@ class PullsListRequestedReviewers extends \Github\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListReviewComments.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListReviewComments.php
@@ -71,11 +71,11 @@ class PullsListReviewComments extends \Github\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('sort', 'direction', 'since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sort' => 'created', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListReviewCommentsForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListReviewCommentsForRepo.php
@@ -68,11 +68,11 @@ class PullsListReviewCommentsForRepo extends \Github\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('sort', 'direction', 'since', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sort' => 'created', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListReviews.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/PullsListReviews.php
@@ -48,8 +48,8 @@ class PullsListReviews extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForCommitComment.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForCommitComment.php
@@ -49,9 +49,9 @@ class ReactionsListForCommitComment extends \Github\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('content', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('content', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('content', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForIssue.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForIssue.php
@@ -49,9 +49,9 @@ class ReactionsListForIssue extends \Github\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('content', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('content', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('content', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForIssueComment.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForIssueComment.php
@@ -49,9 +49,9 @@ class ReactionsListForIssueComment extends \Github\Runtime\Client\BaseEndpoint i
         $optionsResolver->setDefined(array('content', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('content', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('content', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForPullRequestReviewComment.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForPullRequestReviewComment.php
@@ -49,9 +49,9 @@ class ReactionsListForPullRequestReviewComment extends \Github\Runtime\Client\Ba
         $optionsResolver->setDefined(array('content', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('content', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('content', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForTeamDiscussionCommentInOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForTeamDiscussionCommentInOrg.php
@@ -53,9 +53,9 @@ class ReactionsListForTeamDiscussionCommentInOrg extends \Github\Runtime\Client\
         $optionsResolver->setDefined(array('content', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('content', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('content', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForTeamDiscussionCommentLegacy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForTeamDiscussionCommentLegacy.php
@@ -51,9 +51,9 @@ class ReactionsListForTeamDiscussionCommentLegacy extends \Github\Runtime\Client
         $optionsResolver->setDefined(array('content', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('content', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('content', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForTeamDiscussionInOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForTeamDiscussionInOrg.php
@@ -50,9 +50,9 @@ class ReactionsListForTeamDiscussionInOrg extends \Github\Runtime\Client\BaseEnd
         $optionsResolver->setDefined(array('content', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('content', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('content', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForTeamDiscussionLegacy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReactionsListForTeamDiscussionLegacy.php
@@ -48,9 +48,9 @@ class ReactionsListForTeamDiscussionLegacy extends \Github\Runtime\Client\BaseEn
         $optionsResolver->setDefined(array('content', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('content', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('content', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetClones.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetClones.php
@@ -44,7 +44,7 @@ class ReposGetClones extends \Github\Runtime\Client\BaseEndpoint implements \Git
         $optionsResolver->setDefined(array('per'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per' => 'day'));
-        $optionsResolver->setAllowedTypes('per', array('string'));
+        $optionsResolver->addAllowedTypes('per', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetContent.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetContent.php
@@ -78,7 +78,7 @@ class ReposGetContent extends \Github\Runtime\Client\BaseEndpoint implements \Gi
         $optionsResolver->setDefined(array('ref'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ref', array('string'));
+        $optionsResolver->addAllowedTypes('ref', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetReadme.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetReadme.php
@@ -46,7 +46,7 @@ class ReposGetReadme extends \Github\Runtime\Client\BaseEndpoint implements \Git
         $optionsResolver->setDefined(array('ref'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ref', array('string'));
+        $optionsResolver->addAllowedTypes('ref', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetViews.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetViews.php
@@ -44,7 +44,7 @@ class ReposGetViews extends \Github\Runtime\Client\BaseEndpoint implements \Gith
         $optionsResolver->setDefined(array('per'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per' => 'day'));
-        $optionsResolver->setAllowedTypes('per', array('string'));
+        $optionsResolver->addAllowedTypes('per', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListBranches.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListBranches.php
@@ -46,9 +46,9 @@ class ReposListBranches extends \Github\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('protected', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('protected', array('bool'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('protected', array('bool'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListCollaborators.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListCollaborators.php
@@ -51,9 +51,9 @@ class ReposListCollaborators extends \Github\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('affiliation', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('affiliation' => 'all', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('affiliation', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('affiliation', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListCommentsForCommit.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListCommentsForCommit.php
@@ -48,8 +48,8 @@ class ReposListCommentsForCommit extends \Github\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListCommitCommentsForRepo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListCommitCommentsForRepo.php
@@ -47,8 +47,8 @@ class ReposListCommitCommentsForRepo extends \Github\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListCommitStatusesForRef.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListCommitStatusesForRef.php
@@ -50,8 +50,8 @@ class ReposListCommitStatusesForRef extends \Github\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListCommits.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListCommits.php
@@ -70,13 +70,13 @@ class ReposListCommits extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('sha', 'path', 'author', 'since', 'until', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('sha', array('string'));
-        $optionsResolver->setAllowedTypes('path', array('string'));
-        $optionsResolver->setAllowedTypes('author', array('string'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('until', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sha', array('string'));
+        $optionsResolver->addAllowedTypes('path', array('string'));
+        $optionsResolver->addAllowedTypes('author', array('string'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('until', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListContributors.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListContributors.php
@@ -48,9 +48,9 @@ class ReposListContributors extends \Github\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('anon', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('anon', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('anon', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListDeployKeys.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListDeployKeys.php
@@ -45,8 +45,8 @@ class ReposListDeployKeys extends \Github\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListDeploymentStatuses.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListDeploymentStatuses.php
@@ -48,8 +48,8 @@ class ReposListDeploymentStatuses extends \Github\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListDeployments.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListDeployments.php
@@ -49,12 +49,12 @@ class ReposListDeployments extends \Github\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('sha', 'ref', 'task', 'environment', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sha' => 'none', 'ref' => 'none', 'task' => 'none', 'environment' => 'none', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('sha', array('string'));
-        $optionsResolver->setAllowedTypes('ref', array('string'));
-        $optionsResolver->setAllowedTypes('task', array('string'));
-        $optionsResolver->setAllowedTypes('environment', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sha', array('string'));
+        $optionsResolver->addAllowedTypes('ref', array('string'));
+        $optionsResolver->addAllowedTypes('task', array('string'));
+        $optionsResolver->addAllowedTypes('environment', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListForAuthenticatedUser.php
@@ -53,15 +53,15 @@ class ReposListForAuthenticatedUser extends \Github\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('visibility', 'affiliation', 'type', 'sort', 'direction', 'per_page', 'page', 'since', 'before'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('visibility' => 'all', 'affiliation' => 'owner,collaborator,organization_member', 'type' => 'all', 'sort' => 'full_name', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('visibility', array('string'));
-        $optionsResolver->setAllowedTypes('affiliation', array('string'));
-        $optionsResolver->setAllowedTypes('type', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('before', array('string'));
+        $optionsResolver->addAllowedTypes('visibility', array('string'));
+        $optionsResolver->addAllowedTypes('affiliation', array('string'));
+        $optionsResolver->addAllowedTypes('type', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('before', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListForOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListForOrg.php
@@ -45,11 +45,11 @@ class ReposListForOrg extends \Github\Runtime\Client\BaseEndpoint implements \Gi
         $optionsResolver->setDefined(array('type', 'sort', 'direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sort' => 'created', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('type', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('type', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListForUser.php
@@ -45,11 +45,11 @@ class ReposListForUser extends \Github\Runtime\Client\BaseEndpoint implements \G
         $optionsResolver->setDefined(array('type', 'sort', 'direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('type' => 'owner', 'sort' => 'full_name', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('type', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('type', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListForks.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListForks.php
@@ -46,9 +46,9 @@ class ReposListForks extends \Github\Runtime\Client\BaseEndpoint implements \Git
         $optionsResolver->setDefined(array('sort', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sort' => 'newest', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListInvitations.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListInvitations.php
@@ -45,8 +45,8 @@ class ReposListInvitations extends \Github\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListInvitationsForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListInvitationsForAuthenticatedUser.php
@@ -39,8 +39,8 @@ class ReposListInvitationsForAuthenticatedUser extends \Github\Runtime\Client\Ba
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListPagesBuilds.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListPagesBuilds.php
@@ -45,8 +45,8 @@ class ReposListPagesBuilds extends \Github\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListPublic.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListPublic.php
@@ -42,9 +42,9 @@ class ReposListPublic extends \Github\Runtime\Client\BaseEndpoint implements \Gi
         $optionsResolver->setDefined(array('per_page', 'since', 'visibility'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('visibility', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('visibility', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListPullRequestsAssociatedWithCommit.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListPullRequestsAssociatedWithCommit.php
@@ -48,8 +48,8 @@ class ReposListPullRequestsAssociatedWithCommit extends \Github\Runtime\Client\B
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListReleaseAssets.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListReleaseAssets.php
@@ -48,8 +48,8 @@ class ReposListReleaseAssets extends \Github\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListReleases.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListReleases.php
@@ -47,8 +47,8 @@ class ReposListReleases extends \Github\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListTags.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListTags.php
@@ -45,8 +45,8 @@ class ReposListTags extends \Github\Runtime\Client\BaseEndpoint implements \Gith
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListTeams.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListTeams.php
@@ -45,8 +45,8 @@ class ReposListTeams extends \Github\Runtime\Client\BaseEndpoint implements \Git
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListWebhooks.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposListWebhooks.php
@@ -45,8 +45,8 @@ class ReposListWebhooks extends \Github\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposUploadReleaseAsset.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposUploadReleaseAsset.php
@@ -70,8 +70,8 @@ class ReposUploadReleaseAsset extends \Github\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('name', 'label'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('name', array('string'));
-        $optionsResolver->setAllowedTypes('label', array('string'));
+        $optionsResolver->addAllowedTypes('name', array('string'));
+        $optionsResolver->addAllowedTypes('label', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ScimListProvisionedIdentities.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ScimListProvisionedIdentities.php
@@ -64,9 +64,9 @@ class ScimListProvisionedIdentities extends \Github\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('startIndex', 'count', 'filter'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('startIndex', array('int'));
-        $optionsResolver->setAllowedTypes('count', array('int'));
-        $optionsResolver->setAllowedTypes('filter', array('string'));
+        $optionsResolver->addAllowedTypes('startIndex', array('int'));
+        $optionsResolver->addAllowedTypes('count', array('int'));
+        $optionsResolver->addAllowedTypes('filter', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchCode.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchCode.php
@@ -59,11 +59,11 @@ class SearchCode extends \Github\Runtime\Client\BaseEndpoint implements \Github\
         $optionsResolver->setDefined(array('q', 'sort', 'order', 'per_page', 'page'));
         $optionsResolver->setRequired(array('q'));
         $optionsResolver->setDefaults(array('order' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('q', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('order', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('q', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('order', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchCommits.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchCommits.php
@@ -49,11 +49,11 @@ class SearchCommits extends \Github\Runtime\Client\BaseEndpoint implements \Gith
         $optionsResolver->setDefined(array('q', 'sort', 'order', 'per_page', 'page'));
         $optionsResolver->setRequired(array('q'));
         $optionsResolver->setDefaults(array('order' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('q', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('order', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('q', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('order', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchIssuesAndPullRequests.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchIssuesAndPullRequests.php
@@ -51,11 +51,11 @@ class SearchIssuesAndPullRequests extends \Github\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('q', 'sort', 'order', 'per_page', 'page'));
         $optionsResolver->setRequired(array('q'));
         $optionsResolver->setDefaults(array('order' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('q', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('order', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('q', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('order', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchLabels.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchLabels.php
@@ -49,10 +49,10 @@ class SearchLabels extends \Github\Runtime\Client\BaseEndpoint implements \Githu
         $optionsResolver->setDefined(array('repository_id', 'q', 'sort', 'order'));
         $optionsResolver->setRequired(array('repository_id', 'q'));
         $optionsResolver->setDefaults(array('order' => 'desc'));
-        $optionsResolver->setAllowedTypes('repository_id', array('int'));
-        $optionsResolver->setAllowedTypes('q', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('order', array('string'));
+        $optionsResolver->addAllowedTypes('repository_id', array('int'));
+        $optionsResolver->addAllowedTypes('q', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('order', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchRepos.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchRepos.php
@@ -54,11 +54,11 @@ class SearchRepos extends \Github\Runtime\Client\BaseEndpoint implements \Github
         $optionsResolver->setDefined(array('q', 'sort', 'order', 'per_page', 'page'));
         $optionsResolver->setRequired(array('q'));
         $optionsResolver->setDefaults(array('order' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('q', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('order', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('q', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('order', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchTopics.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchTopics.php
@@ -46,7 +46,7 @@ class SearchTopics extends \Github\Runtime\Client\BaseEndpoint implements \Githu
         $optionsResolver->setDefined(array('q'));
         $optionsResolver->setRequired(array('q'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('q', array('string'));
+        $optionsResolver->addAllowedTypes('q', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchUsers.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/SearchUsers.php
@@ -50,11 +50,11 @@ class SearchUsers extends \Github\Runtime\Client\BaseEndpoint implements \Github
         $optionsResolver->setDefined(array('q', 'sort', 'order', 'per_page', 'page'));
         $optionsResolver->setRequired(array('q'));
         $optionsResolver->setDefaults(array('order' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('q', array('string'));
-        $optionsResolver->setAllowedTypes('sort', array('string'));
-        $optionsResolver->setAllowedTypes('order', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('q', array('string'));
+        $optionsResolver->addAllowedTypes('sort', array('string'));
+        $optionsResolver->addAllowedTypes('order', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsList.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsList.php
@@ -42,8 +42,8 @@ class TeamsList extends \Github\Runtime\Client\BaseEndpoint implements \Github\R
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListChildInOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListChildInOrg.php
@@ -46,8 +46,8 @@ class TeamsListChildInOrg extends \Github\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListChildLegacy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListChildLegacy.php
@@ -42,8 +42,8 @@ class TeamsListChildLegacy extends \Github\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListDiscussionCommentsInOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListDiscussionCommentsInOrg.php
@@ -50,9 +50,9 @@ class TeamsListDiscussionCommentsInOrg extends \Github\Runtime\Client\BaseEndpoi
         $optionsResolver->setDefined(array('direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('direction' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListDiscussionCommentsLegacy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListDiscussionCommentsLegacy.php
@@ -48,9 +48,9 @@ class TeamsListDiscussionCommentsLegacy extends \Github\Runtime\Client\BaseEndpo
         $optionsResolver->setDefined(array('direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('direction' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListDiscussionsInOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListDiscussionsInOrg.php
@@ -47,9 +47,9 @@ class TeamsListDiscussionsInOrg extends \Github\Runtime\Client\BaseEndpoint impl
         $optionsResolver->setDefined(array('direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('direction' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListDiscussionsLegacy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListDiscussionsLegacy.php
@@ -45,9 +45,9 @@ class TeamsListDiscussionsLegacy extends \Github\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('direction', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('direction' => 'desc', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('direction', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('direction', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListForAuthenticatedUser.php
@@ -39,8 +39,8 @@ class TeamsListForAuthenticatedUser extends \Github\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListIdpGroupsForOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListIdpGroupsForOrg.php
@@ -46,8 +46,8 @@ class TeamsListIdpGroupsForOrg extends \Github\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListMembersInOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListMembersInOrg.php
@@ -51,9 +51,9 @@ class TeamsListMembersInOrg extends \Github\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('role', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('role' => 'all', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('role', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('role', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListMembersLegacy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListMembersLegacy.php
@@ -48,9 +48,9 @@ class TeamsListMembersLegacy extends \Github\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('role', 'per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('role' => 'all', 'per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('role', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('role', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListPendingInvitationsInOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListPendingInvitationsInOrg.php
@@ -46,8 +46,8 @@ class TeamsListPendingInvitationsInOrg extends \Github\Runtime\Client\BaseEndpoi
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListPendingInvitationsLegacy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListPendingInvitationsLegacy.php
@@ -44,8 +44,8 @@ class TeamsListPendingInvitationsLegacy extends \Github\Runtime\Client\BaseEndpo
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListProjectsInOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListProjectsInOrg.php
@@ -46,8 +46,8 @@ class TeamsListProjectsInOrg extends \Github\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListProjectsLegacy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListProjectsLegacy.php
@@ -44,8 +44,8 @@ class TeamsListProjectsLegacy extends \Github\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListReposInOrg.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListReposInOrg.php
@@ -46,8 +46,8 @@ class TeamsListReposInOrg extends \Github\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListReposLegacy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/TeamsListReposLegacy.php
@@ -42,8 +42,8 @@ class TeamsListReposLegacy extends \Github\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersGetContextForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersGetContextForUser.php
@@ -49,8 +49,8 @@ class UsersGetContextForUser extends \Github\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('subject_type', 'subject_id'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('subject_type', array('string'));
-        $optionsResolver->setAllowedTypes('subject_id', array('string'));
+        $optionsResolver->addAllowedTypes('subject_type', array('string'));
+        $optionsResolver->addAllowedTypes('subject_id', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersList.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersList.php
@@ -41,8 +41,8 @@ class UsersList extends \Github\Runtime\Client\BaseEndpoint implements \Github\R
         $optionsResolver->setDefined(array('since', 'per_page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30));
-        $optionsResolver->setAllowedTypes('since', array('string'));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('since', array('string'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListEmailsForAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListEmailsForAuthenticated.php
@@ -39,8 +39,8 @@ class UsersListEmailsForAuthenticated extends \Github\Runtime\Client\BaseEndpoin
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListFollowedByAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListFollowedByAuthenticated.php
@@ -39,8 +39,8 @@ class UsersListFollowedByAuthenticated extends \Github\Runtime\Client\BaseEndpoi
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListFollowersForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListFollowersForAuthenticatedUser.php
@@ -39,8 +39,8 @@ class UsersListFollowersForAuthenticatedUser extends \Github\Runtime\Client\Base
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListFollowersForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListFollowersForUser.php
@@ -42,8 +42,8 @@ class UsersListFollowersForUser extends \Github\Runtime\Client\BaseEndpoint impl
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListFollowingForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListFollowingForUser.php
@@ -42,8 +42,8 @@ class UsersListFollowingForUser extends \Github\Runtime\Client\BaseEndpoint impl
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListGpgKeysForAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListGpgKeysForAuthenticated.php
@@ -39,8 +39,8 @@ class UsersListGpgKeysForAuthenticated extends \Github\Runtime\Client\BaseEndpoi
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListGpgKeysForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListGpgKeysForUser.php
@@ -42,8 +42,8 @@ class UsersListGpgKeysForUser extends \Github\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListPublicEmailsForAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListPublicEmailsForAuthenticated.php
@@ -39,8 +39,8 @@ class UsersListPublicEmailsForAuthenticated extends \Github\Runtime\Client\BaseE
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListPublicKeysForUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListPublicKeysForUser.php
@@ -42,8 +42,8 @@ class UsersListPublicKeysForUser extends \Github\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListPublicSshKeysForAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListPublicSshKeysForAuthenticated.php
@@ -39,8 +39,8 @@ class UsersListPublicSshKeysForAuthenticated extends \Github\Runtime\Client\Base
         $optionsResolver->setDefined(array('per_page', 'page'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('per_page' => 30, 'page' => 1));
-        $optionsResolver->setAllowedTypes('per_page', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('per_page', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Endpoint/GetUsers.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Endpoint/GetUsers.php
@@ -38,7 +38,7 @@ class GetUsers extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Ba
         $optionsResolver->setDefined(array('userState'));
         $optionsResolver->setRequired(array('userState'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('userState', array('string'));
+        $optionsResolver->addAllowedTypes('userState', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/AllEventRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/AllEventRules.php
@@ -38,7 +38,7 @@ class AllEventRules extends \CreditSafe\API\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/BankMatch.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/BankMatch.php
@@ -47,11 +47,11 @@ class BankMatch extends \CreditSafe\API\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('checkType', 'companyId', 'sortCode', 'accountNumber', 'iban', 'vatNumber'));
         $optionsResolver->setRequired(array('checkType', 'companyId'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('companyId', array('string'));
-        $optionsResolver->setAllowedTypes('sortCode', array('string'));
-        $optionsResolver->setAllowedTypes('accountNumber', array('string'));
-        $optionsResolver->setAllowedTypes('iban', array('string'));
-        $optionsResolver->setAllowedTypes('vatNumber', array('string'));
+        $optionsResolver->addAllowedTypes('companyId', array('string'));
+        $optionsResolver->addAllowedTypes('sortCode', array('string'));
+        $optionsResolver->addAllowedTypes('accountNumber', array('string'));
+        $optionsResolver->addAllowedTypes('iban', array('string'));
+        $optionsResolver->addAllowedTypes('vatNumber', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -60,7 +60,7 @@ class BankMatch extends \CreditSafe\API\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ClearCompaniesFromAPortfolio.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ClearCompaniesFromAPortfolio.php
@@ -50,7 +50,7 @@ class ClearCompaniesFromAPortfolio extends \CreditSafe\API\Runtime\Client\BaseEn
         $optionsResolver->setDefined(array('clearAll'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('clearAll' => false));
-        $optionsResolver->setAllowedTypes('clearAll', array('bool'));
+        $optionsResolver->addAllowedTypes('clearAll', array('bool'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -59,7 +59,7 @@ class ClearCompaniesFromAPortfolio extends \CreditSafe\API\Runtime\Client\BaseEn
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyComplianceSearch.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyComplianceSearch.php
@@ -52,14 +52,14 @@ class CompanyComplianceSearch extends \CreditSafe\API\Runtime\Client\BaseEndpoin
         $optionsResolver->setDefined(array('countries', 'name', 'street', 'houseNo', 'city', 'postCode', 'province', 'phoneNo'));
         $optionsResolver->setRequired(array('name'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('countries', array('string'));
-        $optionsResolver->setAllowedTypes('name', array('string'));
-        $optionsResolver->setAllowedTypes('street', array('string'));
-        $optionsResolver->setAllowedTypes('houseNo', array('string'));
-        $optionsResolver->setAllowedTypes('city', array('string'));
-        $optionsResolver->setAllowedTypes('postCode', array('string'));
-        $optionsResolver->setAllowedTypes('province', array('string'));
-        $optionsResolver->setAllowedTypes('phoneNo', array('string'));
+        $optionsResolver->addAllowedTypes('countries', array('string'));
+        $optionsResolver->addAllowedTypes('name', array('string'));
+        $optionsResolver->addAllowedTypes('street', array('string'));
+        $optionsResolver->addAllowedTypes('houseNo', array('string'));
+        $optionsResolver->addAllowedTypes('city', array('string'));
+        $optionsResolver->addAllowedTypes('postCode', array('string'));
+        $optionsResolver->addAllowedTypes('province', array('string'));
+        $optionsResolver->addAllowedTypes('phoneNo', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -68,7 +68,7 @@ class CompanyComplianceSearch extends \CreditSafe\API\Runtime\Client\BaseEndpoin
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyComplianceSearchCriteria.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyComplianceSearchCriteria.php
@@ -38,7 +38,7 @@ class CompanyComplianceSearchCriteria extends \CreditSafe\API\Runtime\Client\Bas
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyCreditReport.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyCreditReport.php
@@ -48,10 +48,10 @@ class CompanyCreditReport extends \CreditSafe\API\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('language', 'template', 'customData', 'callRef'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('language' => 'en', 'template' => 'full'));
-        $optionsResolver->setAllowedTypes('language', array('string'));
-        $optionsResolver->setAllowedTypes('template', array('string'));
-        $optionsResolver->setAllowedTypes('customData', array('string'));
-        $optionsResolver->setAllowedTypes('callRef', array('string'));
+        $optionsResolver->addAllowedTypes('language', array('string'));
+        $optionsResolver->addAllowedTypes('template', array('string'));
+        $optionsResolver->addAllowedTypes('customData', array('string'));
+        $optionsResolver->addAllowedTypes('callRef', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -60,7 +60,7 @@ class CompanyCreditReport extends \CreditSafe\API\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyEvents.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyEvents.php
@@ -48,10 +48,10 @@ class CompanyEvents extends \CreditSafe\API\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('startDate', 'endDate', 'page', 'pageSize'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('page' => 0, 'pageSize' => 50));
-        $optionsResolver->setAllowedTypes('startDate', array('string'));
-        $optionsResolver->setAllowedTypes('endDate', array('string'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('pageSize', array('int'));
+        $optionsResolver->addAllowedTypes('startDate', array('string'));
+        $optionsResolver->addAllowedTypes('endDate', array('string'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('pageSize', array('int'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -60,7 +60,7 @@ class CompanyEvents extends \CreditSafe\API\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyImage.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyImage.php
@@ -41,7 +41,7 @@ class CompanyImage extends \CreditSafe\API\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyImageDocuments.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyImageDocuments.php
@@ -44,9 +44,9 @@ class CompanyImageDocuments extends \CreditSafe\API\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('Id', 'olderThan', 'newerThan'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Id', array('string'));
-        $optionsResolver->setAllowedTypes('olderThan', array('string'));
-        $optionsResolver->setAllowedTypes('newerThan', array('string'));
+        $optionsResolver->addAllowedTypes('Id', array('string'));
+        $optionsResolver->addAllowedTypes('olderThan', array('string'));
+        $optionsResolver->addAllowedTypes('newerThan', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -55,7 +55,7 @@ class CompanyImageDocuments extends \CreditSafe\API\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyReportJSONSchema.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanyReportJSONSchema.php
@@ -46,8 +46,8 @@ class CompanyReportJSONSchema extends \CreditSafe\API\Runtime\Client\BaseEndpoin
         $optionsResolver->setDefined(array('section', 'template'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('section', array('string'));
-        $optionsResolver->setAllowedTypes('template', array('string'));
+        $optionsResolver->addAllowedTypes('section', array('string'));
+        $optionsResolver->addAllowedTypes('template', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -56,7 +56,7 @@ class CompanyReportJSONSchema extends \CreditSafe\API\Runtime\Client\BaseEndpoin
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanySearch.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanySearch.php
@@ -64,29 +64,29 @@ class CompanySearch extends \CreditSafe\API\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('countries', 'language', 'id', 'safeNo', 'regNo', 'vatNo', 'name', 'tradeName', 'acronym', 'exact', 'address', 'street', 'houseNo', 'city', 'postCode', 'province', 'phone', 'officeType', 'status', 'type', 'page', 'pageSize', 'callRef'));
         $optionsResolver->setRequired(array('countries'));
         $optionsResolver->setDefaults(array('language' => 'en'));
-        $optionsResolver->setAllowedTypes('countries', array('string'));
-        $optionsResolver->setAllowedTypes('language', array('string'));
-        $optionsResolver->setAllowedTypes('id', array('string'));
-        $optionsResolver->setAllowedTypes('safeNo', array('string'));
-        $optionsResolver->setAllowedTypes('regNo', array('string'));
-        $optionsResolver->setAllowedTypes('vatNo', array('string'));
-        $optionsResolver->setAllowedTypes('name', array('string'));
-        $optionsResolver->setAllowedTypes('tradeName', array('string'));
-        $optionsResolver->setAllowedTypes('acronym', array('string'));
-        $optionsResolver->setAllowedTypes('exact', array('bool'));
-        $optionsResolver->setAllowedTypes('address', array('string'));
-        $optionsResolver->setAllowedTypes('street', array('string'));
-        $optionsResolver->setAllowedTypes('houseNo', array('string'));
-        $optionsResolver->setAllowedTypes('city', array('string'));
-        $optionsResolver->setAllowedTypes('postCode', array('string'));
-        $optionsResolver->setAllowedTypes('province', array('string'));
-        $optionsResolver->setAllowedTypes('phone', array('string'));
-        $optionsResolver->setAllowedTypes('officeType', array('string'));
-        $optionsResolver->setAllowedTypes('status', array('string'));
-        $optionsResolver->setAllowedTypes('type', array('string'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('pageSize', array('int'));
-        $optionsResolver->setAllowedTypes('callRef', array('string'));
+        $optionsResolver->addAllowedTypes('countries', array('string'));
+        $optionsResolver->addAllowedTypes('language', array('string'));
+        $optionsResolver->addAllowedTypes('id', array('string'));
+        $optionsResolver->addAllowedTypes('safeNo', array('string'));
+        $optionsResolver->addAllowedTypes('regNo', array('string'));
+        $optionsResolver->addAllowedTypes('vatNo', array('string'));
+        $optionsResolver->addAllowedTypes('name', array('string'));
+        $optionsResolver->addAllowedTypes('tradeName', array('string'));
+        $optionsResolver->addAllowedTypes('acronym', array('string'));
+        $optionsResolver->addAllowedTypes('exact', array('bool'));
+        $optionsResolver->addAllowedTypes('address', array('string'));
+        $optionsResolver->addAllowedTypes('street', array('string'));
+        $optionsResolver->addAllowedTypes('houseNo', array('string'));
+        $optionsResolver->addAllowedTypes('city', array('string'));
+        $optionsResolver->addAllowedTypes('postCode', array('string'));
+        $optionsResolver->addAllowedTypes('province', array('string'));
+        $optionsResolver->addAllowedTypes('phone', array('string'));
+        $optionsResolver->addAllowedTypes('officeType', array('string'));
+        $optionsResolver->addAllowedTypes('status', array('string'));
+        $optionsResolver->addAllowedTypes('type', array('string'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('pageSize', array('int'));
+        $optionsResolver->addAllowedTypes('callRef', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -95,7 +95,7 @@ class CompanySearch extends \CreditSafe\API\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanySearchCriteria.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CompanySearchCriteria.php
@@ -42,7 +42,7 @@ class CompanySearchCriteria extends \CreditSafe\API\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('countries'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('countries', array('string'));
+        $optionsResolver->addAllowedTypes('countries', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -51,7 +51,7 @@ class CompanySearchCriteria extends \CreditSafe\API\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CopyCompaniesFromOneToAnotherPortfolioS.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CopyCompaniesFromOneToAnotherPortfolioS.php
@@ -50,7 +50,7 @@ class CopyCompaniesFromOneToAnotherPortfolioS extends \CreditSafe\API\Runtime\Cl
         $optionsResolver->setDefined(array('copyAll'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('copyAll' => false));
-        $optionsResolver->setAllowedTypes('copyAll', array('bool'));
+        $optionsResolver->addAllowedTypes('copyAll', array('bool'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -59,7 +59,7 @@ class CopyCompaniesFromOneToAnotherPortfolioS extends \CreditSafe\API\Runtime\Cl
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CountriesInSubscription.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CountriesInSubscription.php
@@ -38,7 +38,7 @@ class CountriesInSubscription extends \CreditSafe\API\Runtime\Client\BaseEndpoin
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CreateMonitoringPortfolio.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CreateMonitoringPortfolio.php
@@ -43,7 +43,7 @@ class CreateMonitoringPortfolio extends \CreditSafe\API\Runtime\Client\BaseEndpo
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CustomReportParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/CustomReportParameters.php
@@ -45,7 +45,7 @@ class CustomReportParameters extends \CreditSafe\API\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('template'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('template' => 'full'));
-        $optionsResolver->setAllowedTypes('template', array('string'));
+        $optionsResolver->addAllowedTypes('template', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -54,7 +54,7 @@ class CustomReportParameters extends \CreditSafe\API\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/DeleteMonitoringPortfolioByPortfolioId.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/DeleteMonitoringPortfolioByPortfolioId.php
@@ -41,7 +41,7 @@ class DeleteMonitoringPortfolioByPortfolioId extends \CreditSafe\API\Runtime\Cli
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/DeleteMonitoringPortfoliosByPortfolioIdCompanyById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/DeleteMonitoringPortfoliosByPortfolioIdCompanyById.php
@@ -44,7 +44,7 @@ class DeleteMonitoringPortfoliosByPortfolioIdCompanyById extends \CreditSafe\API
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/DeletePendingFreshInvesitgation.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/DeletePendingFreshInvesitgation.php
@@ -41,7 +41,7 @@ class DeletePendingFreshInvesitgation extends \CreditSafe\API\Runtime\Client\Bas
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/DirectorReport.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/DirectorReport.php
@@ -46,8 +46,8 @@ class DirectorReport extends \CreditSafe\API\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('language', 'callRef'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('language' => 'en'));
-        $optionsResolver->setAllowedTypes('language', array('string'));
-        $optionsResolver->setAllowedTypes('callRef', array('string'));
+        $optionsResolver->addAllowedTypes('language', array('string'));
+        $optionsResolver->addAllowedTypes('callRef', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -56,7 +56,7 @@ class DirectorReport extends \CreditSafe\API\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/EditPendingFreshInvestigation.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/EditPendingFreshInvestigation.php
@@ -41,7 +41,7 @@ class EditPendingFreshInvestigation extends \CreditSafe\API\Runtime\Client\BaseE
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/FilteredEventRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/FilteredEventRules.php
@@ -41,7 +41,7 @@ class FilteredEventRules extends \CreditSafe\API\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/FreshInvestigationReport.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/FreshInvestigationReport.php
@@ -45,7 +45,7 @@ class FreshInvestigationReport extends \CreditSafe\API\Runtime\Client\BaseEndpoi
         $optionsResolver->setDefined(array('sections'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('sections', array('string'));
+        $optionsResolver->addAllowedTypes('sections', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -54,7 +54,7 @@ class FreshInvestigationReport extends \CreditSafe\API\Runtime\Client\BaseEndpoi
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/GetAMonitoredCompanyFromAPortfolio.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/GetAMonitoredCompanyFromAPortfolio.php
@@ -44,7 +44,7 @@ class GetAMonitoredCompanyFromAPortfolio extends \CreditSafe\API\Runtime\Client\
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/GetFilteredPortfolioEventRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/GetFilteredPortfolioEventRules.php
@@ -44,7 +44,7 @@ class GetFilteredPortfolioEventRules extends \CreditSafe\API\Runtime\Client\Base
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ImageDocumentCategoryTypes.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ImageDocumentCategoryTypes.php
@@ -42,7 +42,7 @@ class ImageDocumentCategoryTypes extends \CreditSafe\API\Runtime\Client\BaseEndp
         $optionsResolver->setDefined(array('countries'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('countries', array('string'));
+        $optionsResolver->addAllowedTypes('countries', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -51,7 +51,7 @@ class ImageDocumentCategoryTypes extends \CreditSafe\API\Runtime\Client\BaseEndp
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/IndividualPersonComplianceSearch.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/IndividualPersonComplianceSearch.php
@@ -52,14 +52,14 @@ class IndividualPersonComplianceSearch extends \CreditSafe\API\Runtime\Client\Ba
         $optionsResolver->setDefined(array('countries', 'name', 'street', 'houseNo', 'city', 'postCode', 'province', 'phoneNo'));
         $optionsResolver->setRequired(array('name'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('countries', array('string'));
-        $optionsResolver->setAllowedTypes('name', array('string'));
-        $optionsResolver->setAllowedTypes('street', array('string'));
-        $optionsResolver->setAllowedTypes('houseNo', array('string'));
-        $optionsResolver->setAllowedTypes('city', array('string'));
-        $optionsResolver->setAllowedTypes('postCode', array('string'));
-        $optionsResolver->setAllowedTypes('province', array('string'));
-        $optionsResolver->setAllowedTypes('phoneNo', array('string'));
+        $optionsResolver->addAllowedTypes('countries', array('string'));
+        $optionsResolver->addAllowedTypes('name', array('string'));
+        $optionsResolver->addAllowedTypes('street', array('string'));
+        $optionsResolver->addAllowedTypes('houseNo', array('string'));
+        $optionsResolver->addAllowedTypes('city', array('string'));
+        $optionsResolver->addAllowedTypes('postCode', array('string'));
+        $optionsResolver->addAllowedTypes('province', array('string'));
+        $optionsResolver->addAllowedTypes('phoneNo', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -68,7 +68,7 @@ class IndividualPersonComplianceSearch extends \CreditSafe\API\Runtime\Client\Ba
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/IndividualsComplianceSearchCriteria.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/IndividualsComplianceSearchCriteria.php
@@ -38,7 +38,7 @@ class IndividualsComplianceSearchCriteria extends \CreditSafe\API\Runtime\Client
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListAllPortfolios.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListAllPortfolios.php
@@ -44,9 +44,9 @@ class ListAllPortfolios extends \CreditSafe\API\Runtime\Client\BaseEndpoint impl
         $optionsResolver->setDefined(array('searchQuery', 'page', 'pageSize'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('page' => 0, 'pageSize' => 50));
-        $optionsResolver->setAllowedTypes('searchQuery', array('string'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('pageSize', array('int'));
+        $optionsResolver->addAllowedTypes('searchQuery', array('string'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('pageSize', array('int'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -55,7 +55,7 @@ class ListAllPortfolios extends \CreditSafe\API\Runtime\Client\BaseEndpoint impl
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListCompanySpecificNotificationEvents.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListCompanySpecificNotificationEvents.php
@@ -53,12 +53,12 @@ class ListCompanySpecificNotificationEvents extends \CreditSafe\API\Runtime\Clie
         $optionsResolver->setDefined(array('searchQuery', 'sortDir', 'pageSize', 'page', 'isProcessed', 'sortBy'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sortDir' => 'asc', 'pageSize' => 50, 'page' => 0, 'sortBy' => 'companyName'));
-        $optionsResolver->setAllowedTypes('searchQuery', array('string'));
-        $optionsResolver->setAllowedTypes('sortDir', array('string'));
-        $optionsResolver->setAllowedTypes('pageSize', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('isProcessed', array('bool'));
-        $optionsResolver->setAllowedTypes('sortBy', array('string'));
+        $optionsResolver->addAllowedTypes('searchQuery', array('string'));
+        $optionsResolver->addAllowedTypes('sortDir', array('string'));
+        $optionsResolver->addAllowedTypes('pageSize', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('isProcessed', array('bool'));
+        $optionsResolver->addAllowedTypes('sortBy', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -67,7 +67,7 @@ class ListCompanySpecificNotificationEvents extends \CreditSafe\API\Runtime\Clie
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListCountriesOfMonitoredCompanies.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListCountriesOfMonitoredCompanies.php
@@ -41,7 +41,7 @@ class ListCountriesOfMonitoredCompanies extends \CreditSafe\API\Runtime\Client\B
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListDecisionTrees.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListDecisionTrees.php
@@ -45,10 +45,10 @@ class ListDecisionTrees extends \CreditSafe\API\Runtime\Client\BaseEndpoint impl
         $optionsResolver->setDefined(array('type', 'sortBy', 'sortDir', 'callRef'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sortBy' => 'friendlyName', 'sortDir' => 'asc'));
-        $optionsResolver->setAllowedTypes('type', array('string'));
-        $optionsResolver->setAllowedTypes('sortBy', array('string'));
-        $optionsResolver->setAllowedTypes('sortDir', array('string'));
-        $optionsResolver->setAllowedTypes('callRef', array('string'));
+        $optionsResolver->addAllowedTypes('type', array('string'));
+        $optionsResolver->addAllowedTypes('sortBy', array('string'));
+        $optionsResolver->addAllowedTypes('sortDir', array('string'));
+        $optionsResolver->addAllowedTypes('callRef', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -57,7 +57,7 @@ class ListDecisionTrees extends \CreditSafe\API\Runtime\Client\BaseEndpoint impl
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListFilteredCompaniesInAPortfolio.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListFilteredCompaniesInAPortfolio.php
@@ -49,11 +49,11 @@ class ListFilteredCompaniesInAPortfolio extends \CreditSafe\API\Runtime\Client\B
         $optionsResolver->setDefined(array('searchQuery', 'pageSize', 'page', 'countryCode', 'events'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('pageSize' => 50, 'page' => 0, 'events' => false));
-        $optionsResolver->setAllowedTypes('searchQuery', array('string'));
-        $optionsResolver->setAllowedTypes('pageSize', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('countryCode', array('string'));
-        $optionsResolver->setAllowedTypes('events', array('bool'));
+        $optionsResolver->addAllowedTypes('searchQuery', array('string'));
+        $optionsResolver->addAllowedTypes('pageSize', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('countryCode', array('string'));
+        $optionsResolver->addAllowedTypes('events', array('bool'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -62,7 +62,7 @@ class ListFilteredCompaniesInAPortfolio extends \CreditSafe\API\Runtime\Client\B
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListNotificationEventsInAPortfolioFiltered.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListNotificationEventsInAPortfolioFiltered.php
@@ -49,11 +49,11 @@ class ListNotificationEventsInAPortfolioFiltered extends \CreditSafe\API\Runtime
         $optionsResolver->setDefined(array('searchQuery', 'sortDir', 'pageSize', 'page', 'sortBy'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sortDir' => 'asc', 'pageSize' => 50, 'page' => 0));
-        $optionsResolver->setAllowedTypes('searchQuery', array('string'));
-        $optionsResolver->setAllowedTypes('sortDir', array('string'));
-        $optionsResolver->setAllowedTypes('pageSize', array('int'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('sortBy', array('string'));
+        $optionsResolver->addAllowedTypes('searchQuery', array('string'));
+        $optionsResolver->addAllowedTypes('sortDir', array('string'));
+        $optionsResolver->addAllowedTypes('pageSize', array('int'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('sortBy', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -62,7 +62,7 @@ class ListNotificationEventsInAPortfolioFiltered extends \CreditSafe\API\Runtime
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListOfCompanyPreDefinedSearches.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListOfCompanyPreDefinedSearches.php
@@ -38,7 +38,7 @@ class ListOfCompanyPreDefinedSearches extends \CreditSafe\API\Runtime\Client\Bas
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListOfIndividualsPreDefinedSearches.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListOfIndividualsPreDefinedSearches.php
@@ -38,7 +38,7 @@ class ListOfIndividualsPreDefinedSearches extends \CreditSafe\API\Runtime\Client
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListPortfolioEventRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListPortfolioEventRules.php
@@ -41,7 +41,7 @@ class ListPortfolioEventRules extends \CreditSafe\API\Runtime\Client\BaseEndpoin
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListSubmittedFreshInvestigations.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListSubmittedFreshInvestigations.php
@@ -55,20 +55,20 @@ class ListSubmittedFreshInvestigations extends \CreditSafe\API\Runtime\Client\Ba
         $optionsResolver->setDefined(array('page', 'pageSize', 'transactionId', 'reportCreatedAfter', 'reportCreatedBefore', 'createdBefore', 'createdSince', 'lookUpOrderBy', 'companyDetailsCountry', 'companyDetailsName', 'searchCriteriaCountry', 'searchCriteriaName', 'sortBy', 'sortDir'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('page' => 0, 'pageSize' => 50));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('pageSize', array('int'));
-        $optionsResolver->setAllowedTypes('transactionId', array('string'));
-        $optionsResolver->setAllowedTypes('reportCreatedAfter', array('string'));
-        $optionsResolver->setAllowedTypes('reportCreatedBefore', array('string'));
-        $optionsResolver->setAllowedTypes('createdBefore', array('string'));
-        $optionsResolver->setAllowedTypes('createdSince', array('string'));
-        $optionsResolver->setAllowedTypes('lookUpOrderBy', array('string'));
-        $optionsResolver->setAllowedTypes('companyDetailsCountry', array('string'));
-        $optionsResolver->setAllowedTypes('companyDetailsName', array('string'));
-        $optionsResolver->setAllowedTypes('searchCriteriaCountry', array('string'));
-        $optionsResolver->setAllowedTypes('searchCriteriaName', array('string'));
-        $optionsResolver->setAllowedTypes('sortBy', array('string'));
-        $optionsResolver->setAllowedTypes('sortDir', array('string'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('pageSize', array('int'));
+        $optionsResolver->addAllowedTypes('transactionId', array('string'));
+        $optionsResolver->addAllowedTypes('reportCreatedAfter', array('string'));
+        $optionsResolver->addAllowedTypes('reportCreatedBefore', array('string'));
+        $optionsResolver->addAllowedTypes('createdBefore', array('string'));
+        $optionsResolver->addAllowedTypes('createdSince', array('string'));
+        $optionsResolver->addAllowedTypes('lookUpOrderBy', array('string'));
+        $optionsResolver->addAllowedTypes('companyDetailsCountry', array('string'));
+        $optionsResolver->addAllowedTypes('companyDetailsName', array('string'));
+        $optionsResolver->addAllowedTypes('searchCriteriaCountry', array('string'));
+        $optionsResolver->addAllowedTypes('searchCriteriaName', array('string'));
+        $optionsResolver->addAllowedTypes('sortBy', array('string'));
+        $optionsResolver->addAllowedTypes('sortDir', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -77,7 +77,7 @@ class ListSubmittedFreshInvestigations extends \CreditSafe\API\Runtime\Client\Ba
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/MonitoringUserDetails.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/MonitoringUserDetails.php
@@ -38,7 +38,7 @@ class MonitoringUserDetails extends \CreditSafe\API\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/MoveCompaniesFromOneToAnotherPortfolioS.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/MoveCompaniesFromOneToAnotherPortfolioS.php
@@ -50,7 +50,7 @@ class MoveCompaniesFromOneToAnotherPortfolioS extends \CreditSafe\API\Runtime\Cl
         $optionsResolver->setDefined(array('removeAll'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('removeAll' => false));
-        $optionsResolver->setAllowedTypes('removeAll', array('bool'));
+        $optionsResolver->addAllowedTypes('removeAll', array('bool'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -59,7 +59,7 @@ class MoveCompaniesFromOneToAnotherPortfolioS extends \CreditSafe\API\Runtime\Cl
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/NotificationEvents.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/NotificationEvents.php
@@ -48,13 +48,13 @@ class NotificationEvents extends \CreditSafe\API\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('searchQuery', 'sortBy', 'sortDir', 'startDate', 'endDate', 'page', 'pageSize'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('sortBy' => 'companyName', 'sortDir' => 'asc', 'page' => 0, 'pageSize' => 50));
-        $optionsResolver->setAllowedTypes('searchQuery', array('string'));
-        $optionsResolver->setAllowedTypes('sortBy', array('string'));
-        $optionsResolver->setAllowedTypes('sortDir', array('string'));
-        $optionsResolver->setAllowedTypes('startDate', array('string'));
-        $optionsResolver->setAllowedTypes('endDate', array('string'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('pageSize', array('int'));
+        $optionsResolver->addAllowedTypes('searchQuery', array('string'));
+        $optionsResolver->addAllowedTypes('sortBy', array('string'));
+        $optionsResolver->addAllowedTypes('sortDir', array('string'));
+        $optionsResolver->addAllowedTypes('startDate', array('string'));
+        $optionsResolver->addAllowedTypes('endDate', array('string'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('pageSize', array('int'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -63,7 +63,7 @@ class NotificationEvents extends \CreditSafe\API\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PeopleDirectorSearch.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PeopleDirectorSearch.php
@@ -55,20 +55,20 @@ class PeopleDirectorSearch extends \CreditSafe\API\Runtime\Client\BaseEndpoint i
         $optionsResolver->setDefined(array('countries', 'id', 'regNo', 'safeNumber', 'peopleId', 'firstName', 'lastName', 'companyName', 'companyNumber', 'localDirectorNumber', 'dateOfBirth', 'page', 'pageSize', 'callRef'));
         $optionsResolver->setRequired(array('countries'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('countries', array('string'));
-        $optionsResolver->setAllowedTypes('id', array('string'));
-        $optionsResolver->setAllowedTypes('regNo', array('string'));
-        $optionsResolver->setAllowedTypes('safeNumber', array('string'));
-        $optionsResolver->setAllowedTypes('peopleId', array('string'));
-        $optionsResolver->setAllowedTypes('firstName', array('string'));
-        $optionsResolver->setAllowedTypes('lastName', array('string'));
-        $optionsResolver->setAllowedTypes('companyName', array('string'));
-        $optionsResolver->setAllowedTypes('companyNumber', array('string'));
-        $optionsResolver->setAllowedTypes('localDirectorNumber', array('string'));
-        $optionsResolver->setAllowedTypes('dateOfBirth', array('string'));
-        $optionsResolver->setAllowedTypes('page', array('int'));
-        $optionsResolver->setAllowedTypes('pageSize', array('int'));
-        $optionsResolver->setAllowedTypes('callRef', array('string'));
+        $optionsResolver->addAllowedTypes('countries', array('string'));
+        $optionsResolver->addAllowedTypes('id', array('string'));
+        $optionsResolver->addAllowedTypes('regNo', array('string'));
+        $optionsResolver->addAllowedTypes('safeNumber', array('string'));
+        $optionsResolver->addAllowedTypes('peopleId', array('string'));
+        $optionsResolver->addAllowedTypes('firstName', array('string'));
+        $optionsResolver->addAllowedTypes('lastName', array('string'));
+        $optionsResolver->addAllowedTypes('companyName', array('string'));
+        $optionsResolver->addAllowedTypes('companyNumber', array('string'));
+        $optionsResolver->addAllowedTypes('localDirectorNumber', array('string'));
+        $optionsResolver->addAllowedTypes('dateOfBirth', array('string'));
+        $optionsResolver->addAllowedTypes('page', array('int'));
+        $optionsResolver->addAllowedTypes('pageSize', array('int'));
+        $optionsResolver->addAllowedTypes('callRef', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -77,7 +77,7 @@ class PeopleDirectorSearch extends \CreditSafe\API\Runtime\Client\BaseEndpoint i
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PeopleDirectorSearchCriteria.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PeopleDirectorSearchCriteria.php
@@ -42,7 +42,7 @@ class PeopleDirectorSearchCriteria extends \CreditSafe\API\Runtime\Client\BaseEn
         $optionsResolver->setDefined(array('countries'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('countries', array('string'));
+        $optionsResolver->addAllowedTypes('countries', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -51,7 +51,7 @@ class PeopleDirectorSearchCriteria extends \CreditSafe\API\Runtime\Client\BaseEn
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PortfolioUserPermissions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PortfolioUserPermissions.php
@@ -41,7 +41,7 @@ class PortfolioUserPermissions extends \CreditSafe\API\Runtime\Client\BaseEndpoi
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PortoflioRiskSummary.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PortoflioRiskSummary.php
@@ -41,7 +41,7 @@ class PortoflioRiskSummary extends \CreditSafe\API\Runtime\Client\BaseEndpoint i
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PostMonitoringPortfoliosByPortfolioIdCompany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PostMonitoringPortfoliosByPortfolioIdCompany.php
@@ -46,7 +46,7 @@ class PostMonitoringPortfoliosByPortfolioIdCompany extends \CreditSafe\API\Runti
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PostMonitoringPortfoliosByPortfolioIdImport.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PostMonitoringPortfoliosByPortfolioIdImport.php
@@ -46,7 +46,7 @@ class PostMonitoringPortfoliosByPortfolioIdImport extends \CreditSafe\API\Runtim
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PutMonitoringPortfoliosByPortfolioIdEventRuleByCountryCode.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/PutMonitoringPortfoliosByPortfolioIdEventRuleByCountryCode.php
@@ -49,7 +49,7 @@ class PutMonitoringPortfoliosByPortfolioIdEventRuleByCountryCode extends \Credit
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/RequestFreshInvestigation.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/RequestFreshInvestigation.php
@@ -43,7 +43,7 @@ class RequestFreshInvestigation extends \CreditSafe\API\Runtime\Client\BaseEndpo
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ResetPortfolioEventRulesToDefaultValues.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ResetPortfolioEventRulesToDefaultValues.php
@@ -41,7 +41,7 @@ class ResetPortfolioEventRulesToDefaultValues extends \CreditSafe\API\Runtime\Cl
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/RetrievePortfolioById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/RetrievePortfolioById.php
@@ -41,7 +41,7 @@ class RetrievePortfolioById extends \CreditSafe\API\Runtime\Client\BaseEndpoint 
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/RunDecisionTree.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/RunDecisionTree.php
@@ -52,9 +52,9 @@ class RunDecisionTree extends \CreditSafe\API\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('companyId', 'originationId', 'callRef'));
         $optionsResolver->setRequired(array('companyId'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('companyId', array('string'));
-        $optionsResolver->setAllowedTypes('originationId', array('string'));
-        $optionsResolver->setAllowedTypes('callRef', array('string'));
+        $optionsResolver->addAllowedTypes('companyId', array('string'));
+        $optionsResolver->addAllowedTypes('originationId', array('string'));
+        $optionsResolver->addAllowedTypes('callRef', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -63,7 +63,7 @@ class RunDecisionTree extends \CreditSafe\API\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/SharePortfolioId.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/SharePortfolioId.php
@@ -46,7 +46,7 @@ class SharePortfolioId extends \CreditSafe\API\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/SyncPortfolioCompaniesToCSVRecords.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/SyncPortfolioCompaniesToCSVRecords.php
@@ -46,7 +46,7 @@ class SyncPortfolioCompaniesToCSVRecords extends \CreditSafe\API\Runtime\Client\
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/UpdateCompanyDetailsInAPortfolio.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/UpdateCompanyDetailsInAPortfolio.php
@@ -49,7 +49,7 @@ class UpdateCompanyDetailsInAPortfolio extends \CreditSafe\API\Runtime\Client\Ba
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/UpdateIsProcessedFlagOnAnNotificationEvent.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/UpdateIsProcessedFlagOnAnNotificationEvent.php
@@ -49,7 +49,7 @@ class UpdateIsProcessedFlagOnAnNotificationEvent extends \CreditSafe\API\Runtime
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/UpdatePortfolioDetails.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/UpdatePortfolioDetails.php
@@ -46,7 +46,7 @@ class UpdatePortfolioDetails extends \CreditSafe\API\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('Authorization'));
         $optionsResolver->setRequired(array('Authorization'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('Authorization', array('string'));
+        $optionsResolver->addAllowedTypes('Authorization', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/BusinessProcessWaitForCompletion.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/BusinessProcessWaitForCompletion.php
@@ -47,8 +47,8 @@ class BusinessProcessWaitForCompletion extends \PicturePark\API\Runtime\Client\B
         $optionsResolver->setDefined(array('timeout', 'waitForContinuationCompletion'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('waitForContinuationCompletion' => true));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitForContinuationCompletion', array('bool'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitForContinuationCompletion', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/BusinessProcessWaitForLifeCycles.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/BusinessProcessWaitForLifeCycles.php
@@ -42,8 +42,8 @@ class BusinessProcessWaitForLifeCycles extends \PicturePark\API\Runtime\Client\B
         $optionsResolver->setDefined(array('lifeCycles', 'timeout'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('lifeCycles', array('array', 'null'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('lifeCycles', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/BusinessProcessWaitForStates.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/BusinessProcessWaitForStates.php
@@ -42,8 +42,8 @@ class BusinessProcessWaitForStates extends \PicturePark\API\Runtime\Client\BaseE
         $optionsResolver->setDefined(array('states', 'timeout'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('states', array('array', 'null'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('states', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentCreate.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentCreate.php
@@ -48,10 +48,10 @@ class ContentCreate extends \PicturePark\API\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('resolveBehaviors', 'allowMissingDependencies', 'timeout', 'waitSearchDocCreation'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('allowMissingDependencies' => false, 'waitSearchDocCreation' => true));
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
-        $optionsResolver->setAllowedTypes('allowMissingDependencies', array('bool'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitSearchDocCreation', array('bool'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('allowMissingDependencies', array('bool'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitSearchDocCreation', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentDelete.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentDelete.php
@@ -45,9 +45,9 @@ class ContentDelete extends \PicturePark\API\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('forceReferenceRemoval', 'timeout', 'waitSearchDocCreation'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('forceReferenceRemoval' => false, 'waitSearchDocCreation' => true));
-        $optionsResolver->setAllowedTypes('forceReferenceRemoval', array('bool'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitSearchDocCreation', array('bool'));
+        $optionsResolver->addAllowedTypes('forceReferenceRemoval', array('bool'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitSearchDocCreation', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentDownload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentDownload.php
@@ -49,8 +49,8 @@ class ContentDownload extends \PicturePark\API\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('width', 'height'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('width', array('int', 'null'));
-        $optionsResolver->setAllowedTypes('height', array('int', 'null'));
+        $optionsResolver->addAllowedTypes('width', array('int', 'null'));
+        $optionsResolver->addAllowedTypes('height', array('int', 'null'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -59,7 +59,7 @@ class ContentDownload extends \PicturePark\API\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('range'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('range', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('range', array('string', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentDownloadThumbnail.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentDownloadThumbnail.php
@@ -45,8 +45,8 @@ class ContentDownloadThumbnail extends \PicturePark\API\Runtime\Client\BaseEndpo
         $optionsResolver->setDefined(array('width', 'height'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('width', array('int', 'null'));
-        $optionsResolver->setAllowedTypes('height', array('int', 'null'));
+        $optionsResolver->addAllowedTypes('width', array('int', 'null'));
+        $optionsResolver->addAllowedTypes('height', array('int', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentGet.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentGet.php
@@ -41,7 +41,7 @@ class ContentGet extends \PicturePark\API\Runtime\Client\BaseEndpoint implements
         $optionsResolver->setDefined(array('resolveBehaviors'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentGetMany.php
@@ -40,8 +40,8 @@ class ContentGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('ids', 'resolveBehaviors'));
         $optionsResolver->setRequired(array('ids'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentPermissionSetGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentPermissionSetGetMany.php
@@ -38,7 +38,7 @@ class ContentPermissionSetGetMany extends \PicturePark\API\Runtime\Client\BaseEn
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentPermissionSetGetPermissionsMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentPermissionSetGetPermissionsMany.php
@@ -38,7 +38,7 @@ class ContentPermissionSetGetPermissionsMany extends \PicturePark\API\Runtime\Cl
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentRestore.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentRestore.php
@@ -45,9 +45,9 @@ class ContentRestore extends \PicturePark\API\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('allowMissingDependencies', 'timeout', 'waitSearchDocCreation'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('allowMissingDependencies' => false, 'waitSearchDocCreation' => true));
-        $optionsResolver->setAllowedTypes('allowMissingDependencies', array('bool'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitSearchDocCreation', array('bool'));
+        $optionsResolver->addAllowedTypes('allowMissingDependencies', array('bool'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitSearchDocCreation', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentTransferOwnership.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentTransferOwnership.php
@@ -49,8 +49,8 @@ class ContentTransferOwnership extends \PicturePark\API\Runtime\Client\BaseEndpo
         $optionsResolver->setDefined(array('timeout', 'waitSearchDocCreation'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('waitSearchDocCreation' => true));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitSearchDocCreation', array('bool'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitSearchDocCreation', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentUpdateMetadata.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentUpdateMetadata.php
@@ -54,10 +54,10 @@ class ContentUpdateMetadata extends \PicturePark\API\Runtime\Client\BaseEndpoint
         $optionsResolver->setDefined(array('resolveBehaviors', 'allowMissingDependencies', 'timeout', 'waitSearchDocCreation'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('allowMissingDependencies' => false, 'waitSearchDocCreation' => true));
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
-        $optionsResolver->setAllowedTypes('allowMissingDependencies', array('bool'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitSearchDocCreation', array('bool'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('allowMissingDependencies', array('bool'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitSearchDocCreation', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentUpdatePermissions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentUpdatePermissions.php
@@ -50,9 +50,9 @@ class ContentUpdatePermissions extends \PicturePark\API\Runtime\Client\BaseEndpo
         $optionsResolver->setDefined(array('resolveBehaviors', 'timeout', 'waitSearchDocCreation'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('waitSearchDocCreation' => true));
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitSearchDocCreation', array('bool'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitSearchDocCreation', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/DocumentHistoryCompareWithCurrent.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/DocumentHistoryCompareWithCurrent.php
@@ -44,7 +44,7 @@ class DocumentHistoryCompareWithCurrent extends \PicturePark\API\Runtime\Client\
         $optionsResolver->setDefined(array('version'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('version', array('int'));
+        $optionsResolver->addAllowedTypes('version', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/DocumentHistoryCompareWithVersion.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/DocumentHistoryCompareWithVersion.php
@@ -47,7 +47,7 @@ class DocumentHistoryCompareWithVersion extends \PicturePark\API\Runtime\Client\
         $optionsResolver->setDefined(array('version'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('version', array('int'));
+        $optionsResolver->addAllowedTypes('version', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemCreate.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemCreate.php
@@ -48,10 +48,10 @@ class ListItemCreate extends \PicturePark\API\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('resolveBehaviors', 'allowMissingDependencies', 'timeout', 'waitSearchDocCreation'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('allowMissingDependencies' => false, 'waitSearchDocCreation' => true));
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
-        $optionsResolver->setAllowedTypes('allowMissingDependencies', array('bool'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitSearchDocCreation', array('bool'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('allowMissingDependencies', array('bool'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitSearchDocCreation', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemDelete.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemDelete.php
@@ -45,9 +45,9 @@ class ListItemDelete extends \PicturePark\API\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('forceReferenceRemoval', 'timeout', 'waitSearchDocCreation'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('forceReferenceRemoval' => false, 'waitSearchDocCreation' => true));
-        $optionsResolver->setAllowedTypes('forceReferenceRemoval', array('bool'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitSearchDocCreation', array('bool'));
+        $optionsResolver->addAllowedTypes('forceReferenceRemoval', array('bool'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitSearchDocCreation', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemGet.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemGet.php
@@ -41,7 +41,7 @@ class ListItemGet extends \PicturePark\API\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('resolveBehaviors'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemGetMany.php
@@ -40,8 +40,8 @@ class ListItemGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('ids', 'resolveBehaviors'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemRestore.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemRestore.php
@@ -45,9 +45,9 @@ class ListItemRestore extends \PicturePark\API\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('allowMissingDependencies', 'timeout', 'waitSearchDocCreation'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('allowMissingDependencies' => false, 'waitSearchDocCreation' => true));
-        $optionsResolver->setAllowedTypes('allowMissingDependencies', array('bool'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitSearchDocCreation', array('bool'));
+        $optionsResolver->addAllowedTypes('allowMissingDependencies', array('bool'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitSearchDocCreation', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemUpdate.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemUpdate.php
@@ -51,10 +51,10 @@ class ListItemUpdate extends \PicturePark\API\Runtime\Client\BaseEndpoint implem
         $optionsResolver->setDefined(array('resolveBehaviors', 'allowMissingDependencies', 'timeout', 'waitSearchDocCreation'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array('allowMissingDependencies' => false, 'waitSearchDocCreation' => true));
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
-        $optionsResolver->setAllowedTypes('allowMissingDependencies', array('bool'));
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('waitSearchDocCreation', array('bool'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('allowMissingDependencies', array('bool'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('waitSearchDocCreation', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/OutputFormatGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/OutputFormatGetMany.php
@@ -38,7 +38,7 @@ class OutputFormatGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint i
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaCreate.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaCreate.php
@@ -44,7 +44,7 @@ class SchemaCreate extends \PicturePark\API\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('timeout'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaDelete.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaDelete.php
@@ -43,7 +43,7 @@ class SchemaDelete extends \PicturePark\API\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('timeout'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaGetMany.php
@@ -39,7 +39,7 @@ class SchemaGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaGetManyReferenced.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaGetManyReferenced.php
@@ -38,7 +38,7 @@ class SchemaGetManyReferenced extends \PicturePark\API\Runtime\Client\BaseEndpoi
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaPermissionSetGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaPermissionSetGetMany.php
@@ -38,7 +38,7 @@ class SchemaPermissionSetGetMany extends \PicturePark\API\Runtime\Client\BaseEnd
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaPermissionSetGetPermissionsMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaPermissionSetGetPermissionsMany.php
@@ -38,7 +38,7 @@ class SchemaPermissionSetGetPermissionsMany extends \PicturePark\API\Runtime\Cli
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaTransferOwnership.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaTransferOwnership.php
@@ -47,7 +47,7 @@ class SchemaTransferOwnership extends \PicturePark\API\Runtime\Client\BaseEndpoi
         $optionsResolver->setDefined(array('timeout'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaUpdate.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaUpdate.php
@@ -48,7 +48,7 @@ class SchemaUpdate extends \PicturePark\API\Runtime\Client\BaseEndpoint implemen
         $optionsResolver->setDefined(array('timeout'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('timeout', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('timeout', array('string', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareDownload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareDownload.php
@@ -46,8 +46,8 @@ class ShareDownload extends \PicturePark\API\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('width', 'height'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('width', array('int', 'null'));
-        $optionsResolver->setAllowedTypes('height', array('int', 'null'));
+        $optionsResolver->addAllowedTypes('width', array('int', 'null'));
+        $optionsResolver->addAllowedTypes('height', array('int', 'null'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -56,7 +56,7 @@ class ShareDownload extends \PicturePark\API\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->setDefined(array('range'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('range', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('range', array('string', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareDownloadSingleContent.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareDownloadSingleContent.php
@@ -52,8 +52,8 @@ class ShareDownloadSingleContent extends \PicturePark\API\Runtime\Client\BaseEnd
         $optionsResolver->setDefined(array('width', 'height'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('width', array('int', 'null'));
-        $optionsResolver->setAllowedTypes('height', array('int', 'null'));
+        $optionsResolver->addAllowedTypes('width', array('int', 'null'));
+        $optionsResolver->addAllowedTypes('height', array('int', 'null'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -62,7 +62,7 @@ class ShareDownloadSingleContent extends \PicturePark\API\Runtime\Client\BaseEnd
         $optionsResolver->setDefined(array('range'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('range', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('range', array('string', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareGet.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareGet.php
@@ -41,7 +41,7 @@ class ShareGet extends \PicturePark\API\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->setDefined(array('resolveBehaviors'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareGetShareJson.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareGetShareJson.php
@@ -42,8 +42,8 @@ class ShareGetShareJson extends \PicturePark\API\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('lang', 'resolveBehaviors'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('lang', array('string', 'null'));
-        $optionsResolver->setAllowedTypes('resolveBehaviors', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('lang', array('string', 'null'));
+        $optionsResolver->addAllowedTypes('resolveBehaviors', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/TransferUploadFile.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/TransferUploadFile.php
@@ -57,10 +57,10 @@ class TransferUploadFile extends \PicturePark\API\Runtime\Client\BaseEndpoint im
         $optionsResolver->setDefined(array('ChunkNumber', 'CurrentChunkSize', 'TotalSize', 'TotalChunks'));
         $optionsResolver->setRequired(array('ChunkNumber', 'CurrentChunkSize', 'TotalSize', 'TotalChunks'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ChunkNumber', array('int'));
-        $optionsResolver->setAllowedTypes('CurrentChunkSize', array('int'));
-        $optionsResolver->setAllowedTypes('TotalSize', array('int'));
-        $optionsResolver->setAllowedTypes('TotalChunks', array('int'));
+        $optionsResolver->addAllowedTypes('ChunkNumber', array('int'));
+        $optionsResolver->addAllowedTypes('CurrentChunkSize', array('int'));
+        $optionsResolver->addAllowedTypes('TotalSize', array('int'));
+        $optionsResolver->addAllowedTypes('TotalChunks', array('int'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/UserGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/UserGetMany.php
@@ -38,7 +38,7 @@ class UserGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint implement
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/UserRoleGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/UserRoleGetMany.php
@@ -38,7 +38,7 @@ class UserRoleGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint imple
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/XmpMappingGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/XmpMappingGetMany.php
@@ -38,7 +38,7 @@ class XmpMappingGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint imp
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array', 'null'));
+        $optionsResolver->addAllowedTypes('ids', array('array', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Endpoint/Foo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Endpoint/Foo.php
@@ -34,7 +34,7 @@ class Foo extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEnd
         $optionsResolver->setDefined(array('bar'));
         $optionsResolver->setRequired(array('bar'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('bar', array('string'));
+        $optionsResolver->addAllowedTypes('bar', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestDictionary.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestDictionary.php
@@ -34,7 +34,7 @@ class TestDictionary extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cli
         $optionsResolver->setDefined(array('input'));
         $optionsResolver->setRequired(array('input'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('input', array('string'));
+        $optionsResolver->addAllowedTypes('input', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestGetWithPathParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestGetWithPathParameters.php
@@ -41,7 +41,7 @@ class TestGetWithPathParameters extends \Jane\Component\OpenApi3\Tests\Expected\
         $optionsResolver->setDefined(array('testQuery'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testQuery', array('string'));
+        $optionsResolver->addAllowedTypes('testQuery', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -50,7 +50,7 @@ class TestGetWithPathParameters extends \Jane\Component\OpenApi3\Tests\Expected\
         $optionsResolver->setDefined(array('testHeader'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testHeader', array('string'));
+        $optionsResolver->addAllowedTypes('testHeader', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
@@ -39,12 +39,12 @@ class TestHeaderParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runti
         $optionsResolver->setDefined(array('testString', 'testInteger', 'testFloat', 'testArray', 'testRequired', 'testDefault'));
         $optionsResolver->setRequired(array('testRequired'));
         $optionsResolver->setDefaults(array('testDefault' => 'test'));
-        $optionsResolver->setAllowedTypes('testString', array('string'));
-        $optionsResolver->setAllowedTypes('testInteger', array('int'));
-        $optionsResolver->setAllowedTypes('testFloat', array('float'));
-        $optionsResolver->setAllowedTypes('testArray', array('array'));
-        $optionsResolver->setAllowedTypes('testRequired', array('string'));
-        $optionsResolver->setAllowedTypes('testDefault', array('string'));
+        $optionsResolver->addAllowedTypes('testString', array('string'));
+        $optionsResolver->addAllowedTypes('testInteger', array('int'));
+        $optionsResolver->addAllowedTypes('testFloat', array('float'));
+        $optionsResolver->addAllowedTypes('testArray', array('array'));
+        $optionsResolver->addAllowedTypes('testRequired', array('string'));
+        $optionsResolver->addAllowedTypes('testDefault', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestPostWithPathParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestPostWithPathParameters.php
@@ -41,7 +41,7 @@ class TestPostWithPathParameters extends \Jane\Component\OpenApi3\Tests\Expected
         $optionsResolver->setDefined(array('testQuery'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testQuery', array('string'));
+        $optionsResolver->addAllowedTypes('testQuery', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -50,7 +50,7 @@ class TestPostWithPathParameters extends \Jane\Component\OpenApi3\Tests\Expected
         $optionsResolver->setDefined(array('testHeader'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testHeader', array('string'));
+        $optionsResolver->addAllowedTypes('testHeader', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
@@ -39,12 +39,12 @@ class TestQueryParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runtim
         $optionsResolver->setDefined(array('testString', 'testInteger', 'testFloat', 'testArray', 'testRequired', 'testDefault'));
         $optionsResolver->setRequired(array('testRequired'));
         $optionsResolver->setDefaults(array('testDefault' => 'test'));
-        $optionsResolver->setAllowedTypes('testString', array('string'));
-        $optionsResolver->setAllowedTypes('testInteger', array('int'));
-        $optionsResolver->setAllowedTypes('testFloat', array('float'));
-        $optionsResolver->setAllowedTypes('testArray', array('array'));
-        $optionsResolver->setAllowedTypes('testRequired', array('string'));
-        $optionsResolver->setAllowedTypes('testDefault', array('string'));
+        $optionsResolver->addAllowedTypes('testString', array('string'));
+        $optionsResolver->addAllowedTypes('testInteger', array('int'));
+        $optionsResolver->addAllowedTypes('testFloat', array('float'));
+        $optionsResolver->addAllowedTypes('testArray', array('array'));
+        $optionsResolver->addAllowedTypes('testRequired', array('string'));
+        $optionsResolver->addAllowedTypes('testDefault', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Endpoint/TestNullableQueryParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Endpoint/TestNullableQueryParameters.php
@@ -34,7 +34,7 @@ class TestNullableQueryParameters extends \Jane\Component\OpenApi3\Tests\Expecte
         $optionsResolver->setDefined(array('testNullableInteger'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testNullableInteger', array('int', 'null'));
+        $optionsResolver->addAllowedTypes('testNullableInteger', array('int', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Endpoint/TestGetWithPathParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Endpoint/TestGetWithPathParameters.php
@@ -43,7 +43,7 @@ class TestGetWithPathParameters extends \Jane\OpenApi3\Tests\Expected\Runtime\Cl
         $optionsResolver->setDefined(array('testQuery'));
         $optionsResolver->setRequired(array('testQuery'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testQuery', array('string'));
+        $optionsResolver->addAllowedTypes('testQuery', array('string'));
         return $optionsResolver;
     }
     protected function getHeadersOptionsResolver() : \Symfony\Component\OptionsResolver\OptionsResolver
@@ -52,7 +52,7 @@ class TestGetWithPathParameters extends \Jane\OpenApi3\Tests\Expected\Runtime\Cl
         $optionsResolver->setDefined(array('testHeader'));
         $optionsResolver->setRequired(array('testHeader'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testHeader', array('string'));
+        $optionsResolver->addAllowedTypes('testHeader', array('string'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Endpoint/TestNullableQueryParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Endpoint/TestNullableQueryParameters.php
@@ -34,7 +34,7 @@ class TestNullableQueryParameters extends \Jane\Component\OpenApi3\Tests\Expecte
         $optionsResolver->setDefined(array('testNullableInteger'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('testNullableInteger', array('int', 'null'));
+        $optionsResolver->addAllowedTypes('testNullableInteger', array('int', 'null'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/AddOrDeleteRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/AddOrDeleteRules.php
@@ -43,7 +43,7 @@ class AddOrDeleteRules extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\C
         $optionsResolver->setDefined(array('dry_run'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('dry_run', array('bool'));
+        $optionsResolver->addAllowedTypes('dry_run', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindPrivateTweetMetricsById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindPrivateTweetMetricsById.php
@@ -38,7 +38,7 @@ class FindPrivateTweetMetricsById extends \Jane\Component\OpenApi3\Tests\Expecte
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array('ids'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array'));
+        $optionsResolver->addAllowedTypes('ids', array('array'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindTweetsById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindTweetsById.php
@@ -43,12 +43,12 @@ class FindTweetsById extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cli
         $optionsResolver->setDefined(array('ids', 'format', 'tweet.format', 'user.format', 'place.format', 'expansions'));
         $optionsResolver->setRequired(array('ids'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array'));
-        $optionsResolver->setAllowedTypes('format', array('string'));
-        $optionsResolver->setAllowedTypes('tweet.format', array('string'));
-        $optionsResolver->setAllowedTypes('user.format', array('string'));
-        $optionsResolver->setAllowedTypes('place.format', array('string'));
-        $optionsResolver->setAllowedTypes('expansions', array('array'));
+        $optionsResolver->addAllowedTypes('ids', array('array'));
+        $optionsResolver->addAllowedTypes('format', array('string'));
+        $optionsResolver->addAllowedTypes('tweet.format', array('string'));
+        $optionsResolver->addAllowedTypes('user.format', array('string'));
+        $optionsResolver->addAllowedTypes('place.format', array('string'));
+        $optionsResolver->addAllowedTypes('expansions', array('array'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindUsersByIdOrUsername.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindUsersByIdOrUsername.php
@@ -44,13 +44,13 @@ class FindUsersByIdOrUsername extends \Jane\Component\OpenApi3\Tests\Expected\Ru
         $optionsResolver->setDefined(array('ids', 'usernames', 'format', 'tweet.format', 'user.format', 'place.format', 'expansions'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array'));
-        $optionsResolver->setAllowedTypes('usernames', array('array'));
-        $optionsResolver->setAllowedTypes('format', array('string'));
-        $optionsResolver->setAllowedTypes('tweet.format', array('string'));
-        $optionsResolver->setAllowedTypes('user.format', array('string'));
-        $optionsResolver->setAllowedTypes('place.format', array('string'));
-        $optionsResolver->setAllowedTypes('expansions', array('array'));
+        $optionsResolver->addAllowedTypes('ids', array('array'));
+        $optionsResolver->addAllowedTypes('usernames', array('array'));
+        $optionsResolver->addAllowedTypes('format', array('string'));
+        $optionsResolver->addAllowedTypes('tweet.format', array('string'));
+        $optionsResolver->addAllowedTypes('user.format', array('string'));
+        $optionsResolver->addAllowedTypes('place.format', array('string'));
+        $optionsResolver->addAllowedTypes('expansions', array('array'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/GetRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/GetRules.php
@@ -38,7 +38,7 @@ class GetRules extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Ba
         $optionsResolver->setDefined(array('ids'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array'));
+        $optionsResolver->addAllowedTypes('ids', array('array'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamFilter.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamFilter.php
@@ -38,7 +38,7 @@ class StreamFilter extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Clien
         $optionsResolver->setDefined(array('expansions'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('expansions', array('array'));
+        $optionsResolver->addAllowedTypes('expansions', array('array'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamSample.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamSample.php
@@ -38,7 +38,7 @@ class StreamSample extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Clien
         $optionsResolver->setDefined(array('expansions'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('expansions', array('array'));
+        $optionsResolver->addAllowedTypes('expansions', array('array'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/TweetsRecentSearch.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/TweetsRecentSearch.php
@@ -49,18 +49,18 @@ class TweetsRecentSearch extends \Jane\Component\OpenApi3\Tests\Expected\Runtime
         $optionsResolver->setDefined(array('query', 'start_time', 'end_time', 'since_id', 'until_id', 'max_results', 'next_token', 'format', 'tweet.format', 'user.format', 'place.format', 'expansions'));
         $optionsResolver->setRequired(array('query'));
         $optionsResolver->setDefaults(array('max_results' => 10));
-        $optionsResolver->setAllowedTypes('query', array('string'));
-        $optionsResolver->setAllowedTypes('start_time', array('string'));
-        $optionsResolver->setAllowedTypes('end_time', array('string'));
-        $optionsResolver->setAllowedTypes('since_id', array('string'));
-        $optionsResolver->setAllowedTypes('until_id', array('string'));
-        $optionsResolver->setAllowedTypes('max_results', array('int'));
-        $optionsResolver->setAllowedTypes('next_token', array('string'));
-        $optionsResolver->setAllowedTypes('format', array('string'));
-        $optionsResolver->setAllowedTypes('tweet.format', array('string'));
-        $optionsResolver->setAllowedTypes('user.format', array('string'));
-        $optionsResolver->setAllowedTypes('place.format', array('string'));
-        $optionsResolver->setAllowedTypes('expansions', array('array'));
+        $optionsResolver->addAllowedTypes('query', array('string'));
+        $optionsResolver->addAllowedTypes('start_time', array('string'));
+        $optionsResolver->addAllowedTypes('end_time', array('string'));
+        $optionsResolver->addAllowedTypes('since_id', array('string'));
+        $optionsResolver->addAllowedTypes('until_id', array('string'));
+        $optionsResolver->addAllowedTypes('max_results', array('int'));
+        $optionsResolver->addAllowedTypes('next_token', array('string'));
+        $optionsResolver->addAllowedTypes('format', array('string'));
+        $optionsResolver->addAllowedTypes('tweet.format', array('string'));
+        $optionsResolver->addAllowedTypes('user.format', array('string'));
+        $optionsResolver->addAllowedTypes('place.format', array('string'));
+        $optionsResolver->addAllowedTypes('expansions', array('array'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/AddOrDeleteRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/AddOrDeleteRules.php
@@ -43,7 +43,7 @@ class AddOrDeleteRules extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\Base
         $optionsResolver->setDefined(array('dry_run'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('dry_run', array('bool'));
+        $optionsResolver->addAllowedTypes('dry_run', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/FindTweetsById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/FindTweetsById.php
@@ -43,12 +43,12 @@ class FindTweetsById extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\BaseEn
         $optionsResolver->setDefined(array('ids', 'format', 'tweet.format', 'user.format', 'place.format', 'expansions'));
         $optionsResolver->setRequired(array('ids'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array'));
-        $optionsResolver->setAllowedTypes('format', array('string'));
-        $optionsResolver->setAllowedTypes('tweet.format', array('string'));
-        $optionsResolver->setAllowedTypes('user.format', array('string'));
-        $optionsResolver->setAllowedTypes('place.format', array('string'));
-        $optionsResolver->setAllowedTypes('expansions', array('array'));
+        $optionsResolver->addAllowedTypes('ids', array('array'));
+        $optionsResolver->addAllowedTypes('format', array('string'));
+        $optionsResolver->addAllowedTypes('tweet.format', array('string'));
+        $optionsResolver->addAllowedTypes('user.format', array('string'));
+        $optionsResolver->addAllowedTypes('place.format', array('string'));
+        $optionsResolver->addAllowedTypes('expansions', array('array'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/AddOrDeleteRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/AddOrDeleteRules.php
@@ -43,7 +43,7 @@ class AddOrDeleteRules extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\C
         $optionsResolver->setDefined(array('dry_run'));
         $optionsResolver->setRequired(array());
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('dry_run', array('bool'));
+        $optionsResolver->addAllowedTypes('dry_run', array('bool'));
         return $optionsResolver;
     }
     /**

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/FindTweetsById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/FindTweetsById.php
@@ -43,12 +43,12 @@ class FindTweetsById extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cli
         $optionsResolver->setDefined(array('ids', 'format', 'tweet.format', 'user.format', 'place.format', 'expansions'));
         $optionsResolver->setRequired(array('ids'));
         $optionsResolver->setDefaults(array());
-        $optionsResolver->setAllowedTypes('ids', array('array'));
-        $optionsResolver->setAllowedTypes('format', array('string'));
-        $optionsResolver->setAllowedTypes('tweet.format', array('string'));
-        $optionsResolver->setAllowedTypes('user.format', array('string'));
-        $optionsResolver->setAllowedTypes('place.format', array('string'));
-        $optionsResolver->setAllowedTypes('expansions', array('array'));
+        $optionsResolver->addAllowedTypes('ids', array('array'));
+        $optionsResolver->addAllowedTypes('format', array('string'));
+        $optionsResolver->addAllowedTypes('tweet.format', array('string'));
+        $optionsResolver->addAllowedTypes('user.format', array('string'));
+        $optionsResolver->addAllowedTypes('place.format', array('string'));
+        $optionsResolver->addAllowedTypes('expansions', array('array'));
         return $optionsResolver;
     }
     /**


### PR DESCRIPTION
What's done:
- if parameter name contains `[]`, we remove it, add append "allowed" type to already existing one parameter (without `[]`)
- this way OptionResolver will accept both single and multi-value under same key
- http_query_build will build almost correct QS (brackets will contain index)