### PR TITLE
[OpenApi3] FormBodyContentGenerator - multipart/form-data body is ignored because of header typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [OpenApi3] [GH#690](https://github.com/janephp/janephp/pull/690) Content-Type header typo for multipart/form-data.
 
 ## [7.4.1] - 2023-01-16
 ### Changed

--- a/src/Component/OpenApi3/Generator/RequestBodyContent/FormBodyContentGenerator.php
+++ b/src/Component/OpenApi3/Generator/RequestBodyContent/FormBodyContentGenerator.php
@@ -51,7 +51,7 @@ class FormBodyContentGenerator extends AbstractBodyContentGenerator
                                     new Scalar\String_('multipart/form-data; boundary="'),
                                     new Expr\BinaryOp\Concat(
                                         new Expr\MethodCall(new Expr\Variable('bodyBuilder'), 'getBoundary'),
-                                        new Scalar\String_('""')
+                                        new Scalar\String_('"')
                                     )
                                 )
                             )]),

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestFormFileParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestFormFileParameters.php
@@ -31,7 +31,7 @@ class TestFormFileParameters extends \Jane\Component\OpenApi3\Tests\Expected\Run
                 $value = is_int($value) ? (string) $value : $value;
                 $bodyBuilder->addResource($key, $value);
             }
-            return array(array('Content-Type' => array('multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '""'))), $bodyBuilder->build());
+            return array(array('Content-Type' => array('multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"'))), $bodyBuilder->build());
         }
         return array(array(), null);
     }


### PR DESCRIPTION
`FormBodyContentGenerator` gives _Content-Type_ header with an extra '"' at the end (example bellows) what causes that data is ignored:

```
Content-Type: multipart/form-data; boundary="63c6cf83927f57.77844038""
```