### PR TITLE
Do not implement CacheableSupportsMethodInterface when generating SF7 normalizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- [JsonSchema] [GH#799](https://github.com/janephp/janephp/pull/799) Do not implement `CacheableSupportsMethodInterface` when generating SF7 normalizers for schema and schema object properties
 - [JsonSchema] [GH#798](https://github.com/janephp/janephp/pull/798) Do not implements `CacheableSupportsMethodInterface` when generating SF7 normalizers
 
 ## [7.6.1] - 2024-03-12

--- a/src/Component/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/NormalizerGenerator.php
@@ -106,14 +106,9 @@ class NormalizerGenerator implements GeneratorInterface
             $methods[] = $this->createNormalizeMethod($modelFqdn, $context, $class, true, $this->skipNullValues, $this->skipRequiedFields, $this->includeNullValue);
             $methods[] = $this->createGetSupportedTypesMethod($modelFqdn, $this->useCacheableSupportsMethod);
 
-            if ($this->useCacheableSupportsMethod) {
-                $methods[] = $this->createHasCacheableSupportsMethod();
-            }
-
             $symfony7NormalizerClass = $this->createNormalizerClass(
                 $class->getName() . 'Normalizer',
-                $methods,
-                $this->useCacheableSupportsMethod
+                $methods
             );
 
             $methods = [];

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
@@ -15,7 +15,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-    class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
+    class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
         use DenormalizerAwareTrait;
         use NormalizerAwareTrait;
@@ -118,10 +118,6 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
         public function getSupportedTypes(?string $format = null) : array
         {
             return ['Jane\\Component\\OpenApi2\\Tests\\Expected\\Model\\Schema' => true];
-        }
-        public function hasCacheableSupportsMethod() : bool
-        {
-            return true;
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -15,7 +15,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-    class SchemaObjectPropertyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
+    class SchemaObjectPropertyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
         use DenormalizerAwareTrait;
         use NormalizerAwareTrait;
@@ -57,10 +57,6 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
         public function getSupportedTypes(?string $format = null) : array
         {
             return ['Jane\\Component\\OpenApi2\\Tests\\Expected\\Model\\SchemaObjectProperty' => true];
-        }
-        public function hasCacheableSupportsMethod() : bool
-        {
-            return true;
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
@@ -15,7 +15,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-    class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
+    class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
         use DenormalizerAwareTrait;
         use NormalizerAwareTrait;
@@ -136,10 +136,6 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
         public function getSupportedTypes(?string $format = null) : array
         {
             return ['Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\Schema' => true];
-        }
-        public function hasCacheableSupportsMethod() : bool
-        {
-            return true;
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -15,7 +15,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
-    class SchemaObjectPropertyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface, CacheableSupportsMethodInterface
+    class SchemaObjectPropertyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
         use DenormalizerAwareTrait;
         use NormalizerAwareTrait;
@@ -68,10 +68,6 @@ if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR
         public function getSupportedTypes(?string $format = null) : array
         {
             return ['Jane\\Component\\OpenApi3\\Tests\\Expected\\Model\\SchemaObjectProperty' => true];
-        }
-        public function hasCacheableSupportsMethod() : bool
-        {
-            return true;
         }
     }
 } else {


### PR DESCRIPTION
Fix for https://github.com/janephp/janephp/issues/797 issue (dont implement CacheableSupportsMethodInterface when generating SF7 normalizers).

Proposed solution:
Original solution by @Korbeil (https://github.com/janephp/janephp/pull/798/files) applied also to "generate" method in NormalizerGenerator