### PR TITLE
Allow invalid php variables name in parameters

### DIFF
--- a/src/Component/OpenApi3/Generator/Endpoint/GetConstructorTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetConstructorTrait.php
@@ -50,9 +50,9 @@ trait GetConstructorTrait
             if ($parameter instanceof Parameter && EndpointGenerator::IN_PATH === $parameter->getIn()) {
                 $pathParams[] = $nonBodyParameterGenerator->generateMethodParameter($parameter, $context, $operation->getReference() . '/parameters/' . $key);
                 $pathParamsDoc[] = $nonBodyParameterGenerator->generateMethodDocParameter($parameter, $context, $operation->getReference() . '/parameters/' . $key);
-                $methodStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\PropertyFetch(new Expr\Variable('this'), $parameter->getName()), new Expr\Variable($this->getInflector()->camelize($parameter->getName()))));
+                $methodStatements[] = new Stmt\Expression(new Expr\Assign(new Expr\PropertyFetch(new Expr\Variable('this'), $this->getInflector()->camelize($parameter->getName())), new Expr\Variable($this->getInflector()->camelize($parameter->getName()))));
                 $pathProperties[] = new Stmt\Property(Stmt\Class_::MODIFIER_PROTECTED, [
-                    new Stmt\PropertyProperty($parameter->getName()),
+                    new Stmt\PropertyProperty($this->getInflector()->camelize($parameter->getName())),
                 ]);
             }
 

--- a/src/Component/OpenApi3/Generator/Endpoint/GetGetUriTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetGetUriTrait.php
@@ -26,7 +26,7 @@ trait GetGetUriTrait
 
             if ($parameter instanceof Parameter && EndpointGenerator::IN_PATH === $parameter->getIn()) {
                 // $url = str_replace('{param}', $param, $url)
-                $names[] = $parameter->getName();
+                $names[] = [$parameter->getName(), $this->getInflector()->camelize($parameter->getName())];
             }
         }
 
@@ -44,11 +44,11 @@ trait GetGetUriTrait
             'type' => Stmt\Class_::MODIFIER_PUBLIC,
             'stmts' => [
                 new Stmt\Return_(new Expr\FuncCall(new Name('str_replace'), [
-                    new Arg(new Expr\Array_(array_map(function ($name) {
-                        return new Scalar\String_('{' . $name . '}');
+                    new Arg(new Expr\Array_(array_map(function ($args) {
+                        return new Scalar\String_('{' . $args[0] . '}');
                     }, $names))),
-                    new Arg(new Expr\Array_(array_map(function ($name) {
-                        return new Expr\PropertyFetch(new Expr\Variable('this'), $name);
+                    new Arg(new Expr\Array_(array_map(function ($args) {
+                        return new Expr\PropertyFetch(new Expr\Variable('this'), $args[1]);
                     }, $names))),
                     new Arg(new Scalar\String_($operation->getPath())),
                 ])),

--- a/src/Component/OpenApiCommon/Naming/OperationUrlNaming.php
+++ b/src/Component/OpenApiCommon/Naming/OperationUrlNaming.php
@@ -40,7 +40,7 @@ class OperationUrlNaming implements OperationNamingInterface
         }
 
         $matches = [];
-        preg_match_all('/(?<separator>[^a-zA-Z0-9_{}])+(?<part>[a-zA-Z0-9_{}]*)/', $operation->getPath(), $matches);
+        preg_match_all('/(?<separator>[\/])+(?<part>[^\/]*)/', $operation->getPath(), $matches);
 
         $methodNameParts = [];
         $lastNonParameterPartIndex = 0;
@@ -55,7 +55,7 @@ class OperationUrlNaming implements OperationNamingInterface
             if (preg_match_all('/{(?P<parameter>[^{}]+)}/', $part, $parameterMatches)) {
                 foreach ($parameterMatches[0] as $parameterIndex => $parameterMatch) {
                     $withoutSnakes = preg_replace_callback(
-                        '/(^|_|\.)+(.)/',
+                        '/(^|_|\.|-)+(.)/',
                         function ($match) {
                             return ('.' === $match[1] ? '_' : '') . strtoupper($match[2]);
                         },


### PR DESCRIPTION
Hi Jane team,

I used client generation with Jane for an OAS with hyphens in the parameter names (Keycloak). I fixed the issue by making some changes to the build shown in this draft.

- https://www.keycloak.org/docs-api/latest/rest-api/index.html
- https://www.keycloak.org/docs-api/latest/rest-api/openapi.yaml

Before submitting a complete PR, I’d like your feedback on the following:

- I noticed that there are tests validating the need for variables starting with capital letters or containing underscores. Would it be feasible to standardize all variable names to camelCase moving forward ?
- Converting parameter names to camelCase in the generated code could theoretically lead to naming conflicts, although it seems unlikely to result in an ambiguous OpenAPI Specification. Should the proposed changes account for this potential issue?

Looking forward to your guidance

Best regards,