### PR TITLE
feat(config): Allow pass root-class for OpenApi Client

### DIFF
--- a/src/Component/JsonSchema/Console/Loader/ConfigLoader.php
+++ b/src/Component/JsonSchema/Console/Loader/ConfigLoader.php
@@ -69,6 +69,7 @@ class ConfigLoader implements ConfigLoaderInterface
             'skip-required-fields' => false,
             'custom-string-format-mapping' => [],
             'validation' => false,
+            'root-class'   => '',
         ];
     }
 }

--- a/src/Component/OpenApiCommon/Console/Loader/SchemaLoader.php
+++ b/src/Component/OpenApiCommon/Console/Loader/SchemaLoader.php
@@ -11,7 +11,7 @@ class SchemaLoader extends BaseSchemaLoader implements SchemaLoaderInterface
 {
     protected function newSchema(string $schema, array $options): SchemaInterface
     {
-        return new Schema($schema, $options['namespace'], $options['directory']);
+        return new Schema($schema, $options['namespace'], $options['directory'], $options['root-class'] ?? '');
     }
 
     protected function getDefinedOptions(): array
@@ -37,6 +37,7 @@ class SchemaLoader extends BaseSchemaLoader implements SchemaLoaderInterface
             'custom-query-resolver',
             'throw-unexpected-status-code',
             'custom-string-format-mapping',
+            'root-class',
         ];
     }
 

--- a/src/Component/OpenApiCommon/Generator/ClientGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/ClientGenerator.php
@@ -38,7 +38,8 @@ abstract class ClientGenerator implements GeneratorInterface
             $statements[] = $this->operationGenerator->createOperation($operationName, $operation, $context);
         }
 
-        $client = $this->createResourceClass($schema, 'Client' . $this->getSuffix());
+        $className =  empty($schema->getRootName()) ? 'Client' : $schema->getRootName() . $this->getSuffix();
+        $client = $this->createResourceClass($schema, $className);
         $client->stmts = array_merge(
             $statements,
             [
@@ -51,7 +52,7 @@ abstract class ClientGenerator implements GeneratorInterface
         ]);
 
         $schema->addFile(new File(
-            $schema->getDirectory() . \DIRECTORY_SEPARATOR . 'Client' . $this->getSuffix() . '.php',
+            $schema->getDirectory() . \DIRECTORY_SEPARATOR . $className . '.php',
             $node,
             'client'
         ));

--- a/src/Component/OpenApiCommon/Registry/Schema.php
+++ b/src/Component/OpenApiCommon/Registry/Schema.php
@@ -15,9 +15,9 @@ class Schema extends BaseSchema implements SchemaInterface
     /** @var SecuritySchemeGuess[] List of SecuritySchemes associated to this schema */
     private $securitySchemes = [];
 
-    public function __construct(string $origin, string $namespace, string $directory)
+    public function __construct(string $origin, string $namespace, string $directory, string $rootName)
     {
-        parent::__construct($origin, $namespace, $directory, '');
+        parent::__construct($origin, $namespace, $directory, $rootName);
     }
 
     public function addSecurityScheme(string $reference, SecuritySchemeGuess $securityScheme)


### PR DESCRIPTION
This PR allow adding 'root-class' in config for OpenAPI this new config parameter permit to set a custom name to the generated `Client` class.

The goal were able to generate multiple clients in same project with different client names.

At this time, my workaround is to generate a client, and edit the file via a script to change class name and filename. But could be useful if jane can do it :smile: 

```
return [
    'openapi-file' => '/app/clients/openapi-specs/DomainA-doc.json',
    'namespace' => 'Acme\Domain\DomainA',
    'directory' => '/app/clients/src/DomainA',
    'root-class' => 'DomainAClient',
];
```

Will generate `apps/clients/src/DomainA/AClient.php`
