### PR TITLE
Adding boolean support for HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [OpenApiCommon] [GH#775](https://github.com/janephp/janephp/pull/775) Added support for boolean HTTP headers
+
 ## [7.5.5] - 2023-11-20
 ### Changed
 - [JsonSchema] [GH#698](https://github.com/janephp/janephp/pull/698) Consider nullable property for minLengthValidator
-- [OpenApiCommon] [GH#775](https://github.com/janephp/janephp/pull/775) Added support for boolean HTTP headers
 
 ### Fixed
 - [JsonSchema] [GH#758](https://github.com/janephp/janephp/pull/758) Fixed subproperty validator overwriting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.5.5] - 2023-11-20
 ### Changed
 - [JsonSchema] [GH#698](https://github.com/janephp/janephp/pull/698) Consider nullable property for minLengthValidator
+- [OpenApiCommon] [GH#775](https://github.com/janephp/janephp/pull/775) Added support for boolean HTTP headers
 
 ### Fixed
 - [JsonSchema] [GH#758](https://github.com/janephp/janephp/pull/758) Fixed subproperty validator overwriting

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/Client.php
@@ -54,7 +54,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/Client.php
@@ -54,7 +54,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/Client.php
@@ -68,7 +68,7 @@ abstract class Client
             }
         }
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
         if (count($endpoint->getAuthenticationScopes()) > 0) {
             $scopes = [];

--- a/src/Component/OpenApiCommon/Generator/Runtime/data/Client/Client.php
+++ b/src/Component/OpenApiCommon/Generator/Runtime/data/Client/Client.php
@@ -78,7 +78,7 @@ abstract class Client
         }
 
         foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
         }
 
         if (count($endpoint->getAuthenticationScopes()) > 0) {


### PR DESCRIPTION
There are issues when using boolean headers definition, eg like in the Harbor API. The PSR-7 implementations does not convert the boolean value to a string value, as [the PSR-7 explicitly ask to provide strings, numbers, `\Stringable` objects or specific formats of arrays](https://www.php-fig.org/psr/psr-7/meta/#what-about-special-header-values).

Example OpenAPI 2 definition from Harbor API v2:

```json
{
  "swagger": "2.0",
  "info": {
    "title": "Harbor API",
    "description": "These APIs provide services for manipulating Harbor project.",
    "version": "2.0"
  },
  "basePath": "/api/v2.0",
  "parameters": {
    "resourceNameInLocation": {
      "name": "X-Resource-Name-In-Location",
      "description": "The flag to indicate whether to return the name of the resource in Location. When X-Resource-Name-In-Location is true, the Location will return the name of the resource.",
      "in": "header",
      "type": "boolean",
      "required": false,
      "default": false
    },
    "isResourceName": {
      "name": "X-Is-Resource-Name",
      "description": "The flag to indicate whether the parameter which supports both name and id in the path is the name of the resource. When the X-Is-Resource-Name is false and the parameter can be converted to an integer, the parameter will be as an id, otherwise, it will be as a name.",
      "in": "header",
      "type": "boolean",
      "required": false,
      "default": false
    },
  },
}
```

Example: When using `nyholm/psr7` with a generated client, the following exception is raised: https://github.com/Nyholm/psr7/blob/master/src/MessageTrait.php#L213

Complete OpenAPI 2 for Harbor API v2 is provided here: [harbor.json](https://github.com/janephp/janephp/files/13663114/harbor.json)

Generated code is located here: https://github.com/php-etl/harbor-api-client