### PR TITLE
OpenAPI; support anyOf reference or null property in schema

### DIFF
--- a/src/Component/OpenApi3/Guesser/OpenApiSchema/AnyOfReferencefGuesser.php
+++ b/src/Component/OpenApi3/Guesser/OpenApiSchema/AnyOfReferencefGuesser.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Component\OpenApi3\Guesser\OpenApiSchema;
+
+use Jane\Component\JsonSchema\Generator\Naming;
+use Jane\Component\JsonSchema\Guesser\ChainGuesserAwareInterface;
+use Jane\Component\JsonSchema\Guesser\ChainGuesserAwareTrait;
+use Jane\Component\JsonSchema\Guesser\Guess\MultipleType;
+use Jane\Component\JsonSchema\Guesser\Guess\Type;
+use Jane\Component\JsonSchema\Guesser\GuesserInterface;
+use Jane\Component\JsonSchema\Guesser\GuesserResolverTrait;
+use Jane\Component\JsonSchema\Guesser\TypeGuesserInterface;
+use Jane\Component\JsonSchema\Registry\Registry;
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\JsonSchema\Model\Schema;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class AnyOfReferencefGuesser implements ChainGuesserAwareInterface, GuesserInterface, TypeGuesserInterface
+{
+    use ChainGuesserAwareTrait;
+    use GuesserResolverTrait;
+
+    protected $schemaClass;
+    protected $naming;
+
+    public function __construct(SerializerInterface $serializer, Naming $naming, string $schemaClass)
+    {
+        $this->serializer = $serializer;
+        $this->schemaClass = $schemaClass;
+        $this->naming = $naming;
+    }
+
+    public function supportObject($object): bool
+    {
+        return $object instanceof Schema && \is_array($object->getAnyOf()) && $object->getAnyOf()[0] instanceof Reference;
+    }
+
+    public function guessType($object, string $name, string $reference, Registry $registry): Type
+    {
+        $type = new MultipleType($object);
+        if ($object instanceof Schema) {
+            foreach ($object->getAnyOf() as $index => $anyOf) {
+                if ($anyOf === null) {
+                    continue;
+                }
+                $anyOfSchema = $anyOf;
+                $anyOfReference = $reference . '/anyOf/' . $index;
+
+                if ($anyOf instanceof Reference) {
+                    $anyOfReference = (string) $anyOf->getMergedUri();
+
+                    if ((string) $anyOf->getMergedUri() === (string) $anyOf->getMergedUri()->withFragment('')) {
+                        $anyOfReference .= '#';
+                    }
+
+                    $anyOfSchema = $this->resolve($anyOfSchema, $this->schemaClass);
+                }
+                if (null !== $anyOfSchema->getType()) {
+                    $anyOfType = $this->chainGuesser->guessType($anyOfSchema, $name, $anyOfReference, $registry);
+                    $type->addType($anyOfType);
+                }
+            }
+        }
+
+        return $type;
+    }
+}

--- a/src/Component/OpenApi3/Guesser/OpenApiSchema/GuesserFactory.php
+++ b/src/Component/OpenApi3/Guesser/OpenApiSchema/GuesserFactory.php
@@ -39,6 +39,7 @@ class GuesserFactory
         $chainGuesser->addGuesser(new SchemaGuesser($naming, $serializer));
         $chainGuesser->addGuesser(new AdditionalPropertiesGuesser(Schema::class));
         $chainGuesser->addGuesser(new AllOfGuesser($serializer, $naming, Schema::class));
