### PR TITLE
fix(automapper): isAllowedAttribute() should accept nested fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.4.4] - 2023-03-27
+### Added
+- [AutoMapper] [GH#710](https://github.com/janephp/janephp/pull/710) Add Enum support in AutoMapper bundle
+- [AutoMapper] [GH#711](https://github.com/janephp/janephp/pull/711) Allow nesting properties with `MapperContext::isAllowedAttribute()`
+
 ## [7.4.3] - 2023-03-23
 ### Added
 - [AutoMapper] [GH#707](https://github.com/janephp/janephp/pull/707) Add Enum support

--- a/src/Component/AutoMapper/MapperContext.php
+++ b/src/Component/AutoMapper/MapperContext.php
@@ -171,7 +171,9 @@ class MapperContext
             return true;
         }
 
-        return \in_array($attribute, $context[self::ALLOWED_ATTRIBUTES], true);
+        return \in_array($attribute, $context[self::ALLOWED_ATTRIBUTES], true) // current field is allowed
+            || isset($context[self::ALLOWED_ATTRIBUTES][$attribute]) // some nested fields are allowed
+        ;
     }
 
     /**

--- a/src/Component/AutoMapper/Tests/MapperContextTest.php
+++ b/src/Component/AutoMapper/Tests/MapperContextTest.php
@@ -125,6 +125,7 @@ class MapperContextTest extends TestCase
             ],
         ];
 
+        self::assertTrue(MapperContext::isAllowedAttribute($context, 'foo', 1));
         $newContext = MapperContext::withNewContext($context, 'foo');
 
         self::assertEquals(['bar'], $newContext[MapperContext::ALLOWED_ATTRIBUTES]);


### PR DESCRIPTION
Automapper creates code like this:
```php
if (MapperContext::isAllowedAttribute($context, 'foo', $value->foo)) {
    $result['events'] =& $this->mappers['Mapper_Foo_array']->map($value->foo, MapperContext::withNewContext($context, 'foo'));
}
```
so, if context looks like this, where we only want `bar` fields into `foo` fields:
```php
        $context = [
            MapperContext::ALLOWED_ATTRIBUTES => [
                'foo' => ['bar'],
            ],
        ];
```

we should check the existence of array key `foo`. It is done [like this in Symfony's serializer](https://github.com/symfony/symfony/blob/6.3/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php#L275)