### PR TITLE
feat(AutoMapperBundle): create mappers on cache warmup

### DIFF
--- a/src/Bundle/AutoMapperBundle/CacheWarmup/CacheWarmer.php
+++ b/src/Bundle/AutoMapperBundle/CacheWarmup/CacheWarmer.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Bundle\AutoMapperBundle\CacheWarmup;
+
+use Jane\Component\AutoMapper\Loader\FileLoader;
+use Jane\Component\AutoMapper\MapperGeneratorMetadataFactoryInterface;
+use Jane\Component\AutoMapper\MapperGeneratorMetadataRegistryInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * @internal
+ */
+final class CacheWarmer implements CacheWarmerInterface
+{
+    private $fileLoader;
+    private $autoMapperRegistry;
+    private $mapperConfigurationFactory;
+    /** @var iterable<CacheWarmerLoaderInterface> */
+    private $cacheWarmerLoaders;
+
+    /** @param iterable<CacheWarmerLoaderInterface> $cacheWarmerLoaders */
+    public function __construct(
+        FileLoader $fileLoader,
+        MapperGeneratorMetadataRegistryInterface $autoMapperRegistry,
+        MapperGeneratorMetadataFactoryInterface $mapperConfigurationFactory,
+        iterable $cacheWarmerLoaders
+    ) {
+        $this->fileLoader = $fileLoader;
+        $this->autoMapperRegistry = $autoMapperRegistry;
+        $this->mapperConfigurationFactory = $mapperConfigurationFactory;
+        $this->cacheWarmerLoaders = $cacheWarmerLoaders;
+    }
+
+    public function isOptional()
+    {
+        return false;
+    }
+
+    public function warmUp($cacheDir)
+    {
+        $mapperClasses = [];
+
+        foreach ($this->cacheWarmerLoaders as $cacheWarmerLoader) {
+            foreach ($cacheWarmerLoader->loadCacheWarmupData() as $cacheWarmupData) {
+                $mapperClasses[] = $this->fileLoader->saveMapper(
+                    $this->mapperConfigurationFactory->create(
+                        $this->autoMapperRegistry,
+                        $cacheWarmupData->getSource(),
+                        $cacheWarmupData->getTarget()
+                    )
+                );
+            }
+        }
+
+        return $mapperClasses;
+    }
+}

--- a/src/Bundle/AutoMapperBundle/CacheWarmup/CacheWarmerLoaderInterface.php
+++ b/src/Bundle/AutoMapperBundle/CacheWarmup/CacheWarmerLoaderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Bundle\AutoMapperBundle\CacheWarmup;
+
+interface CacheWarmerLoaderInterface
+{
+    /**
+     * @return iterable<CacheWarmupData>
+     */
+    public function loadCacheWarmupData(): iterable;
+}

