### PR TITLE
Move PHP CS Fixer to a separate composer.json file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,22 +6,17 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@master
-      - name: cache-composer
-        uses: actions/cache@v2
-        with:
-          path: ~/.composer/cache/
-          key: composer-7.4-${{ github.sha }}
       - name: setup
         uses: shivammathur/setup-php@2.9.0
         with:
-          php-version: 8.0
-          extensions: mbstring, fileinfo, json, intl, dom
-      - name: install
-        run: composer update --prefer-stable
+          php-version: 8.2
+          coverage: none
+      - name: install PHP CS Fixer
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: '--working-dir=tools/php-cs-fixer'
       - name: 'php-cs-fixer check'
-        run: 'vendor/bin/php-cs-fixer fix --dry-run --diff'
-        env:
-          PHP_CS_FIXER_IGNORE_ENV: 1
+        run: 'tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff'
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
-.php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache
 vendor
 composer.lock
@@ -18,3 +18,6 @@ cache/*
 !cache/.gitkeep
 src/Component/AutoMapper/Tests/cache/*
 !src/Component/AutoMapper/Tests/cache/.gitkeep
+
+tools/*/composer.lock
+tools/*/vendor

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,6 +1,6 @@
 <?php
 
-$dirs = PhpCsFixer\Finder::create()
+$finder = (new PhpCsFixer\Finder())
     ->exclude('Component/JsonSchema/JsonSchema')
     ->exclude('Component/JsonSchema/Tests/fixtures')
     ->exclude('Component/JsonSchema/Tests/generated')
@@ -27,14 +27,23 @@ $dirs = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
 ;
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'array_syntax' => ['syntax' => 'short'],
         'concat_space' => ['spacing' => 'one'],
-        'yoda_style' => null,
+        'yoda_style' => false,
+        'native_constant_invocation' => false,
+        'no_superfluous_phpdoc_tags' => [
+            'remove_inheritdoc' => false,
+        ],
+        'nullable_type_declaration_for_default_null_value' => false,
+
+        // Can be removed once PHP requirement is upgraded
+        'get_class_to_class_keyword' => false,
+        'modernize_strpos' => false,
     ])
-    ->setFinder($dirs)
+    ->setFinder($finder)
 ;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [Jane] [GH#748](https://github.com/janephp/janephp/pull/748) Move PHP CS Fixer to a separate composer.json file
 
 ## [7.5.3] - 2023-08-04
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,13 @@ Please, write [commit messages that make sense](http://tbaggery.com/2008/04/19/a
 One may ask you to [squash your commits](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html) too. This is used to "clean" your Pull Request before merging it (we don't want commits such as `fix tests`, `fix 2`, `fix 3`, etc.).
 
 Also, when creating your Pull Request on GitHub, you **MUST** write a description which gives the context and/or explains why you are creating it.
+
+## PHP CS Fixer
+
+```bash
+composer install --working-dir=tools/php-cs-fixer
+# Check what can be fixed
+tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff
+# Fix them
+tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --diff
+```

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,6 @@
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",
-        "friendsofphp/php-cs-fixer": "2.17.2",
         "jms/serializer": "^3.12",
         "kriswallsmith/buzz": "^1.1",
         "moneyphp/money": "^3.0",

--- a/src/Benchmark/JaneAutoMapperBenchmark.php
+++ b/src/Benchmark/JaneAutoMapperBenchmark.php
@@ -19,8 +19,11 @@ use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 
 /**
  * @BeforeMethods({"initAutomapper"})
+ *
  * @Warmup(1)
+ *
  * @Revs(60)
+ *
  * @Iterations(60)
  */
 class JaneAutoMapperBenchmark

--- a/src/Benchmark/JmsSerializerBenchmark.php
+++ b/src/Benchmark/JmsSerializerBenchmark.php
@@ -12,8 +12,11 @@ use PhpBench\Benchmark\Metadata\Annotations\Warmup;
 
 /**
  * @BeforeMethods({"initSerializer"})
+ *
  * @Warmup(1)
+ *
  * @Revs(60)
+ *
  * @Iterations(60)
  */
 class JmsSerializerBenchmark
@@ -22,7 +25,7 @@ class JmsSerializerBenchmark
 
     public function initSerializer(): void
     {
-        $this->serializer = (SerializerBuilder::create())->build();
+        $this->serializer = SerializerBuilder::create()->build();
     }
 
     public function benchJmsSerializer()

--- a/src/Benchmark/SymfonyObjectNormalizerBenchmark.php
+++ b/src/Benchmark/SymfonyObjectNormalizerBenchmark.php
@@ -21,8 +21,11 @@ use Symfony\Component\Serializer\Serializer;
 
 /**
  * @BeforeMethods({"initObjectNormalizer"})
+ *
  * @Warmup(1)
+ *
  * @Revs(60)
+ *
  * @Iterations(60)
  */
 class SymfonyObjectNormalizerBenchmark