+        $chainGuesser->addGuesser(new AnyOfReferencefGuesser($serializer, $naming, Schema::class));
         $chainGuesser->addGuesser(new ArrayGuesser(Schema::class));
         $chainGuesser->addGuesser(new ItemsGuesser(Schema::class));
         $chainGuesser->addGuesser(new SimpleTypeGuesser(Schema::class));

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.yaml',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Client.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetUserNotFoundException
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\Account|\Psr\Http\Message\ResponseInterface
+     */
+    public function getUser(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetUser(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = array(), array $additionalNormalizers = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer());
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Endpoint/GetUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Endpoint/GetUser.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetUser extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod() : string
+    {
+        return 'GET';
+    }
+    public function getUri() : string
+    {
+        return '/user';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    {
+        return array(array(), null);
+    }
+    public function getExtraHeaders() : array
+    {
+        return array('Accept' => array('application/json'));
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\GetUserNotFoundException
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\Account
+     */
+    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        if (is_null($contentType) === false && (200 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Account', 'json');
+        }
+        if (404 === $status) {
+            throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\GetUserNotFoundException();
+        }
+    }
+    public function getAuthenticationScopes() : array
+    {
+        return array();
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/ApiException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/ClientException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/GetUserNotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/GetUserNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class GetUserNotFoundException extends NotFoundException
+{
+    public function __construct()
+    {
+        parent::__construct('Resource not found');
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/NotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class NotFoundException extends \RuntimeException implements ClientException
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 404);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/ServerException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Model/Account.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Model/Account.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class Account
+{
+    /**
+     * 
+     *
+     * @var int
+     */
+    protected $id;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $firstname;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $lastname;
+    /**
+     * 
+     *
+     * @var Country|null
+     */
+    protected $countryOfBirth;
+    /**
+     * 
+     *
+     * @var Country
+     */
+    protected $country;
+    /**
+     * 
+     *
+     * @return int
+     */
+    public function getId() : int
+    {
+        return $this->id;
+    }
+    /**
+     * 
+     *
+     * @param int $id
+     *
+     * @return self
+     */
+    public function setId(int $id) : self
+    {
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getFirstname() : string
+    {
+        return $this->firstname;
+    }
+    /**
+     * 
+     *
+     * @param string $firstname
+     *
+     * @return self
+     */
+    public function setFirstname(string $firstname) : self
+    {
+        $this->firstname = $firstname;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getLastname() : string
+    {
+        return $this->lastname;
+    }
+    /**
+     * 
+     *
+     * @param string $lastname
+     *
+     * @return self
+     */
+    public function setLastname(string $lastname) : self
+    {
+        $this->lastname = $lastname;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return Country|null
+     */
+    public function getCountryOfBirth() : ?Country
+    {
+        return $this->countryOfBirth;
+    }
+    /**
+     * 
+     *
+     * @param Country|null $countryOfBirth
+     *
+     * @return self
+     */
+    public function setCountryOfBirth(?Country $countryOfBirth) : self
+    {
+        $this->countryOfBirth = $countryOfBirth;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return Country
+     */
+    public function getCountry() : Country
+    {
+        return $this->country;
+    }
+    /**
+     * 
+     *
+     * @param Country $country
+     *
+     * @return self
+     */
+    public function setCountry(Country $country) : self
+    {
+        $this->country = $country;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Model/Country.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Model/Country.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class Country
+{
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $iso;
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $printableName;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getIso() : string
+    {
+        return $this->iso;
+    }
+    /**
+     * 
+     *
+     * @param string $iso
+     *
+     * @return self
+     */
+    public function setIso(string $iso) : self
+    {
+        $this->iso = $iso;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getPrintableName() : string
+    {
+        return $this->printableName;
+    }
+    /**
+     * 
+     *
+     * @param string $printableName
+     *
+     * @return self
+     */
+    public function setPrintableName(string $printableName) : self
+    {
+        $this->printableName = $printableName;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Normalizer/AccountNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Normalizer/AccountNormalizer.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class AccountNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization($data, $type, $format = null) : bool
+    {
+        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Account';
+    }
+    public function supportsNormalization($data, $format = null) : bool
+    {
+        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Account';
+    }
+    /**
+     * @return mixed
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Account();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+        }
+        if (\array_key_exists('firstname', $data)) {
+            $object->setFirstname($data['firstname']);
+        }
+        if (\array_key_exists('lastname', $data)) {
+            $object->setLastname($data['lastname']);
+        }
+        if (\array_key_exists('countryOfBirth', $data) && $data['countryOfBirth'] !== null) {
+            $value = $data['countryOfBirth'];
+            if (is_array($data['countryOfBirth'])) {
+                $value = $this->denormalizer->denormalize($data['countryOfBirth'], 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Country', 'json', $context);
+            }
+            $object->setCountryOfBirth($value);
+        }
+        elseif (\array_key_exists('countryOfBirth', $data) && $data['countryOfBirth'] === null) {
+            $object->setCountryOfBirth(null);
+        }
+        if (\array_key_exists('country', $data)) {
+            $object->setCountry($this->denormalizer->denormalize($data['country'], 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Country', 'json', $context));
+        }
+        return $object;
+    }
+    /**
+     * @return array|string|int|float|bool|\ArrayObject|null
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getFirstname()) {
+            $data['firstname'] = $object->getFirstname();
+        }
+        if (null !== $object->getLastname()) {
+            $data['lastname'] = $object->getLastname();
+        }
+        if (null !== $object->getCountryOfBirth()) {
+            $value = $object->getCountryOfBirth();
+            if (is_object($object->getCountryOfBirth())) {
+                $value = $this->normalizer->normalize($object->getCountryOfBirth(), 'json', $context);
+            }
+            $data['countryOfBirth'] = $value;
+        }
+        if (null !== $object->getCountry()) {
+            $data['country'] = $this->normalizer->normalize($object->getCountry(), 'json', $context);
+        }
+        return $data;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Normalizer/CountryNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Normalizer/CountryNormalizer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class CountryNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization($data, $type, $format = null) : bool
+    {
+        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Country';
+    }
+    public function supportsNormalization($data, $format = null) : bool
+    {
+        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Country';
+    }
+    /**
+     * @return mixed
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Country();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('iso', $data)) {
+            $object->setIso($data['iso']);
+        }
+        if (\array_key_exists('printableName', $data)) {
+            $object->setPrintableName($data['printableName']);
+        }
+        return $object;
+    }
+    /**
+     * @return array|string|int|float|bool|\ArrayObject|null
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if (null !== $object->getIso()) {
+            $data['iso'] = $object->getIso();
+        }
+        if (null !== $object->getPrintableName()) {
+            $data['printableName'] = $object->getPrintableName();
+        }
+        return $data;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = array('Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Account' => 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Normalizer\\AccountNormalizer', 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Country' => 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Normalizer\\CountryNormalizer', '\\Jane\\Component\\JsonSchemaRuntime\\Reference' => '\\Jane\\Component\\OpenApi3\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null) : bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null) : bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    /**
+     * @return array|string|int|float|bool|\ArrayObject|null
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    /**
+     * @return mixed
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected $queryParameters = [];
+    protected $headerParameters = [];
+    protected $body;
+    public abstract function getMethod() : string;
+    public abstract function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    public abstract function getUri() : string;
+    public abstract function getAuthenticationScopes() : array;
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders() : array
+    {
+        return [];
+    }
+    public function getQueryString() : string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(function ($value) {
+            return null !== $value ? $value : '';
+        }, $optionsResolved);
+        return http_build_query($optionsResolved, '', '&', PHP_QUERY_RFC3986);
+    }
+    public function getHeaders(array $baseHeaders = []) : array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getHeadersOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody() : array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null) : array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer) : array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Client.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    /**
+     * @var ClientInterface
+     */
+    protected $httpClient;
+    /**
+     * @var RequestFactoryInterface
+     */
+    protected $requestFactory;
+    /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+    /**
+     * @var StreamFactoryInterface
+     */
+    protected $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString() : string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri() : string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod() : string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []) : array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes() : array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array) : bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $object->getReferenceUri();
+        return $ref;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null) : bool
+    {
+        return $data instanceof Reference;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends \RuntimeException
+{
+    /** @var ConstraintViolationListInterface */
+    private $violationList;
+    public function __construct(ConstraintViolationListInterface $violationList)
+    {
+        $this->violationList = $violationList;
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList() : ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint) : void
+    {
+        $validator = \Symfony\Component\Validator\Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/openapi.yaml
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/openapi.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.0
+info:
+  title: 'Any of nullable object in property'
+  version: ''
+paths:
+  /user:
+    get:
+      operationId: get_user
+      responses:
+        200:
+          description: 'Account resource'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+        404:
+          description: 'Resource not found'
+
+components:
+  schemas:
+    Account:
+      type: object
+      description: User.
+      properties:
+        id:
+          readOnly: true
+          type: integer
+        firstname:
+          type: string
+        lastname:
+          type: string
+        countryOfBirth:
+          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Country'
+        country:
+          $ref: '#/components/schemas/Country'
+    Country:
+      type: object
+      properties:
+        iso:
+          type: string
+        printableName:
+          type: string

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/Installation.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/Installation.php
@@ -13,7 +13,7 @@ class Installation
     /**
      * 
      *
-     * @var mixed|null
+     * @var SimpleUser|Enterprise|null
      */
     protected $account;
     /**
@@ -136,7 +136,7 @@ class Installation
     /**
      * 
      *
-     * @return mixed
+     * @return SimpleUser|Enterprise|null
      */
     public function getAccount()
     {
@@ -145,7 +145,7 @@ class Installation
     /**
      * 
      *
-     * @param mixed $account
+     * @param SimpleUser|Enterprise|null $account
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/InstallationNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/InstallationNormalizer.php
@@ -49,7 +49,13 @@ class InstallationNormalizer implements DenormalizerInterface, NormalizerInterfa
             $object->setId($data['id']);
         }
         if (\array_key_exists('account', $data) && $data['account'] !== null) {
-            $object->setAccount($data['account']);
+            $value = $data['account'];
+            if (is_array($data['account']) and isset($data['account']['login']) and isset($data['account']['id']) and isset($data['account']['node_id']) and isset($data['account']['avatar_url']) and isset($data['account']['gravatar_id']) and isset($data['account']['url']) and isset($data['account']['html_url']) and isset($data['account']['followers_url']) and isset($data['account']['following_url']) and isset($data['account']['gists_url']) and isset($data['account']['starred_url']) and isset($data['account']['subscriptions_url']) and isset($data['account']['organizations_url']) and isset($data['account']['repos_url']) and isset($data['account']['events_url']) and isset($data['account']['received_events_url']) and isset($data['account']['type']) and isset($data['account']['site_admin'])) {
+                $value = $this->denormalizer->denormalize($data['account'], 'Github\\Model\\SimpleUser', 'json', $context);
+            } elseif (is_array($data['account']) and isset($data['account']['html_url']) and isset($data['account']['id']) and isset($data['account']['node_id']) and isset($data['account']['name']) and isset($data['account']['slug']) and isset($data['account']['created_at']) and isset($data['account']['updated_at']) and isset($data['account']['avatar_url'])) {
+                $value = $this->denormalizer->denormalize($data['account'], 'Github\\Model\\Enterprise', 'json', $context);
+            }
+            $object->setAccount($value);
         }
         elseif (\array_key_exists('account', $data) && $data['account'] === null) {
             $object->setAccount(null);
@@ -80,8 +86,8 @@ class InstallationNormalizer implements DenormalizerInterface, NormalizerInterfa
         }
         if (\array_key_exists('events', $data)) {
             $values = array();
-            foreach ($data['events'] as $value) {
-                $values[] = $value;
+            foreach ($data['events'] as $value_1) {
+                $values[] = $value_1;
             }
             $object->setEvents($values);
         }
@@ -127,7 +133,13 @@ class InstallationNormalizer implements DenormalizerInterface, NormalizerInterfa
     {
         $data = array();
         $data['id'] = $object->getId();
-        $data['account'] = $object->getAccount();
+        $value = $object->getAccount();
+        if (is_object($object->getAccount())) {
+            $value = $this->normalizer->normalize($object->getAccount(), 'json', $context);
+        } elseif (is_object($object->getAccount())) {
+            $value = $this->normalizer->normalize($object->getAccount(), 'json', $context);
+        }
+        $data['account'] = $value;
         $data['repository_selection'] = $object->getRepositorySelection();
         $data['access_tokens_url'] = $object->getAccessTokensUrl();
         $data['repositories_url'] = $object->getRepositoriesUrl();
@@ -137,8 +149,8 @@ class InstallationNormalizer implements DenormalizerInterface, NormalizerInterfa
         $data['target_type'] = $object->getTargetType();
         $data['permissions'] = $this->normalizer->normalize($object->getPermissions(), 'json', $context);
         $values = array();
-        foreach ($object->getEvents() as $value) {
-            $values[] = $value;
+        foreach ($object->getEvents() as $value_1) {
+            $values[] = $value_1;
         }
         $data['events'] = $values;
         $data['created_at'] = $object->getCreatedAt()->format('Y-m-d\\TH:i:sP');


### PR DESCRIPTION
The OpenAPI 3.0 schema allows an anyOf reference as a property that can also be nullable. Example;

```yaml
components:
  schemas:
    Account:
      type: object
      description: User.
      properties:
        id:
          readOnly: true
          type: integer
        firstname:
          type: string
        lastname:
          type: string
        countryOfBirth:
          nullable: true
          anyOf:
            - $ref: '#/components/schemas/Country'
        country:
          $ref: '#/components/schemas/Country'
    Country:
      type: object
      properties:
        iso:
          type: string
        printableName:
          type: string
```

Before this fix the reference would not be denormalized but only added raw as an array. You can see this in the github testcase with the Installation schema.

This adds a new Guesser that checks for anyOf references to be used as a MultipleType. The end result will be updated normalizers that converts array shapes into concrete objects.

![Screenshot from 2022-09-20 16-27-37](https://user-images.githubusercontent.com/5694009/191518214-ee6e55f4-1aa4-41e6-97c8-5d1e2ae87923.png)