--- a/src/Bundle/AutoMapperBundle/CacheWarmup/CacheWarmupData.php
+++ b/src/Bundle/AutoMapperBundle/CacheWarmup/CacheWarmupData.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Bundle\AutoMapperBundle\CacheWarmup;
+
+final class CacheWarmupData
+{
+    private $source;
+    private $target;
+
+    public function __construct(string $source, string $target)
+    {
+        if (!$this->isValid($source) || !$this->isValid($target)) {
+            throw CacheWarmupDataException::sourceOrTargetDoesNoExist($source, $target);
+        }
+
+        if ($target === $source) {
+            throw CacheWarmupDataException::sourceAndTargetAreEquals($source);
+        }
+
+        $this->source = $source;
+        $this->target = $target;
+    }
+
+    /**
+     * @param array{source: string, target: string} $array
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self($array['source'], $array['target']);
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    public function getTarget(): string
+    {
+        return $this->target;
+    }
+
+    private function isValid(string $arrayOrClass): bool
+    {
+        return $arrayOrClass === 'array' || class_exists($arrayOrClass);
+    }
+}

--- a/src/Bundle/AutoMapperBundle/CacheWarmup/CacheWarmupDataException.php
+++ b/src/Bundle/AutoMapperBundle/CacheWarmup/CacheWarmupDataException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Bundle\AutoMapperBundle\CacheWarmup;
+
+/**
+ * @internal
+ */
+final class CacheWarmupDataException extends \RuntimeException
+{
+    private function __construct(string $message, string $source, string $target)
+    {
+        parent::__construct(
+            "Invalid automapper warmup configuration: $message. {source: \"$source\", target: \"$target\"} given."
+        );
+    }
+
+    public static function sourceAndTargetAreEquals(string $value): self
+    {
+        return new self('source and target must be different', $value, $value);
+    }
+
+    public static function sourceOrTargetDoesNoExist(string $source, string $target): self
+    {
+        return new self('source and target must be "array" or a valid class name', $source, $target);
+    }
+}

--- a/src/Bundle/AutoMapperBundle/CacheWarmup/ConfigurationCacheWarmerLoader.php
+++ b/src/Bundle/AutoMapperBundle/CacheWarmup/ConfigurationCacheWarmerLoader.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Bundle\AutoMapperBundle\CacheWarmup;
+
+/**
+ * @internal
+ */
+final class ConfigurationCacheWarmerLoader implements CacheWarmerLoaderInterface
+{
+    private $mappersToGenerateOnWarmup;
+
+    /**
+     * @param list<array{source: string, target: string}> $mappersToGenerateOnWarmup
+     */
+    public function __construct(array $mappersToGenerateOnWarmup)
+    {
+        $this->mappersToGenerateOnWarmup = $mappersToGenerateOnWarmup;
+    }
+
+    public function loadCacheWarmupData(): iterable
+    {
+        foreach ($this->mappersToGenerateOnWarmup as $mapperToGenerate) {
+            yield CacheWarmupData::fromArray($mapperToGenerate);
+        }
+    }
+}

--- a/src/Bundle/AutoMapperBundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/AutoMapperBundle/DependencyInjection/Configuration.php
@@ -30,6 +30,14 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('date_time_format')->defaultValue(\DateTimeInterface::RFC3339)->end()
                 ->booleanNode('hot_reload')->defaultValue($this->debug)->end()
                 ->booleanNode('allow_readonly_target_to_populate')->defaultFalse()->end()
+                ->arrayNode('warmup')
+                    ->arrayPrototype()
+                        ->children()
+                            ->scalarNode('source')->defaultValue('array')->end()
+                            ->scalarNode('target')->defaultValue('array')->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/src/Bundle/AutoMapperBundle/DependencyInjection/JaneAutoMapperExtension.php
+++ b/src/Bundle/AutoMapperBundle/DependencyInjection/JaneAutoMapperExtension.php
@@ -2,6 +2,8 @@
 
 namespace Jane\Bundle\AutoMapperBundle\DependencyInjection;
 
+use Jane\Bundle\AutoMapperBundle\CacheWarmup\CacheWarmerLoaderInterface;
+use Jane\Bundle\AutoMapperBundle\CacheWarmup\ConfigurationCacheWarmerLoader;
 use Jane\Bundle\AutoMapperBundle\Configuration\MapperConfigurationInterface;
 use Jane\Component\AutoMapper\Extractor\FromSourceMappingExtractor;
 use Jane\Component\AutoMapper\Extractor\FromTargetMappingExtractor;
@@ -56,8 +58,7 @@ class JaneAutoMapperExtension extends Extension
         if ($config['normalizer']) {
             $container
                 ->getDefinition(AutoMapperNormalizer::class)
-                ->addTag('serializer.normalizer', ['priority' => 1000])
-            ;
+                ->addTag('serializer.normalizer', ['priority' => 1000]);
         }
 
         if (null !== $config['name_converter']) {
@@ -77,5 +78,10 @@ class JaneAutoMapperExtension extends Extension
         }
 
         $container->setParameter('automapper.cache_dir', $config['cache_dir']);
+
+        $container->registerForAutoconfiguration(CacheWarmerLoaderInterface::class)->addTag('jane_auto_mapper.cache_warmer_loader');
+        $container
+            ->getDefinition(ConfigurationCacheWarmerLoader::class)
+            ->replaceArgument(0, $config['warmup']);
     }
 }

--- a/src/Bundle/AutoMapperBundle/Resources/config/services.xml
+++ b/src/Bundle/AutoMapperBundle/Resources/config/services.xml
@@ -107,5 +107,18 @@
         </service>
 
         <service id="Jane\Component\AutoMapper\Transformer\SymfonyUidTransformerFactory" />