--- a/src/Component/AutoMapper/Attribute/MapToContext.php
+++ b/src/Component/AutoMapper/Attribute/MapToContext.php
@@ -6,7 +6,7 @@ namespace Jane\Component\AutoMapper\Attribute;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PARAMETER)] final class MapToContext
+#[\Attribute(\Attribute::TARGET_PARAMETER)] final class MapToContext
 {
     public function __construct(
         private string $contextName,

--- a/src/Component/AutoMapper/Extractor/MapToContextPropertyInfoExtractorDecorator.php
+++ b/src/Component/AutoMapper/Extractor/MapToContextPropertyInfoExtractorDecorator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jane\Component\AutoMapper\Extractor;
 
 use Jane\Component\AutoMapper\Attribute\MapToContext;
-use ReflectionException;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyReadInfo;
@@ -89,7 +88,7 @@ final class MapToContextPropertyInfoExtractorDecorator implements PropertyAccess
             }
 
             return (bool) ($reflectionProperty->getModifiers() & \ReflectionProperty::IS_PUBLIC);
-        } catch (ReflectionException $e) {
+        } catch (\ReflectionException $e) {
             // Return false if the property doesn't exist
         }
 

--- a/src/Component/AutoMapper/MapperMetadata.php
+++ b/src/Component/AutoMapper/MapperMetadata.php
@@ -39,7 +39,7 @@ class MapperMetadata implements MapperGeneratorMetadataInterface
 
     private $attributeChecking;
 
-    private $targetReflectionClass = null;
+    private $targetReflectionClass;
 
     public function __construct(MapperGeneratorMetadataRegistryInterface $metadataRegistry, MappingExtractorInterface $mappingExtractor, string $source, string $target, bool $isTargetReadOnlyClass, string $classPrefix = 'Mapper_')
     {

--- a/src/Component/AutoMapper/Tests/AutoMapperTest.php
+++ b/src/Component/AutoMapper/Tests/AutoMapperTest.php
@@ -1100,6 +1100,7 @@ class AutoMapperTest extends AutoMapperBaseTest
 
     /**
      * @requires PHP 8.1
+     *
      * @dataProvider provideReadonly
      */
     public function testReadonly(string $addressWithReadonlyClass): void

--- a/src/Component/AutoMapper/Tests/Fixtures/IssueTargetToPopulate/VatEntity.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/IssueTargetToPopulate/VatEntity.php
@@ -7,7 +7,7 @@ class VatEntity
     /**
      * @var int|null
      */
-    private $id = null;
+    private $id;
 
     /**
      * @var string

--- a/src/Component/AutoMapper/Tests/Fixtures/SkipNullValues/Input.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/SkipNullValues/Input.php
@@ -7,5 +7,5 @@ class Input
     /**
      * @var string|null
      */
-    public $name = null;
+    public $name;
 }

--- a/src/Component/AutoMapper/Tests/Fixtures/UserPartialConstructor.php
+++ b/src/Component/AutoMapper/Tests/Fixtures/UserPartialConstructor.php
@@ -2,8 +2,6 @@
 
 namespace Jane\Component\AutoMapper\Tests\Fixtures;
 
-use Symfony\Component\Serializer\Annotation\Groups;
-
 class UserPartialConstructor
 {
     /**

--- a/src/Component/AutoMapper/Transformer/ChainTransformerFactory.php
+++ b/src/Component/AutoMapper/Transformer/ChainTransformerFactory.php
@@ -13,7 +13,7 @@ final class ChainTransformerFactory implements TransformerFactoryInterface
     private $factories = [];
 
     /** @var TransformerFactoryInterface[]|null */
-    private $sorted = null;
+    private $sorted;
 
     /**
      * Biggest priority is MultipleTransformerFactory with 128, so default priority will be bigger in order to

--- a/src/Component/AutoMapper/Transformer/ObjectTransformer.php
+++ b/src/Component/AutoMapper/Transformer/ObjectTransformer.php
@@ -36,14 +36,14 @@ final class ObjectTransformer implements TransformerInterface, DependentTransfor
         $mapperName = $this->getDependencyName();
 
         return [new Expr\MethodCall(new Expr\ArrayDimFetch(
-                new Expr\PropertyFetch(new Expr\Variable('this'), 'mappers'),
+            new Expr\PropertyFetch(new Expr\Variable('this'), 'mappers'),
             new Scalar\String_($mapperName)
-            ), 'map', [
-                new Arg($input),
-                new Arg(new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'withNewContext', [
-                    new Arg(new Expr\Variable('context')),
-                    new Arg(new Scalar\String_($propertyMapping->getProperty())),
-                ])),
+        ), 'map', [
+            new Arg($input),
+            new Arg(new Expr\StaticCall(new Name\FullyQualified(MapperContext::class), 'withNewContext', [
+                new Arg(new Expr\Variable('context')),
+                new Arg(new Scalar\String_($propertyMapping->getProperty())),
+            ])),
         ]), []];
     }
 

--- a/src/Component/JsonSchema/Generator/Model/PropertyGenerator.php
+++ b/src/Component/JsonSchema/Generator/Model/PropertyGenerator.php
@@ -30,7 +30,7 @@ trait PropertyGenerator
             $default = $property->getDefault();
         }
 
-        if ((null !== $default && is_scalar($default)) || (Type::TYPE_ARRAY === $property->getType()->getTypeHint($namespace) && \is_array($default))) {
+        if ((null !== $default && \is_scalar($default)) || (Type::TYPE_ARRAY === $property->getType()->getTypeHint($namespace) && \is_array($default))) {
             $propertyStmt->default = $this->getDefaultAsExpr($default)->expr;
         }
 
@@ -54,7 +54,7 @@ trait PropertyGenerator
  *
 
 EOD
-        , $property->getDescription());
+            , $property->getDescription());
 
         if ($property->isDeprecated()) {
             $description .= <<<EOD
@@ -68,7 +68,7 @@ EOD;
  * @var %s
  */
 EOD
-        , $docTypeHint);
+            , $docTypeHint);
 
         return new Doc($description);
     }

