### PR TITLE
Do not implements `CacheableSupportsMethodInterface` when generating SF7 normalizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [JsonSchema] [GH#798](https://github.com/janephp/janephp/pull/798) Do not implements `CacheableSupportsMethodInterface` when generating SF7 normalizers
+
 ## [7.6.1] - 2024-03-12
 ### Changed
 - [Jane] [GH#792](https://github.com/janephp/janephp/pull/792) Improve Normalizer generation by including null values or not

--- a/src/Component/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/NormalizerGenerator.php
@@ -74,7 +74,7 @@ class NormalizerGenerator implements GeneratorInterface
         $this->naming = $naming;
         $this->parser = $parser;
         $this->useReference = $useReference;
-        $this->useCacheableSupportsMethod = $this->canUseCacheableSupportsMethod($useCacheableSupportsMethod);
+        $this->useCacheableSupportsMethod = $useCacheableSupportsMethod;
         $this->skipNullValues = $skipNullValues;
         $this->skipRequiedFields = $skipRequiedFields;
         $this->validation = $validation;
@@ -165,13 +165,6 @@ class NormalizerGenerator implements GeneratorInterface
         ));
     }
 
-    protected function canUseCacheableSupportsMethod(?bool $useCacheableSupportsMethod): bool
-    {
-        return
-            true === $useCacheableSupportsMethod
-            || (null === $useCacheableSupportsMethod && class_exists('Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface'));
-    }
-
     protected function createJaneObjectNormalizerClass(Schema $schema, array $normalizers): array
     {
         if ($this->useReference) {
@@ -197,14 +190,9 @@ class NormalizerGenerator implements GeneratorInterface
         $methods[] = $this->createBaseNormalizerInitNormalizerMethod();
         $methods[] = $this->createProxyGetSupportedTypesMethod(array_keys($normalizers));
 
-        if ($this->useCacheableSupportsMethod) {
-            $methods[] = $this->createHasCacheableSupportsMethod();
-        }
-
         $symfony7NormalizerClass = $this->createNormalizerClass(
             'JaneObjectNormalizer',
-            $methods,
-            $this->useCacheableSupportsMethod
+            $methods
         );
 
         $methods = [];

--- a/src/Component/JsonSchema/Tests/Validation/ValidationTest.php
+++ b/src/Component/JsonSchema/Tests/Validation/ValidationTest.php
@@ -631,7 +631,7 @@ class ValidationTest extends TestCase
                 'stringProperty4' => 'toto',
                 'stringProperty5' => 'tototo',
                 'stringProperty6' => 'totototo',
-                ], ObjectObject::class);
+            ], ObjectObject::class);
         } catch (ValidationException $exception) {
             $caughtException = $exception;
         }

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/JaneObjectNormalizer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-    class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
+    class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
         use DenormalizerAwareTrait;
         use NormalizerAwareTrait;
@@ -55,10 +55,6 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
         public function getSupportedTypes(?string $format = null) : array
         {
             return ['Jane\\Component\\OpenApi2\\Tests\\Expected\\Model\\Schema' => false, 'Jane\\Component\\OpenApi2\\Tests\\Expected\\Model\\SchemaObjectProperty' => false, '\\Jane\\Component\\JsonSchemaRuntime\\Reference' => false];
-        }
-        public function hasCacheableSupportsMethod() : bool
-        {
-            return true;
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/JaneObjectNormalizer.php
@@ -13,7 +13,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-    class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
+    class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
         use DenormalizerAwareTrait;
         use NormalizerAwareTrait;
@@ -55,10 +55,6 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
         public function getSupportedTypes(?string $format = null) : array
         {
             return ['Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Schema' => false, 'Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\SchemaObjectProperty' => false, '\\Jane\\Component\\JsonSchemaRuntime\\Reference' => false];
-        }
-        public function hasCacheableSupportsMethod() : bool
-        {
-            return true;
         }
     }
 } else {

--- a/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
@@ -121,50 +121,50 @@ EOD
 EOD
                             )]]),
                             new Stmt\ClassMethod('__construct', [
-                                                            'type' => Stmt\Class_::MODIFIER_PUBLIC,
-                                                            'params' => [
-                                                                new Param(new Expr\Variable($realPropertyName), null, $isArray ? null : new Name('\\' . $classFqdn)),
-                                                                new Param(new Expr\Variable('response'), null, new Name('\\Psr\\Http\\Message\\ResponseInterface')),
-                                                            ],
-                                                            'stmts' => [
-                                                                new Stmt\Expression(new Expr\StaticCall(new Name('parent'), '__construct', [
-                                                                    new Scalar\String_($description),
-                                                                ])),
-                                                                new Stmt\Expression(new Expr\Assign(
-                                                                    new Expr\PropertyFetch(
-                                                                        new Expr\Variable('this'),
-                                                                        $propertyName
-                                                                    ), new Expr\Variable($realPropertyName)
-                                                                )),
-                                                                new Stmt\Expression(new Expr\Assign(
-                                                                    new Expr\PropertyFetch(
-                                                                        new Expr\Variable('this'),
-                                                                        'response'
-                                                                    ), new Expr\Variable('response')
-                                                                )),
-                                                            ],
-                                                        ]),
+                                'type' => Stmt\Class_::MODIFIER_PUBLIC,
+                                'params' => [
+                                    new Param(new Expr\Variable($realPropertyName), null, $isArray ? null : new Name('\\' . $classFqdn)),
+                                    new Param(new Expr\Variable('response'), null, new Name('\\Psr\\Http\\Message\\ResponseInterface')),
+                                ],
+                                'stmts' => [
+                                    new Stmt\Expression(new Expr\StaticCall(new Name('parent'), '__construct', [
+                                        new Scalar\String_($description),
+                                    ])),
+                                    new Stmt\Expression(new Expr\Assign(
+                                        new Expr\PropertyFetch(
+                                            new Expr\Variable('this'),
+                                            $propertyName
+                                        ), new Expr\Variable($realPropertyName)
+                                    )),
+                                    new Stmt\Expression(new Expr\Assign(
+                                        new Expr\PropertyFetch(
+                                            new Expr\Variable('this'),
+                                            'response'
+                                        ), new Expr\Variable('response')
+                                    )),
+                                ],
+                            ]),
                             new Stmt\ClassMethod($methodName, [
                                 'type' => Stmt\Class_::MODIFIER_PUBLIC,
                                 'stmts' => [
-                                                                new Stmt\Return_(
-                                                                    new Expr\PropertyFetch(
-                                                                        new Expr\Variable('this'),
-                                                                        $propertyName
-                                                                    )
-                                                                ),
+                                    new Stmt\Return_(
+                                        new Expr\PropertyFetch(
+                                            new Expr\Variable('this'),
+                                            $propertyName
+                                        )
+                                    ),
                                 ],
                                 'returnType' => ($isArray ? null : new Name('\\' . $classFqdn)),
                             ]),
                             new Stmt\ClassMethod('getResponse', [
                                 'type' => Stmt\Class_::MODIFIER_PUBLIC,
                                 'stmts' => [
-                                                                new Stmt\Return_(
-                                                                    new Expr\PropertyFetch(
-                                                                        new Expr\Variable('this'),
-                                                                        'response'
-                                                                    )
-                                                                ),
+                                    new Stmt\Return_(
+                                        new Expr\PropertyFetch(
+                                            new Expr\Variable('this'),
+                                            'response'
+                                        )
+                                    ),
                                 ],
                                 'returnType' => new Name('\\Psr\\Http\\Message\\ResponseInterface'),
                             ]),


### PR DESCRIPTION
Fixes #797 