### PR TITLE
Adjust type errors where `Schema|Reference` may occur in `NonBodyParameterGenerator`

### DIFF
--- a/src/OpenApiCommon/Guesser/GuessClass.php
+++ b/src/OpenApiCommon/Guesser/GuessClass.php
@@ -39,6 +39,13 @@ class GuessClass
         return $registry->getClass($reference);
     }
 
+    /**
+     * @template TDenormalized of object
+     *
+     * @param class-string<TDenormalized> $class
+     *
+     * @return array{string, TDenormalized}
+     */
     public function resolve(Reference $reference, string $class): array
     {
         $result = $reference;


### PR DESCRIPTION
This is a fix for #126 and #108 findings, more
specifically https://github.com/janephp/janephp/issues/108#issuecomment-1764856437

The codebase in `master` has multiple type-level errors that could be caught by using an aggressive type checker, but the project doesn't currently use one.

These changes mostly guarantee that `Schema|Reference|null|false` becomes a `Schema|null`, where relevant in the `NonBodyParameterGenerator`.