### PR TITLE
fix: cache warmer should generate mappers for nested classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [AutoMapper] [GH#733](https://github.com/janephp/janephp/pull/733) Configure date format with context
 
+### Fixed
+- [AutoMapper] [GH#734](https://github.com/janephp/janephp/pull/734) Cache warmer should generate mappers for nested classes
+
 ## [7.5.1] - 2023-06-13
 ### Fixed
 - [AutoMapper] [GH#729](https://github.com/janephp/janephp/pull/729) Allow to add full objects in `allowed_attribute` context

--- a/src/Bundle/AutoMapperBundle/Resources/config/services.xml
+++ b/src/Bundle/AutoMapperBundle/Resources/config/services.xml
@@ -109,10 +109,9 @@
         <service id="Jane\Component\AutoMapper\Transformer\SymfonyUidTransformerFactory" />
 
         <service id="Jane\Bundle\AutoMapperBundle\CacheWarmup\CacheWarmer">
-            <argument type="service" id="Jane\Component\AutoMapper\Loader\FileLoader" />
             <argument type="service" id="Jane\Component\AutoMapper\AutoMapperRegistryInterface" />
-            <argument type="service" id="Jane\Component\AutoMapper\MapperGeneratorMetadataFactoryInterface" />
             <argument type="tagged_iterator" tag="jane_auto_mapper.cache_warmer_loader" />
+            <argument type="string">%automapper.cache_dir%</argument>
             <tag name="kernel.cache_warmer" />
         </service>
 

--- a/src/Bundle/AutoMapperBundle/Tests/Fixtures/NestedObject.php
+++ b/src/Bundle/AutoMapperBundle/Tests/Fixtures/NestedObject.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Bundle\AutoMapperBundle\Tests\Fixtures;
+
+class NestedObject
+{
+    /**
+     * @var User
+     */
+    public $user;
+}

--- a/src/Bundle/AutoMapperBundle/Tests/Resources/app/config.yml
+++ b/src/Bundle/AutoMapperBundle/Tests/Resources/app/config.yml
@@ -7,7 +7,7 @@ jane_auto_mapper:
     normalizer: true
     name_converter: DummyApp\IdNameConverter
     warmup:
-      - {source: 'Jane\Bundle\AutoMapperBundle\Tests\Fixtures\Address', target: 'array'}
+      - {source: 'Jane\Bundle\AutoMapperBundle\Tests\Fixtures\NestedObject', target: 'array'}
 
 services:
   _defaults:

--- a/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
+++ b/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
@@ -23,6 +23,22 @@ class ServiceInstantiationTest extends WebTestCase
         (new Filesystem())->remove(__DIR__ . '/Resources/var/cache/test');
     }
 
+    /**
+     * @see Resources/app/config.yml
+     */
+    public function testWarmup(): void
+    {
+        static::bootKernel();
+
+        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_NestedObject_array.php');
+        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_User_array.php');
+        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_AddressDTO_array.php');
+
+        self::assertInstanceOf(\Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_NestedObject_array::class, new \Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_NestedObject_array());
+        self::assertInstanceOf(\Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_User_array::class, new \Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_User_array());
+        self::assertInstanceOf(\Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_AddressDTO_array::class, new \Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_AddressDTO_array());
+    }
+
     public function testAutoMapper()
     {
         static::bootKernel();
@@ -100,15 +116,5 @@ class ServiceInstantiationTest extends WebTestCase
         $dto = new DTOWithEnum();
         $dto->enum = SomeEnum::FOO;
         self::assertSame(['enum' => 'foo'], $autoMapper->map($dto, 'array'));
-    }
-
-    /**
-     * @see Resources/app/config.yml
-     */
-    public function testWarmup(): void
-    {
-        static::bootKernel();
-
-        self::assertFileExists(__DIR__ . '/Resources/var/cache/test/automapper/Symfony_Mapper_Jane_Bundle_AutoMapperBundle_Tests_Fixtures_Address_array.php');
     }
 }

--- a/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
+++ b/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
@@ -24,7 +24,7 @@ class ServiceInstantiationTest extends WebTestCase
     }
 
     /**
-     * This method needs to be the first in this test class, more details about why here: https://github.com/janephp/janephp/pull/734#discussion_r1247921885
+     * This method needs to be the first in this test class, more details about why here: https://github.com/janephp/janephp/pull/734#discussion_r1247921885.
      *
      * @see Resources/app/config.yml
      */

--- a/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
+++ b/src/Bundle/AutoMapperBundle/Tests/ServiceInstantiationTest.php
@@ -24,6 +24,8 @@ class ServiceInstantiationTest extends WebTestCase
     }
 
     /**
+     * This method needs to be the first in this test class, more details about why here: https://github.com/janephp/janephp/pull/734#discussion_r1247921885
+     *
      * @see Resources/app/config.yml
      */
     public function testWarmup(): void


### PR DESCRIPTION
Hello,

here is a small fix for the cache wamup process: we now generate the mapper for the given classes and for all nested classes