### PR TITLE
[AutoMapper] Add Enum support

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,6 +11,7 @@ $dirs = PhpCsFixer\Finder::create()
     ->exclude('Component/OpenApi3/Tests/fixtures')
     ->exclude('Component/OpenApi3/Tests/client/generated')
     ->exclude('Component/AutoMapper/Tests/cache')
+    ->notPath('Component/AutoMapper/Tests/Fixtures/AddressType.php') // should be removed once PHP 8.1 is minimal req
     ->exclude('Bundle/AutoMapperBundle/Tests/Resources')
     ->exclude('Bundle/JsonSchemaBundle/Tests/Resources')
     ->exclude('Bundle/OpenApiBundle/Tests/Resources')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [AutoMapper] [GH#707](https://github.com/janephp/janephp/pull/707) Add Enum support
 
 ## [7.4.2] - 2023-03-09
 ### Fixed

--- a/src/Component/AutoMapper/AutoMapper.php
+++ b/src/Component/AutoMapper/AutoMapper.php
@@ -14,6 +14,7 @@ use Jane\Component\AutoMapper\Transformer\ArrayTransformerFactory;
 use Jane\Component\AutoMapper\Transformer\BuiltinTransformerFactory;
 use Jane\Component\AutoMapper\Transformer\ChainTransformerFactory;
 use Jane\Component\AutoMapper\Transformer\DateTimeTransformerFactory;
+use Jane\Component\AutoMapper\Transformer\EnumTransformerFactory;
 use Jane\Component\AutoMapper\Transformer\MultipleTransformerFactory;
 use Jane\Component\AutoMapper\Transformer\NullableTransformerFactory;
 use Jane\Component\AutoMapper\Transformer\ObjectTransformerFactory;
@@ -261,6 +262,7 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface, Ma
         $transformerFactory->addTransformerFactory(new BuiltinTransformerFactory());
         $transformerFactory->addTransformerFactory(new ArrayTransformerFactory($transformerFactory));
         $transformerFactory->addTransformerFactory(new ObjectTransformerFactory($autoMapper));
+        $transformerFactory->addTransformerFactory(new EnumTransformerFactory());
 
         if (class_exists(AbstractUid::class)) {
             $transformerFactory->addTransformerFactory(new SymfonyUidTransformerFactory());

--- a/src/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -6,6 +6,8 @@ use Jane\Component\AutoMapper\AutoMapper;
 use Jane\Component\AutoMapper\Exception\CircularReferenceException;
 use Jane\Component\AutoMapper\Exception\NoMappingFoundException;
 use Jane\Component\AutoMapper\MapperContext;
+use Jane\Component\AutoMapper\Tests\Fixtures\AddressType;
+use Jane\Component\AutoMapper\Tests\Fixtures\AddressWithEnum;
 use Jane\Component\AutoMapper\Tests\Fixtures\Fish;
 use Jane\Component\AutoMapper\Tests\Fixtures\Order;
 use Jane\Component\AutoMapper\Tests\Fixtures\PetOwner;
@@ -985,7 +987,7 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertTrue($target->isDisplayIncVatPrices());
     }
 
-    public function testPartialConstructorWithTargetToPopulate()
+    public function testPartialConstructorWithTargetToPopulate(): void
     {
         $source = new Fixtures\User(1, 'Jack', 37);
         /** @var Fixtures\UserPartialConstructor $target */
@@ -994,5 +996,32 @@ class AutoMapperTest extends AutoMapperBaseTest
         self::assertEquals(1, $target->getId());
         self::assertEquals('Jack', $target->name);
         self::assertEquals(37, $target->age);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testEnum(): void
+    {
+        // enum source
+        $address = new AddressWithEnum();
+        $address->setType(AddressType::APARTMENT);
+        /** @var array $addressData */
+        $addressData = $this->autoMapper->map($address, 'array');
+        $var = AddressType::APARTMENT; // only here for lower PHP version handling
+        self::assertEquals($var->value, $addressData['type']);
+
+        // enum target
+        $data = ['type' => 'flat'];
+        /** @var AddressWithEnum $address */
+        $address = $this->autoMapper->map($data, AddressWithEnum::class);
+        self::assertEquals(AddressType::FLAT, $address->getType());
+
+        // both source & target are enums
+        $address = new AddressWithEnum();
+        $address->setType(AddressType::FLAT);
+        /** @var AddressWithEnum $copyAddress */
+        $copyAddress = $this->autoMapper->map($address, AddressWithEnum::class);
+        self::assertEquals($address->getType(), $copyAddress->getType());
     }
 }

--- a/src/Component/AutoMapper/Tests/Fixtures/AddressType.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/AddressType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Tests\Fixtures;
+
+enum AddressType: string
+{
+    case FLAT = 'flat';
+    case APARTMENT = 'apartment';
+}

--- a/src/Component/AutoMapper/Tests/Fixtures/AddressWithEnum.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/AddressWithEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Tests\Fixtures;
+
+class AddressWithEnum
+{
+    private AddressType $type;
+
+    public function setType(AddressType $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getType(): AddressType
+    {
+        return $this->type;
+    }
+}

--- a/src/Component/AutoMapper/Transformer/ChainTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/ChainTransformerFactory.php
@@ -17,7 +17,7 @@ final class ChainTransformerFactory implements TransformerFactoryInterface
 
     /**
      * Biggest priority is MultipleTransformerFactory with 128, so default priority will be bigger in order to
-     * be used before it, 256 should be enought.
+     * be used before it, 256 should be enough.
      */
     public function addTransformerFactory(TransformerFactoryInterface $transformerFactory, int $priority = 256): void
     {

--- a/src/Component/AutoMapper/Transformer/CopyEnumTransformer.php
+++ b/src/Component/AutoMapper/Transformer/CopyEnumTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Transformer;
+
+use Jane\Component\AutoMapper\Extractor\PropertyMapping;
+use Jane\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Expr;
+
+/**
+ * Transform an Enum into a copied Enum.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class CopyEnumTransformer implements TransformerInterface
+{
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [$input, []];
+    }
+}

--- a/src/Component/AutoMapper/Transformer/EnumTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/EnumTransformerFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Transformer;
+
+use Jane\Component\AutoMapper\MapperMetadataInterface;
+use Symfony\Component\PropertyInfo\Type;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class EnumTransformerFactory extends AbstractUniqueTypeTransformerFactory implements PrioritizedTransformerFactoryInterface
+{
+    protected function createTransformer(Type $sourceType, Type $targetType, MapperMetadataInterface $mapperMetadata): ?TransformerInterface
+    {
+        // source is enum, target isn't
+        if ($this->isEnumType($sourceType, true) && !$this->isEnumType($targetType)) {
+            return new SourceEnumTransformer();
+        }
+
+        // target is enum, source isn't
+        if (!$this->isEnumType($sourceType) && $this->isEnumType($targetType, true)) {
+            return new TargetEnumTransformer($targetType->getClassName());
+        }
+
+        // both source & target are enums
+        if ($this->isEnumType($sourceType) && $this->isEnumType($targetType)) {
+            return new CopyEnumTransformer();
+        }
+
+        return null;
+    }
+
+    private function isEnumType(Type $type, bool $backed = false): bool
+    {
+        if (Type::BUILTIN_TYPE_OBJECT !== $type->getBuiltinType()) {
+            return false;
+        }
+
+        if (!is_subclass_of($type->getClassName(), \UnitEnum::class)) {
+            return false;
+        }
+
+        if ($backed && !is_subclass_of($type->getClassName(), \BackedEnum::class)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getPriority(): int
+    {
+        return 3;
+    }
+}

--- a/src/Component/AutoMapper/Transformer/ObjectTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/ObjectTransformerFactory.php
@@ -48,11 +48,19 @@ final class ObjectTransformerFactory extends AbstractUniqueTypeTransformerFactor
 
     private function isObjectType(Type $type): bool
     {
-        return
-            Type::BUILTIN_TYPE_OBJECT === $type->getBuiltinType()
-            ||
-            (Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType() && !$type->isCollection())
-        ;
+        if (!\in_array($type->getBuiltinType(), [Type::BUILTIN_TYPE_OBJECT, Type::BUILTIN_TYPE_ARRAY])) {
+            return false;
+        }
+
+        if (Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType() && $type->isCollection()) {
+            return false;
+        }
+
+        if (is_subclass_of($type->getClassName(), \UnitEnum::class)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Component/AutoMapper/Transformer/SourceEnumTransformer.php
+++ b/src/Component/AutoMapper/Transformer/SourceEnumTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Transformer;
+
+use Jane\Component\AutoMapper\Extractor\PropertyMapping;
+use Jane\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Expr;
+
+/**
+ * Transform a BackendEnum into a scalar.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class SourceEnumTransformer implements TransformerInterface
+{
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [new Expr\PropertyFetch($input, 'value'), []];
+    }
+}

--- a/src/Component/AutoMapper/Transformer/TargetEnumTransformer.php
+++ b/src/Component/AutoMapper/Transformer/TargetEnumTransformer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Transformer;
+
+use Jane\Component\AutoMapper\Extractor\PropertyMapping;
+use Jane\Component\AutoMapper\Generator\UniqueVariableScope;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+
+/**
+ * Transform a scalar into a BackendEnum.
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class TargetEnumTransformer implements TransformerInterface
+{
+    public $targetClassName;
+
+    public function __construct(string $targetClassName)
+    {
+        $this->targetClassName = $targetClassName;
+    }
+
+    public function transform(Expr $input, Expr $target, PropertyMapping $propertyMapping, UniqueVariableScope $uniqueVariableScope): array
+    {
+        return [new Expr\StaticCall(new Name\FullyQualified($this->targetClassName), 'from', [
+            new Arg($input),
+        ]), []];
+    }
+}


### PR DESCRIPTION
As the title says.

It manages only `\BackedEnum` if source or target is a scalar.
It manages `\UnitEnum` if both source and target are objects.