### PR TITLE
feat(AutoMapper): introduce new attribute `#[MapToContext]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - [AutoMapper] [GH#733](https://github.com/janephp/janephp/pull/733) Configure date format with context
+- [AutoMapper] [GH#731](https://github.com/janephp/janephp/pull/731) Introduce new attribute `MapToContext`
 
 ### Fixed
 - [AutoMapper] [GH#734](https://github.com/janephp/janephp/pull/734) Cache warmer should generate mappers for nested classes

--- a/src/Component/AutoMapper/Attribute/MapToContext.php
+++ b/src/Component/AutoMapper/Attribute/MapToContext.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Component\AutoMapper\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)] final class MapToContext
+{
+    public function __construct(
+        private string $contextName,
+    ) {
+    }
+
+    public function getContextName(): string
+    {
+        return $this->contextName;
+    }
+}

--- a/src/Component/AutoMapper/Extractor/MapToContextReadInfoExtractorDecorator.php
+++ b/src/Component/AutoMapper/Extractor/MapToContextReadInfoExtractorDecorator.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Component\AutoMapper\Extractor;
+
+use Jane\Component\AutoMapper\Attribute\MapToContext;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyReadInfo;
+use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
+
+final class MapToContextReadInfoExtractorDecorator implements PropertyReadInfoExtractorInterface
+{
+    private $decorated;
+
+    public function __construct(PropertyReadInfoExtractorInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    public function getReadInfo(string $class, string $property, array $context = []): ?PropertyReadInfo
+    {
+        $readInfo = $this->decorated->getReadInfo($class, $property, $context);
+
+        if (null === $readInfo) {
+            return null;
+        }
+
+        if ($readInfo->getType() === PropertyReadInfo::TYPE_PROPERTY && PropertyReadInfo::VISIBILITY_PUBLIC !== $readInfo->getVisibility()) {
+            $reflClass = new \ReflectionClass($class);
+            $camelProp = $this->camelize($property);
+
+            // if we have not found a getter, it might be because it has parameters with MapToContext attribute
+            foreach (ReflectionExtractor::$defaultAccessorPrefixes as $prefix) {
+                $methodName = $prefix . $camelProp;
+
+                if (
+                    $reflClass->hasMethod($methodName)
+                    && $reflClass->getMethod($methodName)->getModifiers() === \ReflectionMethod::IS_PUBLIC
+                    && $reflClass->getMethod($methodName)->getNumberOfRequiredParameters()
+                    && $this->allParametersHaveMapToContextAttribute($reflClass->getMethod($methodName))
+                ) {
+                    $method = $reflClass->getMethod($methodName);
+
+                    return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $methodName, PropertyReadInfo::VISIBILITY_PUBLIC, $method->isStatic(), false);
+                }
+            }
+        }
+
+        return $readInfo;
+    }
+
+    private function camelize(string $string): string
+    {
+        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
+    }
+
+    private function allParametersHaveMapToContextAttribute(\ReflectionMethod $method): bool
+    {
+        foreach ($method->getParameters() as $parameter) {
+            if (!$parameter->getAttributes(MapToContext::class)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Component/AutoMapper/Extractor/MappingExtractor.php
+++ b/src/Component/AutoMapper/Extractor/MappingExtractor.php
@@ -31,7 +31,7 @@ abstract class MappingExtractor implements MappingExtractorInterface
     public function __construct(PropertyInfoExtractorInterface $propertyInfoExtractor, PropertyReadInfoExtractorInterface $readInfoExtractor, PropertyWriteInfoExtractorInterface $writeInfoExtractor, TransformerFactoryInterface $transformerFactory, ClassMetadataFactoryInterface $classMetadataFactory = null)
     {
         $this->propertyInfoExtractor = $propertyInfoExtractor;
-        $this->readInfoExtractor = $readInfoExtractor;
+        $this->readInfoExtractor = new MapToContextReadInfoExtractorDecorator($readInfoExtractor);
         $this->writeInfoExtractor = $writeInfoExtractor;
         $this->transformerFactory = $transformerFactory;
         $this->classMetadataFactory = $classMetadataFactory;
@@ -57,6 +57,7 @@ abstract class MappingExtractor implements MappingExtractorInterface
         return new ReadAccessor(
             $type,
             $readInfo->getName(),
+            $source,
             PropertyReadInfo::VISIBILITY_PUBLIC !== $readInfo->getVisibility()
         );
     }

--- a/src/Component/AutoMapper/Generator/Generator.php
+++ b/src/Component/AutoMapper/Generator/Generator.php
@@ -161,8 +161,10 @@ final class Generator
 
             $transformer = $propertyMapping->getTransformer();
 
-            $sourcePropertyAccessor = $propertyMapping->getReadAccessor()->getExpression($sourceInput);
-            [$output, $propStatements] = $transformer->transform($sourcePropertyAccessor, $result, $propertyMapping, $uniqueVariableScope);
+            $fieldValueVariable = new Expr\Variable($uniqueVariableScope->getUniqueName('fieldValue'));
+            $sourcePropertyAccessor = new Expr\Assign($fieldValueVariable, $propertyMapping->getReadAccessor()->getExpression($sourceInput));
+
+            [$output, $propStatements] = $transformer->transform($fieldValueVariable, $result, $propertyMapping, $uniqueVariableScope);
 
             $extractCallback = $propertyMapping->getReadAccessor()->getExtractCallback($mapperGeneratorMetadata->getSource());
 

--- a/src/Component/AutoMapper/MapperContext.php
+++ b/src/Component/AutoMapper/MapperContext.php
@@ -26,12 +26,14 @@ class MapperContext
     public const SKIP_NULL_VALUES = 'skip_null_values';
     public const ALLOW_READONLY_TARGET_TO_POPULATE = 'allow_readonly_target_to_populate';
     public const DATETIME_FORMAT = 'datetime_format';
+    public const MAP_TO_ACCESSOR_PARAMETER = 'map_to_accessor_parameter';
 
     private $context = [
         self::DEPTH => 0,
         self::CIRCULAR_REFERENCE_REGISTRY => [],
         self::CIRCULAR_COUNT_REFERENCE_REGISTRY => [],
         self::CONSTRUCTOR_ARGUMENTS => [],
+        self::MAP_TO_ACCESSOR_PARAMETER => [],
     ];
 
     public function toArray(): array

--- a/src/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -14,6 +14,7 @@ use Jane\Component\AutoMapper\Tests\Fixtures\AddressDTOWithReadonly;
 use Jane\Component\AutoMapper\Tests\Fixtures\AddressDTOWithReadonlyPromotedProperty;
 use Jane\Component\AutoMapper\Tests\Fixtures\AddressType;
 use Jane\Component\AutoMapper\Tests\Fixtures\AddressWithEnum;
+use Jane\Component\AutoMapper\Tests\Fixtures\ClassWithMapToContextAttribute;
 use Jane\Component\AutoMapper\Tests\Fixtures\Fish;
 use Jane\Component\AutoMapper\Tests\Fixtures\ObjectWithDateTime;
 use Jane\Component\AutoMapper\Tests\Fixtures\Order;
@@ -1163,6 +1164,21 @@ class AutoMapperTest extends AutoMapperBaseTest
                 ['dateTime' => '24-01-2023'],
                 ObjectWithDateTime::class,
                 [MapperContext::DATETIME_FORMAT => '!d-m-Y']
+            )
+        );
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testMapToContextAttribute(): void
+    {
+        self::assertSame(
+            ['value' => 'foo_bar_baz'],
+            $this->autoMapper->map(
+                new ClassWithMapToContextAttribute('bar'),
+                'array',
+                [MapperContext::MAP_TO_ACCESSOR_PARAMETER => ['suffix' => 'baz', 'prefix' => 'foo']]
             )
         );
     }

--- a/src/Component/AutoMapper/Tests/Fixtures/ClassWithMapToContextAttribute.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/ClassWithMapToContextAttribute.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\AutoMapper\Tests\Fixtures;
+
+use Jane\Component\AutoMapper\Attribute\MapToContext;
+
+class ClassWithMapToContextAttribute
+{
+    public function __construct(
+        private string $value,
+    ) {
+    }
+
+    public function getValue(
+        #[MapToContext('prefix')] string $prefix,
+        #[MapToContext('suffix')] string $suffix,
+    ): string {
+        return "{$prefix}_{$this->value}_{$suffix}";
+    }
+}


### PR DESCRIPTION
Hello,

here is a proposal for the Automapper: let's allow to map some values from the context to the parameters of an accessor, based on an attribute

Given the following class:
```php
class ClassWithMapToContextAttribute
{
    public function __construct(
        private string $value,
    )
    {
    }

    public function getValue(
        #[MapToContext('prefix')] string $prefix,
    ): string
    {
        return "{$prefix}_{$this->value}";
    }
}
```
usually the `getValue()` would be called without any attribute, but with the attribute added on the parameter, it gets passed the value `prefix` which is in the context.
This would allow to inject any arbitrary value we would need to transform the source field.

My use case is the following: in API Platform I'm normalizing the resources with the automapper and not with Symfony's serializer because of its bad performances, but I sometimes need to translate some fields or enums, and this would be the easiest trick, when I'm asking for the automapper to map the api resource into an array, I'd like to pass the translator, so that I can translate some fields the easiest way. But I think this feat could benefit to other edge cases.

Let me know you think this needs more tests.
Maybe this should also be documented somewhere