--- a/src/Component/JsonSchema/Generator/ModelGenerator.php
+++ b/src/Component/JsonSchema/Generator/ModelGenerator.php
@@ -19,7 +19,7 @@ class ModelGenerator implements GeneratorInterface
     use GetterSetterGenerator;
     use PropertyGenerator;
 
-    const FILE_TYPE_MODEL = 'model';
+    public const FILE_TYPE_MODEL = 'model';
 
     /**
      * @var Naming Naming Service

--- a/src/Component/JsonSchema/Generator/Naming.php
+++ b/src/Component/JsonSchema/Generator/Naming.php
@@ -3,8 +3,6 @@
 namespace Jane\Component\JsonSchema\Generator;
 
 use Jane\Component\JsonSchema\Tools\InflectorTrait;
-use function strtolower;
-use function substr;
 
 /**
  * Helper to generate name for property / class / ....
@@ -13,7 +11,7 @@ class Naming
 {
     use InflectorTrait;
 
-    const BAD_CLASS_NAME_REGEX = '/^
+    public const BAD_CLASS_NAME_REGEX = '/^
         ([0-9])|
         \b(
             (a(bstract|nd|rray|s))|

--- a/src/Component/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -117,9 +117,9 @@ trait NormalizerGenerator
                     );
                 }
 
-                if ((!$context->isStrict() || $property->isNullable() ||
-                    ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1) ||
-                    ($property->getType()->getName() === Type::TYPE_NULL)) && !$skipNullValues) {
+                if ((!$context->isStrict() || $property->isNullable()
+                    || ($property->getType() instanceof MultipleType && \count(array_intersect([Type::TYPE_NULL], $property->getType()->getTypes())) === 1)
+                    || ($property->getType()->getName() === Type::TYPE_NULL)) && !$skipNullValues) {
                     $statements[] = new Stmt\Else_(
                         [new Stmt\Expression(new Expr\Assign(new Expr\ArrayDimFetch($dataVariable, new Scalar\String_($property->getName())), new Expr\ConstFetch(new Name('null'))))]
                     );

--- a/src/Component/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/NormalizerGenerator.php
@@ -17,11 +17,10 @@ use PhpParser\Parser;
 
 class NormalizerGenerator implements GeneratorInterface
 {
-    const FILE_TYPE_NORMALIZER = 'normalizer';
-
     use DenormalizerGenerator;
     use JaneObjectNormalizerGenerator;
     use NormalizerGeneratorTrait;
+    public const FILE_TYPE_NORMALIZER = 'normalizer';
 
     /**
      * @var Naming The naming service
@@ -143,8 +142,8 @@ class NormalizerGenerator implements GeneratorInterface
     protected function canUseCacheableSupportsMethod(?bool $useCacheableSupportsMethod): bool
     {
         return
-            true === $useCacheableSupportsMethod ||
-            (null === $useCacheableSupportsMethod && class_exists('Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface'));
+            true === $useCacheableSupportsMethod
+            || (null === $useCacheableSupportsMethod && class_exists('Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface'));
     }
 
     protected function createJaneObjectNormalizerClass(Schema $schema, array $normalizers): array
@@ -227,7 +226,7 @@ class NormalizerGenerator implements GeneratorInterface
     /**
      * Create method to return the supported type.
      *
-     * @param string[] $modelFqdn Fully Qualified name of the models class denormalized
+     * @param string[] $modelsFqdn Fully Qualified name of the models class denormalized
      *
      * @return Stmt\ClassMethod
      */

