### PR TITLE
Fix circular reference OOM; improve Windows paths support

### DIFF
--- a/src/Component/JsonSchema/Guesser/JsonSchema/ArrayGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/ArrayGuesser.php
@@ -18,6 +18,9 @@ class ArrayGuesser implements GuesserInterface, TypeGuesserInterface, ChainGuess
 {
     use ChainGuesserAwareTrait;
 
+    /** @var array<string, int> */
+    protected $refGuessLevel = [];
+
     /**
      * {@inheritdoc}
      */
@@ -41,6 +44,12 @@ class ArrayGuesser implements GuesserInterface, TypeGuesserInterface, ChainGuess
      */
     public function guessType($object, string $name, string $reference, Registry $registry): Type
     {
+        $this->refGuessLevel[$reference] = ($this->refGuessLevel[$reference] ?? 0) + 1;
+
+        if ($this->refGuessLevel[$reference] > 20) {
+            return new ArrayType($object, new Type($object, 'mixed'));
+        }
+
         $items = $object->getItems();
 
         if (null === $items || (\is_array($items) && 0 === \count($items))) {

--- a/src/Component/JsonSchema/Registry/Registry.php
+++ b/src/Component/JsonSchema/Registry/Registry.php
@@ -33,6 +33,7 @@ class Registry implements RegistryInterface
 
     public function getSchema(string $reference): ?Schema
     {
+        $reference = $this->fixPath($reference);
         $uri = Http::createFromString($reference);
         $schemaUri = (string) $uri->withFragment('');
 
@@ -81,5 +82,14 @@ class Registry implements RegistryInterface
     public function getOptionsHash(): string
     {
         return md5(json_encode([]));
+    }
+
+    private function fixPath(string $path): string
+    {
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $path = lcfirst(str_replace(DIRECTORY_SEPARATOR, '/', $path));
+        }
+
+        return $path;
     }
 }

--- a/src/Component/JsonSchema/Registry/Schema.php
+++ b/src/Component/JsonSchema/Registry/Schema.php
@@ -193,6 +193,9 @@ class Schema implements SchemaInterface
 
     private function fixPath(string $path): string
     {
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $path = lcfirst(str_replace(DIRECTORY_SEPARATOR, '/', $path));
+        }
         $path = preg_replace('#([^:]){1}/{2,}#', '$1/', $path);
 
         if ('/' === $path) {

--- a/src/Component/JsonSchema/Tests/JaneBaseTest.php
+++ b/src/Component/JsonSchema/Tests/JaneBaseTest.php
@@ -16,7 +16,7 @@ class JaneBaseTest extends TestCase
     /**
      * @dataProvider schemaProvider
      */
-    public function testRessources(SplFileInfo $testDirectory): void
+    public function testResources(SplFileInfo $testDirectory): void
     {
         // 1. Generate
         $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader());

--- a/src/Component/JsonSchemaRuntime/Reference.php
+++ b/src/Component/JsonSchemaRuntime/Reference.php
@@ -29,6 +29,8 @@ class Reference
 
     public function __construct(string $reference, string $origin)
     {
+        $reference = $this->fixPath($reference);
+        $origin = $this->fixPath($origin);
         $originParts = UriString::parse($origin);
         $referenceParts = parse_url($reference);
         $mergedParts = array_merge($originParts, $referenceParts);
@@ -174,5 +176,14 @@ class Reference
         }
 
         return implode('/', $resultPathParts);
+    }
+
+    private function fixPath(string $path): string
+    {
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $path = lcfirst(str_replace(DIRECTORY_SEPARATOR, '/', $path));
+        }
+
+        return $path;
     }
 }

--- a/src/Component/OpenApi2/Tests/JaneOpenApiResourceTest.php
+++ b/src/Component/OpenApi2/Tests/JaneOpenApiResourceTest.php
@@ -24,7 +24,7 @@ class JaneOpenApiResourceTest extends TestCase
     /**
      * @dataProvider resourceProvider
      */
-    public function testRessources($name, SplFileInfo $testDirectory): void
+    public function testResources($name, SplFileInfo $testDirectory): void
     {
         // 1. Cleanup generated
         $filesystem = new Filesystem();

--- a/src/Component/OpenApi3/Guesser/OpenApiSchema/OpenApiGuesser.php
+++ b/src/Component/OpenApi3/Guesser/OpenApiSchema/OpenApiGuesser.php
@@ -2,6 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Guesser\OpenApiSchema;
 
+use Jane\Component\AutoMapper\Exception\RuntimeException;
 use Jane\Component\JsonSchema\Guesser\ChainGuesserAwareInterface;
 use Jane\Component\JsonSchema\Guesser\ChainGuesserAwareTrait;
 use Jane\Component\JsonSchema\Guesser\ClassGuesserInterface;
@@ -206,7 +207,9 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
         $operationGuess = new OperationGuess($pathItem, $operation, $path, $operationType, $reference, $securityScopes);
         $operationName = $this->naming->getEndpointName($operationGuess);
 
-        $schema = $registry->getSchema($reference);
+        if (($schema = $registry->getSchema($reference)) === null) {
+            throw new RuntimeException("Schema for reference $reference could not be found");
+        }
         $schema->addOperation($reference, $operationGuess);
         $schema->initOperationRelations($operationName);
 

--- a/src/Component/OpenApi3/Tests/JaneOpenApiResourceTest.php
+++ b/src/Component/OpenApi3/Tests/JaneOpenApiResourceTest.php
@@ -23,7 +23,7 @@ class JaneOpenApiResourceTest extends TestCase
     /**
      * @dataProvider resourceProvider
      */
-    public function testRessources($name, SplFileInfo $testDirectory): void
+    public function testResources($name, SplFileInfo $testDirectory): void
     {
         // 1. Generate
         $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());


### PR DESCRIPTION
This PR fixes https://github.com/janephp/janephp/issues/692

I couldn't run the tests due to a few problems with Windows paths (the library seems to assume all paths are valid URIs..)

Additionally, the aformentioned problem was also causing null-pointer-exceptions;; so code was assuming that a schema is always available.
I fixed as little things as I could, just to get the tests to pass (with the exception of 2 typos).

After seeing the code, I'd like to point out a few notes:
1. Modern IDEs have inspections for when methods are chained unsafely (e.g. `$obj->findSomething()->useSomething()` - last method could cause NPE)
2. Naming conventions could be helpful: `getXX()` _always_ returns `XX` _or_ throws exception. `findXX()` returns `XX` _or_ `null`. 
   `getXX` can be just a convenient shortcut: `return $this->findXX() ?? throw new Exception('XX not found')`.
   OR one can ask themselves if returning null is a common scenario, and if not, don't even provide findXX.
3. The tests are mixed up with the source code...this is a bit difficult and unusual to work with, but also is a problem for the next point..
4. As a project, this is actually pretty heavy (especially considering the documentation). There is a way to make smaller composer packages without losing/removing the existing files - by using `export-ignore <path>` in `.gitattributes`. Documentation, tests, config files - all of that can be removed from the export.
As mentioned in (3), it gets a bit cumbersome with tests in src, but not impossible.