### PR TITLE
fix(AutoMapper): MapToContext should accept virtual properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [AutoMapper] [GH#734](https://github.com/janephp/janephp/pull/741) `#[MapToContext]` should accept virtual properties
+
+## [7.5.2]
 
 ## [7.5.2] - 2023-07-10
 ### Added

--- a/src/Bundle/AutoMapperBundle/Resources/config/services.xml
+++ b/src/Bundle/AutoMapperBundle/Resources/config/services.xml
@@ -14,7 +14,7 @@
 
         <service id="Jane\Component\AutoMapper\Extractor\SourceTargetMappingExtractor">
             <argument type="service" id="property_info" />
-            <argument type="service" id="property_info.reflection_extractor" />
+            <argument type="service" id="Jane\Component\AutoMapper\Extractor\MapToContextPropertyInfoExtractorDecorator" />
             <argument type="service" id="property_info.reflection_extractor" />
             <argument type="service" id="Jane\Component\AutoMapper\Transformer\TransformerFactoryInterface" />
         </service>
@@ -29,7 +29,7 @@
 
         <service id="Jane\Component\AutoMapper\Extractor\FromSourceMappingExtractor">
             <argument type="service" id="property_info" />
-            <argument type="service" id="property_info.reflection_extractor" />
+            <argument type="service" id="Jane\Component\AutoMapper\Extractor\MapToContextPropertyInfoExtractorDecorator" />
             <argument type="service" id="property_info.reflection_extractor" />
             <argument type="service" id="Jane\Component\AutoMapper\Transformer\TransformerFactoryInterface" />
             <argument type="service" id="serializer.mapping.class_metadata_factory" />
@@ -118,6 +118,11 @@
         <service id="Jane\Bundle\AutoMapperBundle\CacheWarmup\ConfigurationCacheWarmerLoader">
             <argument/> <!-- mappers list from config -->
             <tag name="jane_auto_mapper.cache_warmer_loader" />
+        </service>
+
+        <service id="Jane\Component\AutoMapper\Extractor\MapToContextPropertyInfoExtractorDecorator">
+            <argument type="service" id="property_info.reflection_extractor" />
+            <tag name="property_info.access_extractor" priority="-100" />
         </service>
     </services>
 </container>

--- a/src/Component/AutoMapper/AutoMapper.php
+++ b/src/Component/AutoMapper/AutoMapper.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Jane\Component\AutoMapper\Exception\NoMappingFoundException;
 use Jane\Component\AutoMapper\Extractor\FromSourceMappingExtractor;
 use Jane\Component\AutoMapper\Extractor\FromTargetMappingExtractor;
+use Jane\Component\AutoMapper\Extractor\MapToContextPropertyInfoExtractorDecorator;
 use Jane\Component\AutoMapper\Extractor\SourceTargetMappingExtractor;
 use Jane\Component\AutoMapper\Generator\Generator;
 use Jane\Component\AutoMapper\Loader\ClassLoaderInterface;
@@ -218,13 +219,13 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface, Ma
             [$reflectionExtractor],
             [$phpDocExtractor, $reflectionExtractor],
             [$reflectionExtractor],
-            [$reflectionExtractor]
+            [new MapToContextPropertyInfoExtractorDecorator($reflectionExtractor)]
         );
 
         $transformerFactory = new ChainTransformerFactory();
         $sourceTargetMappingExtractor = new SourceTargetMappingExtractor(
             $propertyInfoExtractor,
-            $reflectionExtractor,
+            new MapToContextPropertyInfoExtractorDecorator($reflectionExtractor),
             $reflectionExtractor,
             $transformerFactory,
             $classMetadataFactory
@@ -241,7 +242,7 @@ class AutoMapper implements AutoMapperInterface, AutoMapperRegistryInterface, Ma
 
         $fromSourceMappingExtractor = new FromSourceMappingExtractor(
             $propertyInfoExtractor,
-            $reflectionExtractor,
+            new MapToContextPropertyInfoExtractorDecorator($reflectionExtractor),
             $reflectionExtractor,
             $transformerFactory,
             $classMetadataFactory,

--- a/src/Component/AutoMapper/Extractor/MappingExtractor.php
+++ b/src/Component/AutoMapper/Extractor/MappingExtractor.php
@@ -31,7 +31,7 @@ abstract class MappingExtractor implements MappingExtractorInterface
     public function __construct(PropertyInfoExtractorInterface $propertyInfoExtractor, PropertyReadInfoExtractorInterface $readInfoExtractor, PropertyWriteInfoExtractorInterface $writeInfoExtractor, TransformerFactoryInterface $transformerFactory, ClassMetadataFactoryInterface $classMetadataFactory = null)
     {
         $this->propertyInfoExtractor = $propertyInfoExtractor;
-        $this->readInfoExtractor = new MapToContextReadInfoExtractorDecorator($readInfoExtractor);
+        $this->readInfoExtractor = $readInfoExtractor;
         $this->writeInfoExtractor = $writeInfoExtractor;
         $this->transformerFactory = $transformerFactory;
         $this->classMetadataFactory = $classMetadataFactory;

--- a/src/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -1174,7 +1174,10 @@ class AutoMapperTest extends AutoMapperBaseTest
     public function testMapToContextAttribute(): void
     {
         self::assertSame(
-            ['value' => 'foo_bar_baz'],
+            [
+                'value' => 'foo_bar_baz',
+                'virtualProperty' => 'foo_bar_baz',
+            ],
             $this->autoMapper->map(
                 new ClassWithMapToContextAttribute('bar'),
                 'array',

--- a/src/Component/AutoMapper/Tests/Fixtures/ClassWithMapToContextAttribute.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/ClassWithMapToContextAttribute.php
@@ -17,4 +17,11 @@ class ClassWithMapToContextAttribute
     ): string {
         return "{$prefix}_{$this->value}_{$suffix}";
     }
+
+    public function getVirtualProperty(
+        #[MapToContext('prefix')] string $prefix,
+        #[MapToContext('suffix')] string $suffix,
+    ): string {
+        return "{$prefix}_{$this->value}_{$suffix}";
+    }
 }


### PR DESCRIPTION
I'm just not really sure about the strategy I used to make the service `MapToContextPropertyInfoExtractorDecorator` available: I don't want to decorate `ReflectionExtractor` in the whole app, this is a little bit too intrusive

Another solution would be to declare a new property extractor service specific to the automapper.