+
+        <service id="Jane\Bundle\AutoMapperBundle\CacheWarmup\CacheWarmer">
+            <argument type="service" id="Jane\Component\AutoMapper\Loader\FileLoader" />
+            <argument type="service" id="Jane\Component\AutoMapper\AutoMapperRegistryInterface" />
+            <argument type="service" id="Jane\Component\AutoMapper\MapperGeneratorMetadataFactoryInterface" />
+            <argument type="tagged_iterator" tag="jane_auto_mapper.cache_warmer_loader" />
+            <tag name="kernel.cache_warmer" />
+        </service>
+
+        <service id="Jane\Bundle\AutoMapperBundle\CacheWarmup\ConfigurationCacheWarmerLoader">
+            <argument/> <!-- mappers list from config -->
+            <tag name="jane_auto_mapper.cache_warmer_loader" />
+        </service>
     </services>
 </container>

--- a/src/Bundle/AutoMapperBundle/Tests/Resources/app/config.yml
+++ b/src/Bundle/AutoMapperBundle/Tests/Resources/app/config.yml
@@ -6,6 +6,8 @@ framework:
 jane_auto_mapper:
     normalizer: true
     name_converter: DummyApp\IdNameConverter
+    warmup:
+      - {source: 'Jane\Bundle\AutoMapperBundle\Tests\Fixtures\Address', target: 'array'}
 
 services:
   _defaults:

--- a/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
+++ b/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
@@ -10,6 +10,7 @@ use Jane\Bundle\AutoMapperBundle\Tests\Fixtures\User;
 use Jane\Bundle\AutoMapperBundle\Tests\Fixtures\UserDTO;
 use Jane\Component\AutoMapper\AutoMapperInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Filesystem\Filesystem;
 
 class ServiceInstantiationTest extends WebTestCase
 {
@@ -19,7 +20,7 @@ class ServiceInstantiationTest extends WebTestCase
         $_SERVER['KERNEL_DIR'] = __DIR__ . '/Resources/app';
         $_SERVER['KERNEL_CLASS'] = 'DummyApp\AppKernel';
 
-        @unlink(__DIR__ . '/Resources/var/cache/test');
+        (new Filesystem())->remove(__DIR__ . '/Resources/var/cache/test');
     }
 
     public function testAutoMapper()
@@ -99,5 +100,15 @@ class ServiceInstantiationTest extends WebTestCase
         $dto = new DTOWithEnum();
         $dto->enum = SomeEnum::FOO;
         self::assertSame(['enum' => 'foo'], $autoMapper->map($dto, 'array'));
+    }
+
+    /**
+     * @see Resources/app/config.yml
+     */
+    public function testWarmup(): void
+    {
+        static::bootKernel();
+
+        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_Address_array.php');
     }
 }

--- a/src/Component/AutoMapper/Loader/FileLoader.php
+++ b/src/Component/AutoMapper/Loader/FileLoader.php
@@ -55,7 +55,10 @@ final class FileLoader implements ClassLoaderInterface
         require $classPath;
     }
 
-    public function saveMapper(MapperGeneratorMetadataInterface $mapperGeneratorMetadata): void
+    /**
+     * @return string The generated class name
+     */
+    public function saveMapper(MapperGeneratorMetadataInterface $mapperGeneratorMetadata): string
     {
         $className = $mapperGeneratorMetadata->getMapperClassName();
         $classPath = $this->directory . \DIRECTORY_SEPARATOR . $className . '.php';
@@ -65,6 +68,8 @@ final class FileLoader implements ClassLoaderInterface
         if ($this->hotReload) {
             $this->addHashToRegistry($className, $mapperGeneratorMetadata->getHash());
         }
+
+        return $className;
     }
 
     private function addHashToRegistry($className, $hash): void


### PR DESCRIPTION
Here is a first draft for generating mappers on cache warmup.

My first thought was to generate the mappers from some attribute on the classes, but PHP does not allow to easily load all classes which have a given attribute, so the only implementation shipped in the bundle is a configuration loader.

The following config will generate a mapper from `Address` to `array`
```yml
jane_auto_mapper:
    generate_on_warmup:
      - {source: 'Jane\Bundle\AutoMapperBundle\Tests\Fixtures\Address', target: 'array'}
``` 

The PR also ships an interface `Jane\Bundle\AutoMapperBundle\CacheWarmup\CacheWarmerLoaderInterface` that the user can implement, in order to warmup dynamically all need mappers.

NB: I wanted to update the doc, but it seems it is not up to date :man_shrugging: 