### PR TITLE
Handle PHP8.2 readonly classes

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -18,6 +18,7 @@ $dirs = PhpCsFixer\Finder::create()
         'Component/AutoMapper/Tests/Fixtures/AddressDTOWithReadonly.php',
         'Component/AutoMapper/Tests/Fixtures/AddressDTOWithReadonlyPromotedProperty.php',
         'Component/AutoMapper/Tests/Fixtures/AddressDTOReadonlyClass.php',
+        'Component/AutoMapper/Tests/Fixtures/AddressDTOSecondReadonlyClass.php',
     ])
     ->exclude('Bundle/AutoMapperBundle/Tests/Resources')
     ->exclude('Bundle/JsonSchemaBundle/Tests/Resources')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [AutoMapper] [GH#713](https://github.com/janephp/janephp/pull/713) Use serializer's "ignore" attribute
 - [AutoMapper] [GH#714](https://github.com/janephp/janephp/pull/714) Allow custom context in AutomapperNormalizer
 - [AutoMapper] [GH#716](https://github.com/janephp/janephp/pull/716) Add readonly properties support
+- [AutoMapper] [GH#718](https://github.com/janephp/janephp/pull/718) Disallow readonly target when using object to populate
 
 ## [7.4.3] - 2023-03-23
 ### Added

--- a/src/Bundle/AutoMapperBundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/AutoMapperBundle/DependencyInjection/Configuration.php
@@ -29,6 +29,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/automapper')->end()
                 ->scalarNode('date_time_format')->defaultValue(\DateTimeInterface::RFC3339)->end()
                 ->booleanNode('hot_reload')->defaultValue($this->debug)->end()
+                ->booleanNode('allow_readonly_target_to_populate')->defaultFalse()->end()
             ->end()
         ;
 

--- a/src/Bundle/AutoMapperBundle/DependencyInjection/JaneAutoMapperExtension.php
+++ b/src/Bundle/AutoMapperBundle/DependencyInjection/JaneAutoMapperExtension.php
@@ -5,6 +5,7 @@ namespace Jane\Bundle\AutoMapperBundle\DependencyInjection;
 use Jane\Bundle\AutoMapperBundle\Configuration\MapperConfigurationInterface;
 use Jane\Component\AutoMapper\Extractor\FromSourceMappingExtractor;
 use Jane\Component\AutoMapper\Extractor\FromTargetMappingExtractor;
+use Jane\Component\AutoMapper\Generator\Generator;
 use Jane\Component\AutoMapper\Loader\FileLoader;
 use Jane\Component\AutoMapper\MapperGeneratorMetadataFactory;
 use Jane\Component\AutoMapper\MapperGeneratorMetadataInterface;
@@ -67,6 +68,12 @@ class JaneAutoMapperExtension extends Extension
             $container
                 ->getDefinition(FromSourceMappingExtractor::class)
                 ->addArgument(new Reference($config['name_converter']));
+        }
+
+        if ($config['allow_readonly_target_to_populate']) {
+            $container
+                ->getDefinition(Generator::class)
+                ->replaceArgument(2, $config['allow_readonly_target_to_populate']);
         }
 
         $container->setParameter('automapper.cache_dir', $config['cache_dir']);

--- a/src/Bundle/AutoMapperBundle/README.md
+++ b/src/Bundle/AutoMapperBundle/README.md
@@ -24,6 +24,7 @@ Possible properties:
 - `cache_dir` (default: `%kernel.cache_dir%/automapper`): This settings allows you to customize the output directory for generated mappers;
 - `mappings`: This option allows you to customize Mapper metadata, you have to specify `source` & `target` data types and related configuration using `pass` field.
 This configuration should implements `Jane\Bundle\AutoMapper\Configuration\ConfigurationPassInterface`.
+- `allow_readonly_target_to_populate` (default: `false`): Will throw an exception if you use a readonly class as target to populate if set to `false`.
 
 ## Normalizer Bridge
 A Normalizer Bridge is available, aiming to be 100% feature compatible with the ObjectNormalizer of the ``symfony/serializer`` component. The goal of this bridge **is not to replace the ObjectNormalizer** but rather providing a very fast alternative.

--- a/src/Bundle/AutoMapperBundle/Resources/config/services.xml
+++ b/src/Bundle/AutoMapperBundle/Resources/config/services.xml
@@ -55,6 +55,7 @@
         <service id="Jane\Component\AutoMapper\Generator\Generator">
             <argument>null</argument>
             <argument type="service" id="jane.mapping.class_discriminator_from_class_metadata" />
+            <argument>false</argument>
         </service>
 
         <service id="jane.mapping.class_discriminator_from_class_metadata" class="Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata">

--- a/src/Component/AutoMapper/AutoMapper.php
+++ b/src/Component/AutoMapper/AutoMapper.php
@@ -186,14 +186,16 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface, Ma
         string $classPrefix = 'Mapper_',
         bool $attributeChecking = true,
         bool $autoRegister = true,
-        string $dateTimeFormat = \DateTime::RFC3339
+        string $dateTimeFormat = \DateTime::RFC3339,
+        bool $allowReadOnlyTargetToPopulate = false
     ): self {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
 
         if (null === $loader) {
             $loader = new EvalLoader(new Generator(
                 (new ParserFactory())->create(ParserFactory::PREFER_PHP7),
-                new ClassDiscriminatorFromClassMetadata($classMetadataFactory)
+                new ClassDiscriminatorFromClassMetadata($classMetadataFactory),
+                $allowReadOnlyTargetToPopulate
             ));
         }
 

--- a/src/Component/AutoMapper/Exception/ReadOnlyTargetException.php
+++ b/src/Component/AutoMapper/Exception/ReadOnlyTargetException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Exception;
+
+use Jane\Component\AutoMapper\MapperContext;
+
+/**
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+class ReadOnlyTargetException extends RuntimeException
+{
+    public function __construct(int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct(sprintf('Cannot use readonly class as an object to populate. You can opt-out this behavior by using the context "%s"', MapperContext::ALLOW_READONLY_TARGET_TO_POPULATE), $code, $previous);
+    }
+}

--- a/src/Component/AutoMapper/MapperContext.php
+++ b/src/Component/AutoMapper/MapperContext.php
@@ -24,6 +24,7 @@ class MapperContext
     public const TARGET_TO_POPULATE = 'target_to_populate';
     public const CONSTRUCTOR_ARGUMENTS = 'constructor_arguments';
     public const SKIP_NULL_VALUES = 'skip_null_values';
+    public const ALLOW_READONLY_TARGET_TO_POPULATE = 'allow_readonly_target_to_populate';
 
     private $context = [
         self::DEPTH => 0,
@@ -82,6 +83,20 @@ class MapperContext
     public function setConstructorArgument(string $class, string $key, $value): self
     {
         $this->context[self::CONSTRUCTOR_ARGUMENTS][$class][$key] = $value;
+
+        return $this;
+    }
+
+    public function setSkipNullValues(bool $skipNullValues): self
+    {
+        $this->context[self::SKIP_NULL_VALUES] = $skipNullValues;
+
+        return $this;
+    }
+
+    public function setAllowReadOnlyTargetToPopulate(bool $allowReadOnlyTargetToPopulate): self
+    {
+        $this->context[self::ALLOW_READONLY_TARGET_TO_POPULATE] = $allowReadOnlyTargetToPopulate;
 
         return $this;
     }

--- a/src/Component/AutoMapper/MapperGeneratorMetadataFactory.php
+++ b/src/Component/AutoMapper/MapperGeneratorMetadataFactory.php
@@ -51,10 +51,24 @@ final class MapperGeneratorMetadataFactory implements MapperGeneratorMetadataFac
             $extractor = $this->fromSourcePropertiesMappingExtractor;
         }
 
-        $mapperMetadata = new MapperMetadata($autoMapperRegister, $extractor, $source, $target, $this->classPrefix);
+        $mapperMetadata = new MapperMetadata($autoMapperRegister, $extractor, $source, $target, $this->isReadOnly($target), $this->classPrefix);
         $mapperMetadata->setAttributeChecking($this->attributeChecking);
         $mapperMetadata->setDateTimeFormat($this->dateTimeFormat);
 
         return $mapperMetadata;
+    }
+
+    private function isReadOnly(string $mappedType): bool
+    {
+        try {
+            $reflClass = new \ReflectionClass($mappedType);
+        } catch (\ReflectionException $e) {
+            $reflClass = null;
+        }
+        if (\PHP_VERSION_ID >= 80200 && null !== $reflClass && $reflClass->isReadOnly()) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Component/AutoMapper/MapperMetadata.php
+++ b/src/Component/AutoMapper/MapperMetadata.php
@@ -31,6 +31,8 @@ class MapperMetadata implements MapperGeneratorMetadataInterface
 
     private $isConstructorAllowed;
 
+    private $isTargetReadOnlyClass;
+
     private $dateTimeFormat;
 
     private $classPrefix;
@@ -39,12 +41,13 @@ class MapperMetadata implements MapperGeneratorMetadataInterface
 
     private $targetReflectionClass = null;
 
-    public function __construct(MapperGeneratorMetadataRegistryInterface $metadataRegistry, MappingExtractorInterface $mappingExtractor, string $source, string $target, string $classPrefix = 'Mapper_')
+    public function __construct(MapperGeneratorMetadataRegistryInterface $metadataRegistry, MappingExtractorInterface $mappingExtractor, string $source, string $target, bool $isTargetReadOnlyClass, string $classPrefix = 'Mapper_')
     {
         $this->mappingExtractor = $mappingExtractor;
         $this->metadataRegistry = $metadataRegistry;
         $this->source = $source;
         $this->target = $target;
+        $this->isTargetReadOnlyClass = $isTargetReadOnlyClass;
         $this->isConstructorAllowed = true;
         $this->dateTimeFormat = \DateTime::RFC3339;
         $this->classPrefix = $classPrefix;
@@ -308,5 +311,10 @@ class MapperMetadata implements MapperGeneratorMetadataInterface
         }
 
         return false;
+    }
+
+    public function isTargetReadOnlyClass(): bool
+    {
+        return $this->isTargetReadOnlyClass;
     }
 }

--- a/src/Component/AutoMapper/MapperMetadataInterface.php
+++ b/src/Component/AutoMapper/MapperMetadataInterface.php
@@ -22,6 +22,11 @@ interface MapperMetadataInterface
     public function getTarget(): string;
 
     /**
+     * Check if the target is a read-only class.
+     */
+    public function isTargetReadOnlyClass(): bool;
+
+    /**
      * Get properties to map between source and target.
      *
      * @return PropertyMapping[]

--- a/src/Component/AutoMapper/Tests/AutoMapperBaseTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperBaseTest.php
@@ -9,6 +9,7 @@ use Jane\Component\AutoMapper\Loader\ClassLoaderInterface;
 use Jane\Component\AutoMapper\Loader\FileLoader;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -26,14 +27,22 @@ abstract class AutoMapperBaseTest extends TestCase
 
     protected function setUp(): void
     {
-        @unlink(__DIR__ . '/cache/registry.php');
+        unset($this->autoMapper, $this->loader);
+        $this->buildAutoMapper();
+    }
+
+    protected function buildAutoMapper(bool $allowReadOnlyTargetToPopulate = false): AutoMapper
+    {
+        $fs = new Filesystem();
+        $fs->remove(__DIR__ . '/cache/');
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
 
         $this->loader = new FileLoader(new Generator(
             (new ParserFactory())->create(ParserFactory::PREFER_PHP7),
-            new ClassDiscriminatorFromClassMetadata($classMetadataFactory)
+            new ClassDiscriminatorFromClassMetadata($classMetadataFactory),
+            $allowReadOnlyTargetToPopulate
         ), __DIR__ . '/cache');
 
-        $this->autoMapper = AutoMapper::create(true, $this->loader);
+        return $this->autoMapper = AutoMapper::create(true, $this->loader);
     }
 }

--- a/src/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -1092,4 +1092,18 @@ class AutoMapperTest extends AutoMapperBaseTest
             yield [AddressDTOReadonlyClass::class];
         }
     }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testReadonlyClass(): void
+    {
+        $data = ['city' => 'Nantes'];
+        $toPopulate = new AddressDTOReadonlyClass('city');
+
+        $this->autoMapper->map($data, $toPopulate);
+
+        // value didn't changed because the object class is readonly, we can't change the value there
+        self::assertEquals('city', $toPopulate->city);
+    }
 }

--- a/src/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -5,6 +5,7 @@ namespace Jane\Component\AutoMapper\Tests;
 use Jane\Component\AutoMapper\AutoMapper;
 use Jane\Component\AutoMapper\Exception\CircularReferenceException;
 use Jane\Component\AutoMapper\Exception\NoMappingFoundException;
+use Jane\Component\AutoMapper\Exception\ReadOnlyTargetException;
 use Jane\Component\AutoMapper\MapperContext;
 use Jane\Component\AutoMapper\Tests\Fixtures\Address;
 use Jane\Component\AutoMapper\Tests\Fixtures\AddressDTOReadonlyClass;
@@ -1047,11 +1048,55 @@ class AutoMapperTest extends AutoMapperBaseTest
     }
 
     /**
+     * @requires PHP 8.2
+     */
+    public function testTargetReadonlyClass(): void
+    {
+        $data = ['city' => 'Nantes'];
+        $toPopulate = new Fixtures\AddressDTOSecondReadonlyClass('city', '67100');
+
+        self::expectException(ReadOnlyTargetException::class);
+        $this->autoMapper->map($data, $toPopulate);
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testTargetReadonlyClassSkippedContext(): void
+    {
+        $data = ['city' => 'Nantes'];
+        $toPopulate = new Fixtures\AddressDTOSecondReadonlyClass('city', '67100');
+
+        $this->autoMapper->map($data, $toPopulate, [MapperContext::ALLOW_READONLY_TARGET_TO_POPULATE => true]);
+
+        // value didn't changed because the object class is readonly, we can't change the value there
+        self::assertEquals('city', $toPopulate->city);
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testTargetReadonlyClassAllowed(): void
+    {
+        $this->buildAutoMapper(true);
+
+        $data = ['city' => 'Nantes'];
+        $toPopulate = new AddressDTOReadonlyClass('city');
+
+        $this->autoMapper->map($data, $toPopulate);
+
+        // value didn't changed because the object class is readonly, we can't change the value there
+        self::assertEquals('city', $toPopulate->city);
+    }
+
+    /**
      * @requires PHP 8.1
      * @dataProvider provideReadonly
      */
     public function testReadonly(string $addressWithReadonlyClass): void
     {
+        $this->buildAutoMapper(true);
+
         $address = new Address();
         $address->setCity('city');
 
@@ -1091,19 +1136,5 @@ class AutoMapperTest extends AutoMapperBaseTest
         if (\PHP_VERSION_ID >= 80200) {
             yield [AddressDTOReadonlyClass::class];
         }
-    }
-
-    /**
-     * @requires PHP 8.2
-     */
-    public function testReadonlyClass(): void
-    {
-        $data = ['city' => 'Nantes'];
-        $toPopulate = new AddressDTOReadonlyClass('city');
-
-        $this->autoMapper->map($data, $toPopulate);
-
-        // value didn't changed because the object class is readonly, we can't change the value there
-        self::assertEquals('city', $toPopulate->city);
     }
 }

--- a/src/Component/AutoMapper/Tests/Extractor/FromSourceMappingExtractorTest.php
+++ b/src/Component/AutoMapper/Tests/Extractor/FromSourceMappingExtractorTest.php
@@ -77,7 +77,7 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
     public function testWithTargetAsArray(): void
     {
         $userReflection = new \ReflectionClass(Fixtures\User::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\User::class, 'array');
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\User::class, 'array', false);
         $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(\count($userReflection->getProperties()), $sourcePropertiesMapping);
@@ -90,7 +90,7 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
     public function testWithTargetAsStdClass(): void
     {
         $userReflection = new \ReflectionClass(Fixtures\User::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\User::class, 'stdClass');
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\User::class, 'stdClass', false);
         $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(\count($userReflection->getProperties()), $sourcePropertiesMapping);
@@ -102,7 +102,7 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
 
     public function testWithSourceAsEmpty(): void
     {
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\Empty_::class, 'array');
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\Empty_::class, 'array', false);
         $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(0, $sourcePropertiesMapping);
@@ -111,12 +111,12 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
     public function testWithSourceAsPrivate(): void
     {
         $privateReflection = new \ReflectionClass(Fixtures\Private_::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\Private_::class, 'array');
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\Private_::class, 'array', false);
         $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
         self::assertCount(\count($privateReflection->getProperties()), $sourcePropertiesMapping);
 
         $this->fromSourceMappingExtractorBootstrap(false);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\Private_::class, 'array');
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, Fixtures\Private_::class, 'array', false);
         $sourcePropertiesMapping = $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
         self::assertCount(0, $sourcePropertiesMapping);
     }