--- a/src/Component/JsonSchema/Generator/RuntimeGenerator.php
+++ b/src/Component/JsonSchema/Generator/RuntimeGenerator.php
@@ -10,7 +10,7 @@ use PhpParser\Parser;
 
 class RuntimeGenerator implements GeneratorInterface
 {
-    const FILE_TYPE_RUNTIME = 'runtime';
+    public const FILE_TYPE_RUNTIME = 'runtime';
 
     private $naming;
     private $parser;

--- a/src/Component/JsonSchema/Generator/ValidatorGenerator.php
+++ b/src/Component/JsonSchema/Generator/ValidatorGenerator.php
@@ -14,9 +14,9 @@ use Symfony\Component\Validator\Constraints\Required;
 
 class ValidatorGenerator implements GeneratorInterface
 {
-    const FILE_TYPE_VALIDATOR = 'validator';
-    const VALIDATOR_INTERFACE_NAME = 'ValidatorInterface';
-    const VALIDATOR_EXCEPTION_NAME = 'ValidationException';
+    public const FILE_TYPE_VALIDATOR = 'validator';
+    public const VALIDATOR_INTERFACE_NAME = 'ValidatorInterface';
+    public const VALIDATOR_EXCEPTION_NAME = 'ValidationException';
 
     /** @var Naming */
     private $naming;

--- a/src/Component/JsonSchema/Guesser/Guess/DateTimeType.php
+++ b/src/Component/JsonSchema/Guesser/Guess/DateTimeType.php
@@ -100,6 +100,7 @@ class DateTimeType extends ObjectType
             );
             // new \DateTimeZone('GMT')
             $gmtTimezone = new Expr\New_(new Name('\DateTimeZone'), [new Scalar\String_('GMT')]);
+
             // (new \DateTime($data))->getTimezone()->getName() === 'Z' ? (new \DateTime($data))->setTimezone(new \DateTimeZone('GMT')) : \DateTime($data)
             return new Expr\Ternary(
                 new Expr\BinaryOp\Equal($timezoneName, new Scalar\String_('Z')),

--- a/src/Component/JsonSchema/Guesser/Guess/Type.php
+++ b/src/Component/JsonSchema/Guesser/Guess/Type.php
@@ -9,14 +9,14 @@ use PhpParser\Node\Name;
 
 class Type
 {
-    const TYPE_BOOLEAN = 'bool';
-    const TYPE_INTEGER = 'int';
-    const TYPE_FLOAT = 'float';
-    const TYPE_STRING = 'string';
-    const TYPE_NULL = 'null';
-    const TYPE_MIXED = 'mixed';
-    const TYPE_ARRAY = 'array';
-    const TYPE_OBJECT = 'object';
+    public const TYPE_BOOLEAN = 'bool';
+    public const TYPE_INTEGER = 'int';
+    public const TYPE_FLOAT = 'float';
+    public const TYPE_STRING = 'string';
+    public const TYPE_NULL = 'null';
+    public const TYPE_MIXED = 'mixed';
+    public const TYPE_ARRAY = 'array';
+    public const TYPE_OBJECT = 'object';
 
     protected $phpMapping = [
         self::TYPE_BOOLEAN => 'bool',

--- a/src/Component/JsonSchema/Guesser/JsonSchema/CustomStringFormatGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/CustomStringFormatGuesser.php
@@ -26,9 +26,9 @@ class CustomStringFormatGuesser implements GuesserInterface, TypeGuesserInterfac
         $class = $this->getSchemaClass();
 
         return ($object instanceof $class) && 'string' === $object->getType() && \array_key_exists(
-                $object->getFormat(),
-                $this->mapping
-            );
+            $object->getFormat(),
+            $this->mapping
+        );
     }
 
     public function guessType($object, string $name, string $reference, Registry $registry): Type

--- a/src/Component/JsonSchema/Guesser/JsonSchema/DefinitionGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/DefinitionGuesser.php
@@ -41,10 +41,10 @@ class DefinitionGuesser implements ChainGuesserAwareInterface, GuesserInterface,
      */
     public function supportObject($object): bool
     {
-        return ($object instanceof JsonSchema) &&
-            (
-                (null !== $object->getDefinitions() && \count($object->getDefinitions()) > 0) ||
-                (null !== $object->getDollarDefs() && \count($object->getDollarDefs()) > 0)
+        return ($object instanceof JsonSchema)
+            && (
+                (null !== $object->getDefinitions() && \count($object->getDefinitions()) > 0)
+                || (null !== $object->getDollarDefs() && \count($object->getDollarDefs()) > 0)
             );
     }
 

--- a/src/Component/JsonSchema/Guesser/JsonSchema/ItemsGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/ItemsGuesser.php
@@ -35,10 +35,10 @@ class ItemsGuesser implements GuesserInterface, ClassGuesserInterface, ChainGues
         $class = $this->getSchemaClass();
 
         return
-            $object instanceof $class &&
-            (
-                $object->getItems() instanceof $class ||
-                (\is_array($object->getItems()) && \count($object->getItems()) > 0)
+            $object instanceof $class
+            && (
+                $object->getItems() instanceof $class
+                || (\is_array($object->getItems()) && \count($object->getItems()) > 0)
             )
         ;
     }

--- a/src/Component/JsonSchema/Guesser/JsonSchema/MultipleGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/MultipleGuesser.php
@@ -13,9 +13,8 @@ use Jane\Component\JsonSchema\Registry\Registry;
 
 class MultipleGuesser implements GuesserInterface, TypeGuesserInterface, ChainGuesserAwareInterface
 {
-    protected $bannedTypes = [];
-
     use ChainGuesserAwareTrait;
+    protected $bannedTypes = [];
 
     /**
      * {@inheritdoc}

--- a/src/Component/JsonSchema/Guesser/JsonSchema/ObjectGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/ObjectGuesser.php
@@ -32,7 +32,7 @@ class ObjectGuesser implements GuesserInterface, PropertiesGuesserInterface, Typ
     protected $naming;
 
     /** @var ValidatorInterface */
-    protected $chainValidator = null;
+    protected $chainValidator;
 
     public function __construct(Naming $naming, SerializerInterface $serializer)
     {

--- a/src/Component/JsonSchema/Guesser/JsonSchema/SimpleTypeGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/SimpleTypeGuesser.php
@@ -40,13 +40,10 @@ class SimpleTypeGuesser implements GuesserInterface, TypeGuesserInterface
         $class = $this->getSchemaClass();
 
         return ($object instanceof $class)
-            &&
-            \in_array($object->getType(), $this->typesSupported)
-            &&
-            (
+            && \in_array($object->getType(), $this->typesSupported)
+            && (
                 !\in_array($object->getType(), $this->excludeFormat)
-                ||
-                !\in_array($object->getFormat(), $this->excludeFormat[$object->getType()])
+                || !\in_array($object->getFormat(), $this->excludeFormat[$object->getType()])
             )
         ;
     }

--- a/src/Component/JsonSchema/Guesser/Validator/Any/TypeValidator.php
+++ b/src/Component/JsonSchema/Guesser/Validator/Any/TypeValidator.php
@@ -21,7 +21,7 @@ class TypeValidator implements ValidatorInterface
 
     public function supports($object): bool
     {
-        return $this->checkObject($object) && $object->getType() !== null && (\is_string($object->getType()) || (\is_array($object->getType() && null !== $object->getType()[0])));
+        return $this->checkObject($object) && $object->getType() !== null && (\is_string($object->getType()) || \is_array($object->getType() && null !== $object->getType()[0]));
     }
 
     /**

--- a/src/Component/JsonSchema/Registry/Schema.php
+++ b/src/Component/JsonSchema/Registry/Schema.php
@@ -178,14 +178,14 @@ class Schema implements SchemaInterface
         foreach ($classGuess->getProperties() as $property) {
             // second condition is here to avoid mapping PHP classes such as \DateTime
             /** @var ObjectType $objectType */
-            if (($objectType = $property->getType()) instanceof ObjectType &&
-                '\\' !== substr($objectType->getClassName(), 0, 1)) {
+            if (($objectType = $property->getType()) instanceof ObjectType
+                && '\\' !== substr($objectType->getClassName(), 0, 1)) {
                 $this->addRelation($baseModel, $objectType->getClassName());
             }
 
-            if (($arrayType = $property->getType()) instanceof ArrayType &&
-                ($itemType = $arrayType->getItemType()) instanceof ObjectType &&
-                '\\' !== substr($itemType->getClassName(), 0, 1)) {
+            if (($arrayType = $property->getType()) instanceof ArrayType
+                && ($itemType = $arrayType->getItemType()) instanceof ObjectType
+                && '\\' !== substr($itemType->getClassName(), 0, 1)) {
                 $this->addRelation($baseModel, $itemType->getClassName());
             }
         }

--- a/src/Component/JsonSchema/Tools/InflectorTrait.php
+++ b/src/Component/JsonSchema/Tools/InflectorTrait.php
@@ -7,7 +7,7 @@ use Doctrine\Inflector\InflectorFactory;
 
 trait InflectorTrait
 {
-    private $inflector = null;
+    private $inflector;
 
     protected function getInflector(): Inflector
     {

--- a/src/Component/JsonSchemaRuntime/Reference.php
+++ b/src/Component/JsonSchemaRuntime/Reference.php
@@ -110,14 +110,10 @@ class Reference
     {
         return
             $this->mergedUri->getScheme() === $this->originUri->getScheme()
-            &&
-            $this->mergedUri->getHost() === $this->originUri->getHost()
-            &&
-            $this->mergedUri->getPort() === $this->originUri->getPort()
-            &&
-            $this->mergedUri->getPath() === $this->originUri->getPath()
-            &&
-            $this->mergedUri->getQuery() === $this->originUri->getQuery()
+            && $this->mergedUri->getHost() === $this->originUri->getHost()
+            && $this->mergedUri->getPort() === $this->originUri->getPort()
+            && $this->mergedUri->getPath() === $this->originUri->getPath()
+            && $this->mergedUri->getQuery() === $this->originUri->getQuery()
         ;
     }
 

--- a/src/Component/OpenApi2/Generator/GeneratorFactory.php
+++ b/src/Component/OpenApi2/Generator/GeneratorFactory.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi2\Generator;
 
-use InvalidArgumentException;
 use Jane\Component\JsonSchema\Generator\GeneratorInterface;
 use Jane\Component\OpenApi2\Generator\Parameter\BodyParameterGenerator;
 use Jane\Component\OpenApi2\Generator\Parameter\NonBodyParameterGenerator;
@@ -30,7 +29,7 @@ class GeneratorFactory
         ]);
 
         if (!class_exists($endpointGeneratorClass)) {
-            throw new InvalidArgumentException(sprintf('Unknown generator class %s', $endpointGeneratorClass));
+            throw new \InvalidArgumentException(sprintf('Unknown generator class %s', $endpointGeneratorClass));
         }
 
         $endpointGenerator = new $endpointGeneratorClass($operationNaming, $bodyParameter, $nonBodyParameter, $serializer, $exceptionGenerator);

--- a/src/Component/OpenApi2/Guesser/OpenApiSchema/SchemaGuesser.php
+++ b/src/Component/OpenApi2/Guesser/OpenApiSchema/SchemaGuesser.php
@@ -33,8 +33,8 @@ class SchemaGuesser extends ObjectGuesser
     {
         $classGuess = new ClassGuess($object, $reference, $this->naming->getClassName($name), $extensions);
 
-        if (\is_string($object->getDiscriminator()) &&
-            \is_array($object->getEnum()) && \count($object->getEnum()) > 0) {
+        if (\is_string($object->getDiscriminator())
+            && \is_array($object->getEnum()) && \count($object->getEnum()) > 0) {
             $classGuess = new ParentClass($classGuess, $object->getDiscriminator());
 
             foreach ($object->getEnum() as $subClassName) {

--- a/src/Component/OpenApi3/Generator/Endpoint/GetResponseContentTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetResponseContentTrait.php
@@ -32,7 +32,7 @@ trait GetResponseContentTrait
                 if ($response->getContent()) {
                     foreach ($response->getContent() as $contentType => $content) {
                         $trimmedContentType = trim($contentType);
-                        if (\strlen($trimmedContentType) !== 0 && !\in_array($trimmedContentType, $produces)) {
+                        if ($trimmedContentType !== '' && !\in_array($trimmedContentType, $produces)) {
                             $produces[] = $trimmedContentType;
                         }
                     }
@@ -50,7 +50,7 @@ trait GetResponseContentTrait
                 if ($response->getContent()) {
                     foreach ($response->getContent() as $contentType => $content) {
                         $trimmedContentType = trim($contentType);
-                        if (\strlen($trimmedContentType) !== 0 && !\in_array($trimmedContentType, $produces)) {
+                        if ($trimmedContentType !== '' && !\in_array($trimmedContentType, $produces)) {
                             $produces[] = $trimmedContentType;
                         }
                     }

--- a/src/Component/OpenApi3/Generator/GeneratorFactory.php
+++ b/src/Component/OpenApi3/Generator/GeneratorFactory.php
@@ -2,7 +2,6 @@
 
 namespace Jane\Component\OpenApi3\Generator;
 
-use InvalidArgumentException;
 use Jane\Component\JsonSchema\Generator\GeneratorInterface;
 use Jane\Component\OpenApi3\Generator\Parameter\NonBodyParameterGenerator;
 use Jane\Component\OpenApi3\Generator\RequestBodyContent\DefaultBodyContentGenerator;
@@ -36,7 +35,7 @@ class GeneratorFactory
         $requestBodyGenerator->addRequestBodyGenerator(['application/x-www-form-urlencoded', 'multipart/form-data'], new FormBodyContentGenerator($serializer));
 
         if (!class_exists($endpointGeneratorClass)) {
-            throw new InvalidArgumentException(sprintf('Unknown generator class %s', $endpointGeneratorClass));
+            throw new \InvalidArgumentException(sprintf('Unknown generator class %s', $endpointGeneratorClass));
         }
 
         $endpointGenerator = new $endpointGeneratorClass($operationNaming, $nonBodyParameter, $serializer, $exceptionGenerator, $requestBodyGenerator);

--- a/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
@@ -179,9 +179,9 @@ class NonBodyParameterGenerator extends ParameterGenerator
             $type = 'string';
         }
 
-        if ($additionalProperties instanceof Schema &&
-            'object' === $type &&
-            'string' === $additionalProperties->getType()) {
+        if ($additionalProperties instanceof Schema
+            && 'object' === $type
+            && 'string' === $additionalProperties->getType()) {
             return ['string'];
         }
 

--- a/src/Component/OpenApi3/Guesser/OpenApiSchema/SchemaGuesser.php
+++ b/src/Component/OpenApi3/Guesser/OpenApiSchema/SchemaGuesser.php
@@ -32,8 +32,8 @@ class SchemaGuesser extends ObjectGuesser
         $classGuess = new ClassGuess($object, $reference, $this->naming->getClassName($name), $extensions, $object->getDeprecated() ?? false);
 
         $discriminator = $object->getDiscriminator();
-        if ($discriminator instanceof Discriminator &&
-            is_countable($discriminator->getMapping()) && \count($discriminator->getMapping()) > 0) {
+        if ($discriminator instanceof Discriminator
+            && is_countable($discriminator->getMapping()) && \count($discriminator->getMapping()) > 0) {
             $classGuess = new ParentClass($classGuess, $discriminator->getPropertyName());
 
             foreach ($discriminator->getMapping() as $discriminatorValue => $entryReference) {
@@ -52,8 +52,8 @@ class SchemaGuesser extends ObjectGuesser
             return $classGuess;
         }
 
-        if ($object->getDiscriminator() instanceof Discriminator &&
-            \is_array($object->getEnum()) && \count($object->getEnum()) > 0) {
+        if ($object->getDiscriminator() instanceof Discriminator
+            && \is_array($object->getEnum()) && \count($object->getEnum()) > 0) {
             $classGuess = new ParentClass($classGuess, $object->getDiscriminator()->getPropertyName());
 
             foreach ($object->getEnum() as $subClassName) {

--- a/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
@@ -100,7 +100,7 @@ class ExceptionGenerator
  * @var %s%s
  */
 EOD
-                , '\\' . $classFqdn, ($isArray ? '[]' : ''));
+                , '\\' . $classFqdn, $isArray ? '[]' : '');
 
             $methodName = 'get' . ucfirst($propertyName);
             $exception = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Exception'), [
@@ -119,52 +119,52 @@ EOD
  * @var \Psr\Http\Message\ResponseInterface
  */
 EOD
-)]]),
+                            )]]),
                             new Stmt\ClassMethod('__construct', [
-                                'type' => Stmt\Class_::MODIFIER_PUBLIC,
-                                'params' => [
-                                    new Param(new Node\Expr\Variable($realPropertyName), null, $isArray ? null : new Name('\\' . $classFqdn)),
-                                    new Param(new Node\Expr\Variable('response'), null, new Name('\\Psr\\Http\\Message\\ResponseInterface')),
-                                ],
-                                'stmts' => [
-                                    new Node\Stmt\Expression(new Expr\StaticCall(new Name('parent'), '__construct', [
-                                        new Scalar\String_($description),
-                                    ])),
-                                    new Node\Stmt\Expression(new Expr\Assign(
-                                        new Expr\PropertyFetch(
-                                            new Expr\Variable('this'),
-                                            $propertyName
-                                        ), new Expr\Variable($realPropertyName)
-                                    )),
-                                    new Node\Stmt\Expression(new Expr\Assign(
-                                        new Expr\PropertyFetch(
-                                            new Expr\Variable('this'),
-                                            'response'
-                                        ), new Expr\Variable('response')
-                                    )),
-                                ],
-                            ]),
+                                                            'type' => Stmt\Class_::MODIFIER_PUBLIC,
+                                                            'params' => [
+                                                                new Param(new Node\Expr\Variable($realPropertyName), null, $isArray ? null : new Name('\\' . $classFqdn)),
+                                                                new Param(new Node\Expr\Variable('response'), null, new Name('\\Psr\\Http\\Message\\ResponseInterface')),
+                                                            ],
+                                                            'stmts' => [
+                                                                new Node\Stmt\Expression(new Expr\StaticCall(new Name('parent'), '__construct', [
+                                                                    new Scalar\String_($description),
+                                                                ])),
+                                                                new Node\Stmt\Expression(new Expr\Assign(
+                                                                    new Expr\PropertyFetch(
+                                                                        new Expr\Variable('this'),
+                                                                        $propertyName
+                                                                    ), new Expr\Variable($realPropertyName)
+                                                                )),
+                                                                new Node\Stmt\Expression(new Expr\Assign(
+                                                                    new Expr\PropertyFetch(
+                                                                        new Expr\Variable('this'),
+                                                                        'response'
+                                                                    ), new Expr\Variable('response')
+                                                                )),
+                                                            ],
+                                                        ]),
                             new Stmt\ClassMethod($methodName, [
                                 'type' => Stmt\Class_::MODIFIER_PUBLIC,
                                 'stmts' => [
-                                    new Stmt\Return_(
-                                        new Expr\PropertyFetch(
-                                            new Expr\Variable('this'),
-                                            $propertyName
-                                        )
-                                    ),
+                                                                new Stmt\Return_(
+                                                                    new Expr\PropertyFetch(
+                                                                        new Expr\Variable('this'),
+                                                                        $propertyName
+                                                                    )
+                                                                ),
                                 ],
                                 'returnType' => ($isArray ? null : new Name('\\' . $classFqdn)),
                             ]),
                             new Stmt\ClassMethod('getResponse', [
                                 'type' => Stmt\Class_::MODIFIER_PUBLIC,
                                 'stmts' => [
-                                    new Stmt\Return_(
-                                        new Expr\PropertyFetch(
-                                            new Expr\Variable('this'),
-                                            'response'
-                                        )
-                                    ),
+                                                                new Stmt\Return_(
+                                                                    new Expr\PropertyFetch(
+                                                                        new Expr\Variable('this'),
+                                                                        'response'
+                                                                    )
+                                                                ),
                                 ],
                                 'returnType' => new Name('\\Psr\\Http\\Message\\ResponseInterface'),
                             ]),

--- a/src/Component/OpenApiCommon/Generator/ModelGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/ModelGenerator.php
@@ -26,8 +26,8 @@ class ModelGenerator extends BaseModelGenerator
     protected function doCreateModel(BaseClassGuess $class, array $properties, array $methods): Stmt\Class_
     {
         $extends = null;
-        if ($class instanceof ClassGuess &&
-            $class->getParentClass() instanceof ParentClass) {
+        if ($class instanceof ClassGuess
+            && $class->getParentClass() instanceof ParentClass) {
             $extends = $this->getNaming()->getClassName($class->getParentClass()->getName());
         }
 

--- a/src/Component/OpenApiCommon/Generator/OperationGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/OperationGenerator.php
@@ -29,7 +29,7 @@ class OperationGenerator
         }, $throwTypes))
             . " *\n"
             . ' * @return ' . implode('|', $returnTypes)
-            ;
+        ;
     }
 
     public function createOperation(string $name, OperationGuess $operation, Context $context): Stmt\ClassMethod

--- a/src/Component/OpenApiCommon/Generator/Parameter/ParameterGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/Parameter/ParameterGenerator.php
@@ -21,25 +21,17 @@ abstract class ParameterGenerator
         $this->parser = $parser;
     }
 
-    /**
-     * @param $parameter
-     */
     public function generateMethodParameter($parameter, Context $context, string $reference): ?Node\Param
     {
         return null;
     }
 
-    /**
-     * @param $parameter
-     */
     public function generateMethodDocParameter($parameter, Context $context, string $reference): string
     {
         return '';
     }
 
     /**
-     * @param $parameter
-     *
      * @return Node\Expr[]
      */
     protected function generateInputParamArguments($parameter): array

--- a/src/Component/OpenApiCommon/Generator/Traits/OptionResolverNormalizationTrait.php
+++ b/src/Component/OpenApiCommon/Generator/Traits/OptionResolverNormalizationTrait.php
@@ -20,8 +20,8 @@ trait OptionResolverNormalizationTrait
         if (\array_key_exists('__type', $customQueryResolver)) {
             $genericCustomQueryResolver = $customQueryResolver['__type'];
         }
-        if (\array_key_exists($operation->getPath(), $customQueryResolver) &&
-            \array_key_exists(mb_strtolower($operation->getMethod()), $customQueryResolver[$operation->getPath()])) {
+        if (\array_key_exists($operation->getPath(), $customQueryResolver)
+            && \array_key_exists(mb_strtolower($operation->getMethod()), $customQueryResolver[$operation->getPath()])) {
             $operationCustomQueryResolver = $customQueryResolver[$operation->getPath()][mb_strtolower($operation->getMethod())];
         }
 

--- a/src/Component/OpenApiCommon/Guesser/Guess/ClassGuess.php
+++ b/src/Component/OpenApiCommon/Guesser/Guess/ClassGuess.php
@@ -26,7 +26,7 @@ class ClassGuess extends BaseClassGuess
             return $this->getProperties();
         }
 
-        return array_filter( //return only those properties which not present in parent class
+        return array_filter( // return only those properties which not present in parent class
             $this->getProperties(),
             function (Property $property): bool {
                 return null === $this->parentClass->getProperty($property->getName());

--- a/src/Component/OpenApiCommon/Naming/OperationUrlNaming.php
+++ b/src/Component/OpenApiCommon/Naming/OperationUrlNaming.php
@@ -11,13 +11,12 @@ use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
 
 class OperationUrlNaming implements OperationNamingInterface
 {
-    const FORBIDDEN_EXTENSIONS = [
+    use InflectorTrait;
+    public const FORBIDDEN_EXTENSIONS = [
         '.json',
         '.php',
         '.asp',
     ];
-
-    use InflectorTrait;
 
     protected function getUniqueName(OperationGuess $operation): string
     {

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3.23"
+    }
+}


### PR DESCRIPTION
Hi, this PR moves the PHP CS Fixer requirement from the main composer.json file to a separate one, allowing to install latest version of PHP CS Fixer.

I added some new rules to keep tests working, so the changes are as small as possible :) 