### PR TITLE
tests(openapi): simple object should not generate object

### DIFF
--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.json',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Client.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    public static function create($httpClient = null, array $additionalPlugins = array(), array $additionalNormalizers = array())
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = array();
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = array(new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer());
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, array(new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(array('json_decode_associative' => true)))));
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Model/Foo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Model/Foo.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class Foo extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = array();
+    public function isInitialized($property) : bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var mixed
+     */
+    protected $bar;
+    /**
+     * @return mixed
+     */
+    public function getBar()
+    {
+        return $this->bar;
+    }
+    /**
+     * @param mixed $bar
+     *
+     * @return self
+     */
+    public function setBar($bar) : self
+    {
+        $this->initialized['bar'] = true;
+        $this->bar = $bar;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Normalizer/BarNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Normalizer/BarNormalizer.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class BarNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization($data, $type, $format = null) : bool
+    {
+        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Bar';
+    }
+    public function supportsNormalization($data, $format = null) : bool
+    {
+        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Bar';
+    }
+    /**
+     * @return mixed
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Bar();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('code', $data)) {
+            $values = new \ArrayObject(array(), \ArrayObject::ARRAY_AS_PROPS);
+            foreach ($data['code'] as $key => $value) {
+                $values[$key] = $value;
+            }
+            $object->setCode($values);
+            unset($data['code']);
+        }
+        foreach ($data as $key_1 => $value_1) {
+            if (preg_match('/.*/', (string) $key_1)) {
+                $object[$key_1] = $value_1;
+            }
+        }
+        return $object;
+    }
+    /**
+     * @return array|string|int|float|bool|\ArrayObject|null
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if ($object->isInitialized('code') && null !== $object->getCode()) {
+            $values = array();
+            foreach ($object->getCode() as $key => $value) {
+                $values[$key] = $value;
+            }
+            $data['code'] = $values;
+        }
+        foreach ($object as $key_1 => $value_1) {
+            if (preg_match('/.*/', (string) $key_1)) {
+                $data[$key_1] = $value_1;
+            }
+        }
+        return $data;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Normalizer/FooNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Normalizer/FooNormalizer.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FooNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization($data, $type, $format = null) : bool
+    {
+        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Foo';
+    }
+    public function supportsNormalization($data, $format = null) : bool
+    {
+        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Foo';
+    }
+    /**
+     * @return mixed
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        if (isset($data['$ref'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Foo();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('bar', $data)) {
+            $values = new \ArrayObject(array(), \ArrayObject::ARRAY_AS_PROPS);
+            foreach ($data['bar'] as $key => $value) {
+                $values[$key] = $value;
+            }
+            $object->setBar($values);
+            unset($data['bar']);
+        }
+        foreach ($data as $key_1 => $value_1) {
+            if (preg_match('/.*/', (string) $key_1)) {
+                $object[$key_1] = $value_1;
+            }
+        }
+        return $object;
+    }
+    /**
+     * @return array|string|int|float|bool|\ArrayObject|null
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $data = array();
+        if ($object->isInitialized('bar') && null !== $object->getBar()) {
+            $values = array();
+            foreach ($object->getBar() as $key => $value) {
+                $values[$key] = $value;
+            }
+            $data['bar'] = $values;
+        }
+        foreach ($object as $key_1 => $value_1) {
+            if (preg_match('/.*/', (string) $key_1)) {
+                $data[$key_1] = $value_1;
+            }
+        }
+        return $data;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = array('Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Foo' => 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Normalizer\\FooNormalizer', '\\Jane\\Component\\JsonSchemaRuntime\\Reference' => '\\Jane\\Component\\OpenApi3\\Tests\\Expected\\Runtime\\Normalizer\\ReferenceNormalizer'), $normalizersCache = array();
+    public function supportsDenormalization($data, $type, $format = null) : bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization($data, $format = null) : bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    /**
+     * @return array|string|int|float|bool|\ArrayObject|null
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        $normalizerClass = $this->normalizers[get_class($object)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($object, $format, $context);
+    }
+    /**
+     * @return mixed
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        $denormalizerClass = $this->normalizers[$class];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $class, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected $queryParameters = [];
+    protected $headerParameters = [];
+    protected $body;
+    public abstract function getMethod() : string;
+    public abstract function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    public abstract function getUri() : string;
+    public abstract function getAuthenticationScopes() : array;
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders() : array
+    {
+        return [];
+    }
+    public function getQueryString() : string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(function ($value) {
+            return null !== $value ? $value : '';
+        }, $optionsResolved);
+        return http_build_query($optionsResolved, '', '&', PHP_QUERY_RFC3986);
+    }
+    public function getHeaders(array $baseHeaders = []) : array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getHeadersOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody() : array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null) : array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver() : OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer) : array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Client/Client.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    /**
+     * @var ClientInterface
+     */
+    protected $httpClient;
+    /**
+     * @var RequestFactoryInterface
+     */
+    protected $requestFactory;
+    /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+    /**
+     * @var StreamFactoryInterface
+     */
+    protected $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint) : ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString() : string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri() : string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod() : string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []) : array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes() : array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array) : bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $object->getReferenceUri();
+        return $ref;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null) : bool
+    {
+        return $data instanceof Reference;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends \RuntimeException
+{
+    /** @var ConstraintViolationListInterface */
+    private $violationList;
+    public function __construct(ConstraintViolationListInterface $violationList)
+    {
+        $this->violationList = $violationList;
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList() : ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint) : void
+    {
+        $validator = \Symfony\Component\Validator\Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/swagger.json
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-object-should-not-generate-arrays/swagger.json
@@ -1,0 +1,24 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "paths": {
+    },
+    "components": {
+        "schemas": {
+            "Foo": {
+                "properties": {
+                    "bar": {
+                        "$ref": "#\/components\/schemas\/Bar"
+                    }
+                },
+                "type": "object"
+            },
+            "Bar": {
+                "type": "object"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello,

here is a failing test case for a problem which occurs in `jane-php/open-api-3` version `7.4.0`. Problem was not present in `7.3.1`

given this deifnition
```json
    "components": {
        "schemas": {
            "Foo": {
                "properties": {
                    "bar": {
                        "$ref": "#\/components\/schemas\/Bar"
                    }
                },
                "type": "object"
            },
            "Bar": {
                "type": "object"
            }
        }
    }
```

I expect the type of property `Foo:$bar` to be `mixed`, and not `mixed[]`

WDYT?