### PR TITLE
[NITPICK] Fix typo in swagger.json.

### DIFF
--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/swagger.json
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/swagger.json
@@ -7,7 +7,7 @@
                 "operationId": "Test No Tag",
                 "responses": {
                     "200": {
-                        "description": "Bad request on test exception",
+                        "description": "Bad request on test exception"
                     }
                 }
             }


### PR DESCRIPTION
Nitpick.

My editor complains about the erroneous comma in this JSON file. 