### PR TITLE
feat(automapper): add enum to bundle

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -12,6 +12,7 @@ $dirs = PhpCsFixer\Finder::create()
     ->exclude('Component/OpenApi3/Tests/client/generated')
     ->exclude('Component/AutoMapper/Tests/cache')
     ->notPath('Component/AutoMapper/Tests/Fixtures/AddressType.php') // should be removed once PHP 8.1 is minimal req
+    ->notPath('Bundle/AutoMapperBundle/Tests/Fixtures/SomeEnum.php') // should be removed once PHP 8.1 is minimal req
     ->exclude('Bundle/AutoMapperBundle/Tests/Resources')
     ->exclude('Bundle/JsonSchemaBundle/Tests/Resources')
     ->exclude('Bundle/OpenApiBundle/Tests/Resources')

--- a/src/Bundle/AutoMapperBundle/Resources/config/services.xml
+++ b/src/Bundle/AutoMapperBundle/Resources/config/services.xml
@@ -83,6 +83,10 @@
             <tag name="jane_auto_mapper.transformer_factory" priority="1000" />
         </service>
 
+        <service id="Jane\Component\AutoMapper\Transformer\EnumTransformerFactory">
+            <tag name="jane_auto_mapper.transformer_factory" priority="-999" />
+        </service>
+
         <service id="Jane\Component\AutoMapper\Transformer\DateTimeTransformerFactory">
             <tag name="jane_auto_mapper.transformer_factory" priority="-1000" />
         </service>

--- a/src/Bundle/AutoMapperBundle/Tests/Fixtures/DTOWithEnum.php
+++ b/src/Bundle/AutoMapperBundle/Tests/Fixtures/DTOWithEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Bundle\AutoMapperBundle\Tests\Fixtures;
+
+final class DTOWithEnum
+{
+    /**
+     * @var SomeEnum
+     */
+    public $enum;
+}

--- a/src/Bundle/AutoMapperBundle/Tests/Fixtures/SomeEnum.php
+++ b/src/Bundle/AutoMapperBundle/Tests/Fixtures/SomeEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Bundle\AutoMapperBundle\Tests\Fixtures;
+
+enum SomeEnum: string
+{
+    case FOO = 'foo';
+}

--- a/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
+++ b/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
@@ -3,7 +3,9 @@
 namespace Jane\Bundle\AutoMapperBundle\Tests;
 
 use Jane\Bundle\AutoMapperBundle\Tests\Fixtures\AddressDTO;
+use Jane\Bundle\AutoMapperBundle\Tests\Fixtures\DTOWithEnum;
 use Jane\Bundle\AutoMapperBundle\Tests\Fixtures\Order;
+use Jane\Bundle\AutoMapperBundle\Tests\Fixtures\SomeEnum;
 use Jane\Bundle\AutoMapperBundle\Tests\Fixtures\User;
 use Jane\Bundle\AutoMapperBundle\Tests\Fixtures\UserDTO;
 use Jane\Component\AutoMapper\AutoMapperInterface;
@@ -83,5 +85,19 @@ class ServiceInstantiationTest extends WebTestCase
 
         $pet = $autoMapper->map($data, Fixtures\Pet::class);
         self::assertInstanceOf(Fixtures\Cat::class, $pet);
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testItCanMapEnums(): void
+    {
+        static::bootKernel();
+        $container = static::$kernel->getContainer();
+        $autoMapper = $container->get(AutoMapperInterface::class);
+
+        $dto = new DTOWithEnum();
+        $dto->enum = SomeEnum::FOO;
+        self::assertSame(['enum' => 'foo'], $autoMapper->map($dto, 'array'));
     }
 }

--- a/src/Component/AutoMapper/MapperContext.php
+++ b/src/Component/AutoMapper/MapperContext.php
@@ -171,7 +171,9 @@ class MapperContext
             return true;
         }
 
-        return \in_array($attribute, $context[self::ALLOWED_ATTRIBUTES], true);
+        return \in_array($attribute, $context[self::ALLOWED_ATTRIBUTES], true) // current field is allowed
+            || isset($context[self::ALLOWED_ATTRIBUTES][$attribute]) // some nested fields are allowed
+        ;
     }
 
     /**


### PR DESCRIPTION
`EnumTransformerFactory` was not tagged with `jane_auto_mapper.transformer_factory` thus it was not added  in the automapper service