@@ -126,7 +126,7 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
         self::expectException(InvalidMappingException::class);
         self::expectExceptionMessage('Only array or stdClass are accepted as a target');
 
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, 'array', Fixtures\User::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, 'array', Fixtures\User::class, false);
         $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
     }
 
@@ -135,7 +135,7 @@ class FromSourceMappingExtractorTest extends AutoMapperBaseTest
         self::expectException(InvalidMappingException::class);
         self::expectExceptionMessage('Only array or stdClass are accepted as a target');
 
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, 'stdClass', Fixtures\User::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromSourceMappingExtractor, 'stdClass', Fixtures\User::class, false);
         $this->fromSourceMappingExtractor->getPropertiesMapping($mapperMetadata);
     }
 }

--- a/src/Component/AutoMapper/Tests/Extractor/FromTargetMappingExtractorTest.php
+++ b/src/Component/AutoMapper/Tests/Extractor/FromTargetMappingExtractorTest.php
@@ -77,7 +77,7 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
     public function testWithSourceAsArray(): void
     {
         $userReflection = new \ReflectionClass(Fixtures\User::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\User::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\User::class, false);
         $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(\count($userReflection->getProperties()), $targetPropertiesMapping);
@@ -89,7 +89,7 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
     public function testWithSourceAsStdClass(): void
     {
         $userReflection = new \ReflectionClass(Fixtures\User::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'stdClass', Fixtures\User::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'stdClass', Fixtures\User::class, false);
         $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(\count($userReflection->getProperties()), $targetPropertiesMapping);
@@ -100,7 +100,7 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
 
     public function testWithTargetAsEmpty(): void
     {
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\Empty_::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\Empty_::class, false);
         $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
 
         self::assertCount(0, $targetPropertiesMapping);
@@ -109,12 +109,12 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
     public function testWithTargetAsPrivate(): void
     {
         $privateReflection = new \ReflectionClass(Fixtures\Private_::class);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\Private_::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\Private_::class, false);
         $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
         self::assertCount(\count($privateReflection->getProperties()), $targetPropertiesMapping);
 
         $this->fromTargetMappingExtractorBootstrap(false);
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\Private_::class);
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, 'array', Fixtures\Private_::class, false);
         $targetPropertiesMapping = $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
         self::assertCount(0, $targetPropertiesMapping);
     }
