### PR TITLE
WIP: record location in validation errors

### DIFF
--- a/src/Component/JsonSchema/Guesser/JsonSchema/ObjectGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/ObjectGuesser.php
@@ -122,7 +122,7 @@ class ObjectGuesser implements GuesserInterface, PropertiesGuesserInterface, Typ
             if (method_exists($propertyObj, 'getDeprecated')) {
                 $newProperty->setDeprecated($propertyObj->getDeprecated());
             }
-            $this->chainValidator->guess($propertyObj, $name, $newProperty);
+            $this->chainValidator->guess($propertyObj, $key, $newProperty);
             $properties[$key] = $newProperty;
         }
 

--- a/src/Component/JsonSchema/Guesser/Validator/Array_/MinItemsValidator.php
+++ b/src/Component/JsonSchema/Guesser/Validator/Array_/MinItemsValidator.php
@@ -27,7 +27,7 @@ class MinItemsValidator implements ValidatorInterface
     {
         $guess->addValidatorGuess(new ValidatorGuess(Count::class, [
             'min' => $object->getMinItems(),
-            'minMessage' => 'This array has not enough values. It should have {{ limit }} values or more.',
+            'minMessage' => 'Array "'.$name.'" has not enough values. It should have {{ limit }} values or more.',
         ]));
     }
 }


### PR DESCRIPTION
validation errors currently are very unhelpful because they do not report which data field was the cause of the failure. this makes debugging unnecessary complicated.

if we use the $key instead of $name ($name is the root name of the schema), we know which field is the problem. this could be even better if we could get the whole breadcrumb, but for that the whole validator would have to be rewritten to keep track of some sort of breadcrumb stack to the current property.

if you are happy with this approach, i will update all guessers to integrate the name into their messages.