### PR TITLE
minor: add mixed return type to generated mappers

### DIFF
--- a/src/Component/AutoMapper/Generator/Generator.php
+++ b/src/Component/AutoMapper/Generator/Generator.php
@@ -317,6 +317,7 @@ final class Generator
             ],
             'byRef' => true,
             'stmts' => $statements,
+            'returnType' => \PHP_VERSION_ID >= 80000 ? 'mixed' : null,
         ]);
 
         $constructMethod = new Stmt\ClassMethod('__construct', [


### PR DESCRIPTION
micro tiny update, which prevents following deprecation to be triggered:
> Method "Jane\Component\AutoMapper\MapperInterface::map()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "My_Awesome_Generated_Mapper" now to avoid errors or add an explicit @return annotation to suppress this message