@@ -124,7 +124,7 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
         self::expectException(InvalidMappingException::class);
         self::expectExceptionMessage('Only array or stdClass are accepted as a source');
 
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, Fixtures\User::class, 'array');
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, Fixtures\User::class, 'array', false);
         $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
     }
 
@@ -133,7 +133,7 @@ class FromTargetMappingExtractorTest extends AutoMapperBaseTest
         self::expectException(InvalidMappingException::class);
         self::expectExceptionMessage('Only array or stdClass are accepted as a source');
 
-        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, Fixtures\User::class, 'stdClass');
+        $mapperMetadata = new MapperMetadata($this->autoMapper, $this->fromTargetMappingExtractor, Fixtures\User::class, 'stdClass', false);
         $this->fromTargetMappingExtractor->getPropertiesMapping($mapperMetadata);
     }
 }

--- a/src/Component/AutoMapper/Tests/Fixtures/AddressDTOSecondReadonlyClass.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/AddressDTOSecondReadonlyClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Component\AutoMapper\Tests\Fixtures;
+
+readonly class AddressDTOSecondReadonlyClass
+{
+    public function __construct(public string $city, public string $postalCode)
+    {
+    }
+}

--- a/src/Component/AutoMapper/Tests/MapperGeneratorMetadataFactoryTest.php
+++ b/src/Component/AutoMapper/Tests/MapperGeneratorMetadataFactoryTest.php
@@ -129,6 +129,7 @@ class MapperGeneratorMetadataFactoryTest extends AutoMapperBaseTest
         self::assertInstanceOf(PropertyMapping::class, $metadata->getPropertyMapping('id'));
         self::assertInstanceOf(PropertyMapping::class, $metadata->getPropertyMapping('name'));
         self::assertNull($metadata->getPropertyMapping('email'));
