### PR TITLE
fix(AutoMapper): always require registry.php during cache warmup

### DIFF
--- a/src/Bundle/AutoMapperBundle/CacheWarmup/CacheWarmer.php
+++ b/src/Bundle/AutoMapperBundle/CacheWarmup/CacheWarmer.php
@@ -51,7 +51,7 @@ final class CacheWarmer implements CacheWarmerInterface
             return [];
         }
 
-        $mapppers = array_keys(require_once $registryFile);
+        $mapppers = array_keys(require $registryFile);
 
         return array_map(
             function ($mapper) {


### PR DESCRIPTION
In some cases when clearing the cache, I got this error:
```bash
TypeError {#7873
  #message: "array_keys(): Argument #1 ($array) must be of type array, bool given"
  #code: 0
  #file: "/app/vendor/jane-php/automapper-bundle/CacheWarmup/CacheWarmer.php"
  #line: 55
  trace: {
    /app/vendor/jane-php/automapper-bundle/CacheWarmup/CacheWarmer.php:55 { …}
```

so `require_once` returns a bool although the file do exist (there is a check just above) and I've check that even when the error occurs, the file's content is OK. So I concluded that the file has already been required (but I have to confess that I don't know why :shrug: ) and using `require` instead fixes the problem

check https://3v4l.org/5fadP#v8.2.7 => the second `require_once` returns `true`