+        self::assertFalse($metadata->isTargetReadOnlyClass());
     }
 
     public function testHasNotConstructor(): void
@@ -136,5 +137,16 @@ class MapperGeneratorMetadataFactoryTest extends AutoMapperBaseTest
         $metadata = $this->factory->create($this->autoMapper, 'array', Fixtures\UserDTO::class);
 
         self::assertFalse($metadata->hasConstructor());
+    }
+
+    /**
+     * @requires PHP 8.2
+     */
+    public function testTargetIsReadOnlyClass(): void
+    {
+        $metadata = $this->factory->create($this->autoMapper, 'array', Fixtures\AddressDTOReadonlyClass::class);
+
+        self::assertEquals(Fixtures\AddressDTOReadonlyClass::class, $metadata->getTarget());
+        self::assertTrue($metadata->isTargetReadOnlyClass());
     }
 }


### PR DESCRIPTION
I'm not sure we should throw an exception here, the current behavior seems fine to me: when using a readonly class as object to populate, it's simply ignored.

Here is a sample mapper from the test I added in this PR
```php
    public function &map($value, array $context = array())
    {
        if (null === $value) {
            return $value;
        }
        $result = $context['target_to_populate'] ?? null;
        if (null === $result) {
            if (\Jane\Component\AutoMapper\MapperContext::hasConstructorArgument($context, 'Jane\\Component\\AutoMapper\\Tests\\Fixtures\\AddressDTOReadonlyClass', 'city')) {
                $constructarg = \Jane\Component\AutoMapper\MapperContext::getConstructorArgument($context, 'Jane\\Component\\AutoMapper\\Tests\\Fixtures\\AddressDTOReadonlyClass', 'city');
            } else {
                $constructarg = $value['city'];
            }
            $result = new \Jane\Component\AutoMapper\Tests\Fixtures\AddressDTOReadonlyClass($constructarg);
        }
        return $result;
    }
```

@nikophil any feedback here ?