### PR TITLE
PHP 8.4 & Symfony 7.2.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [PHP] [GH#842](https://github.com/janephp/janephp/pull/842) Fix generated files to be compatible with PHP 8.4
 
 ## [7.8.1] - 2024-07-29
 ### Fixed

--- a/src/Component/JsonSchema/Generator/Runtime/data/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Generator/Runtime/data/Normalizer/ReferenceNormalizer.php
@@ -20,10 +20,18 @@ if (Kernel::MAJOR_VERSION >= 7 || (Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_
 
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+
+        public function getSupportedTypes(?string $format) : array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/additional-properties/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/additional-properties/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/array-object-nullable/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/array-object-nullable/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/date-format/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/date-format/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/date/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/date/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/datetime-format/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/datetime-format/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/datetime-interface/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/datetime-interface/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/datetime-no-format/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/datetime-no-format/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/datetime/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/datetime/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/deep-object/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/deep-object/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/definitions/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/definitions/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/deprecated/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/deprecated/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/disabled-strict-required/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/dollarDefs/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/dollarDefs/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/multi-files/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-files/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema2/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema2/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/name-conflict/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/name-conflict/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/one-of-nullable/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/one-of-nullable/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/one-of/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/one-of/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/read-only/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/read-only/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/reserved-words/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/reserved-words/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/test-default/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/test-default/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/test-no-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/test-no-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/test-not-strict/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/test-not-strict/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/test-null/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/test-null/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/JsonSchema/Tests/fixtures/validator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/validator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Generator/EndpointGenerator.php
+++ b/src/Component/OpenApi2/Generator/EndpointGenerator.php
@@ -59,7 +59,7 @@ class EndpointGenerator implements EndpointGeneratorInterface
         Parameter\BodyParameterGenerator $bodyParameterGenerator,
         Parameter\NonBodyParameterGenerator $nonBodyParameterGenerator,
         DenormalizerInterface $denormalizer,
-        ExceptionGenerator $exceptionGenerator
+        ExceptionGenerator $exceptionGenerator,
     ) {
         $this->operationNaming = $operationNaming;
         $this->bodyParameterGenerator = $bodyParameterGenerator;

--- a/src/Component/OpenApi2/Tests/client/generated/Authentication/ApiKeyAuthAuthentication.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Authentication/ApiKeyAuthAuthentication.php
@@ -9,12 +9,12 @@ class ApiKeyAuthAuthentication implements \Jane\Component\OpenApiRuntime\Client\
     {
         $this->{'apiKey'} = $apiKey;
     }
-    public function authentication(\Psr\Http\Message\RequestInterface $request) : \Psr\Http\Message\RequestInterface
+    public function authentication(\Psr\Http\Message\RequestInterface $request): \Psr\Http\Message\RequestInterface
     {
         $request = $request->withHeader('X-API-Key', $this->{'apiKey'});
         return $request;
     }
-    public function getScope() : string
+    public function getScope(): string
     {
         return 'ApiKeyAuth';
     }

--- a/src/Component/OpenApi2/Tests/client/generated/Client.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Client.php
@@ -14,12 +14,12 @@ class Client extends \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Client\Endpoint\GetEndpoint(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = [];
-            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUrlFactory()->createUri('http://127.0.0.1:4011/');
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('http://127.0.0.1:4011/');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
@@ -29,10 +29,11 @@ class Client extends \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\Client
         }
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
-        $serializer = new \Symfony\Component\Serializer\Serializer(
-            [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi2\Tests\Client\Normalizer\JaneObjectNormalizer()], 
-            [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]
-        );
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi2\Tests\Client\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Endpoint/GetEndpoint.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Endpoint/GetEndpoint.php
@@ -5,19 +5,19 @@ namespace Jane\Component\OpenApi2\Tests\Client\Endpoint;
 class GetEndpoint extends \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\Endpoint
 {
     use \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\EndpointTrait;
-    public function getMethod() : string
+    public function getMethod(): string
     {
         return 'GET';
     }
-    public function getUri() : string
+    public function getUri(): string
     {
         return '/endpoint';
     }
-    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         return [[], null];
     }
-    public function getExtraHeaders() : array
+    public function getExtraHeaders(): array
     {
         return ['Accept' => ['application/json']];
     }
@@ -28,16 +28,18 @@ class GetEndpoint extends \Jane\Component\OpenApi2\Tests\Client\Runtime\Client\B
      *
      * @return null|\Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse
      */
-    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
         if (200 === $status) {
-            return $serializer->deserialize($body, 'Jane\\Component\\OpenApi2\\Tests\\Client\\Model\\SimpleResponse', 'json');
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse', 'json');
         }
         if (401 === $status) {
-            throw new \Jane\Component\OpenApi2\Tests\Client\Exception\GetEndpointUnauthorizedException($serializer->deserialize($body, 'Jane\\Component\\OpenApi2\\Tests\\Client\\Model\\Error', 'json'));
+            throw new \Jane\Component\OpenApi2\Tests\Client\Exception\GetEndpointUnauthorizedException($serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Client\Model\Error', 'json'), $response);
         }
     }
-    public function getAuthenticationScopes() : array
+    public function getAuthenticationScopes(): array
     {
         return ['ApiKeyAuth'];
     }

--- a/src/Component/OpenApi2/Tests/client/generated/Exception/GetEndpointUnauthorizedException.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Exception/GetEndpointUnauthorizedException.php
@@ -4,14 +4,26 @@ namespace Jane\Component\OpenApi2\Tests\Client\Exception;
 
 class GetEndpointUnauthorizedException extends UnauthorizedException
 {
+    /**
+     * @var \Jane\Component\OpenApi2\Tests\Client\Model\Error
+     */
     private $error;
-    public function __construct(\Jane\Component\OpenApi2\Tests\Client\Model\Error $error)
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi2\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
     {
-        parent::__construct('Unauthaurized response', 401);
+        parent::__construct('Unauthaurized response');
         $this->error = $error;
+        $this->response = $response;
     }
-    public function getError()
+    public function getError(): \Jane\Component\OpenApi2\Tests\Client\Model\Error
     {
         return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Model/Error.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Model/Error.php
@@ -5,6 +5,14 @@ namespace Jane\Component\OpenApi2\Tests\Client\Model;
 class Error
 {
     /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
      * 
      *
      * @var string
@@ -15,7 +23,7 @@ class Error
      *
      * @return string
      */
-    public function getMessage() : string
+    public function getMessage(): string
     {
         return $this->message;
     }
@@ -26,8 +34,9 @@ class Error
      *
      * @return self
      */
-    public function setMessage(string $message) : self
+    public function setMessage(string $message): self
     {
+        $this->initialized['message'] = true;
         $this->message = $message;
         return $this;
     }

--- a/src/Component/OpenApi2/Tests/client/generated/Model/SimpleResponse.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Model/SimpleResponse.php
@@ -5,6 +5,14 @@ namespace Jane\Component\OpenApi2\Tests\Client\Model;
 class SimpleResponse
 {
     /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
      * 
      *
      * @var string
@@ -21,7 +29,7 @@ class SimpleResponse
      *
      * @return string
      */
-    public function getFoo() : string
+    public function getFoo(): string
     {
         return $this->foo;
     }
@@ -32,8 +40,9 @@ class SimpleResponse
      *
      * @return self
      */
-    public function setFoo(string $foo) : self
+    public function setFoo(string $foo): self
     {
+        $this->initialized['foo'] = true;
         $this->foo = $foo;
         return $this;
     }
@@ -42,7 +51,7 @@ class SimpleResponse
      *
      * @return bool
      */
-    public function getBaz() : bool
+    public function getBaz(): bool
     {
         return $this->baz;
     }
@@ -53,8 +62,9 @@ class SimpleResponse
      *
      * @return self
      */
-    public function setBaz(bool $baz) : self
+    public function setBaz(bool $baz): self
     {
+        $this->initialized['baz'] = true;
         $this->baz = $baz;
         return $this;
     }

--- a/src/Component/OpenApi2/Tests/client/generated/Normalizer/ErrorNormalizer.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Normalizer/ErrorNormalizer.php
@@ -4,6 +4,7 @@ namespace Jane\Component\OpenApi2\Tests\Client\Normalizer;
 
 use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\ValidatorTrait;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
@@ -11,42 +12,101 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
-{
-    use DenormalizerAwareTrait;
-    use NormalizerAwareTrait;
-    use CheckArray;
-    public function supportsDenormalization($data, $type, $format = null)
+use Symfony\Component\HttpKernel\Kernel;
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        return $type === 'Jane\\Component\\OpenApi2\\Tests\\Client\\Model\\Error';
-    }
-    public function supportsNormalization($data, $format = null, $context = []) : bool
-    {
-        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi2\\Tests\\Client\\Model\\Error';
-    }
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []) : mixed
-    {
-        if (isset($data['$ref'])) {
-            return new Reference($data['$ref'], $context['document-origin']);
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi2\Tests\Client\Model\Error::class;
         }
-        if (isset($data['$recursiveRef'])) {
-            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Client\Model\Error::class;
         }
-        $object = new \Jane\Component\OpenApi2\Tests\Client\Model\Error();
-        if (null === $data || false === \is_array($data)) {
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi2\Tests\Client\Model\Error();
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('message', $data)) {
+                $object->setMessage($data['message']);
+            }
             return $object;
         }
-        if (\array_key_exists('message', $data)) {
-            $object->setMessage($data['message']);
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $data = [];
+            if ($object->isInitialized('message') && null !== $object->getMessage()) {
+                $data['message'] = $object->getMessage();
+            }
+            return $data;
         }
-        return $object;
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi2\Tests\Client\Model\Error::class => false];
+        }
     }
-    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+} else {
+    class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        $data = [];
-        if (null !== $object->getMessage()) {
-            $data['message'] = $object->getMessage();
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization($data, $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi2\Tests\Client\Model\Error::class;
         }
-        return $data;
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Client\Model\Error::class;
+        }
+        /**
+         * @return mixed
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi2\Tests\Client\Model\Error();
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('message', $data)) {
+                $object->setMessage($data['message']);
+            }
+            return $object;
+        }
+        /**
+         * @return array|string|int|float|bool|\ArrayObject|null
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $data = [];
+            if ($object->isInitialized('message') && null !== $object->getMessage()) {
+                $data['message'] = $object->getMessage();
+            }
+            return $data;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi2\Tests\Client\Model\Error::class => false];
+        }
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Normalizer/JaneObjectNormalizer.php
@@ -3,48 +3,132 @@
 namespace Jane\Component\OpenApi2\Tests\Client\Normalizer;
 
 use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\ValidatorTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
-{
-    use DenormalizerAwareTrait;
-    use NormalizerAwareTrait;
-    use CheckArray;
-    protected $normalizers = ['Jane\\Component\\OpenApi2\\Tests\\Client\\Model\\SimpleResponse' => 'Jane\\Component\\OpenApi2\\Tests\\Client\\Normalizer\\SimpleResponseNormalizer', 'Jane\\Component\\OpenApi2\\Tests\\Client\\Model\\Error' => 'Jane\\Component\\OpenApi2\\Tests\\Client\\Normalizer\\ErrorNormalizer', \Jane\Component\JsonSchemaRuntime\Reference::class => '\\Jane\\Component\\OpenApi2\\Tests\\Client\\Runtime\\Normalizer\\ReferenceNormalizer'], $normalizersCache = [];
-    public function supportsDenormalization($data, $type, $format = null)
+use Symfony\Component\HttpKernel\Kernel;
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        return array_key_exists($type, $this->normalizers);
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        protected $normalizers = [
+            
+            \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class => \Jane\Component\OpenApi2\Tests\Client\Normalizer\SimpleResponseNormalizer::class,
+            
+            \Jane\Component\OpenApi2\Tests\Client\Model\Error::class => \Jane\Component\OpenApi2\Tests\Client\Normalizer\ErrorNormalizer::class,
+            
+            \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\ReferenceNormalizer::class,
+        ], $normalizersCache = [];
+        public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
+        {
+            return array_key_exists($type, $this->normalizers);
+        }
+        public function supportsNormalization($data, $format = null, array $context = []): bool
+        {
+            return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+        }
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $normalizerClass = $this->normalizers[get_class($object)];
+            $normalizer = $this->getNormalizer($normalizerClass);
+            return $normalizer->normalize($object, $format, $context);
+        }
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+        {
+            $denormalizerClass = $this->normalizers[$type];
+            $denormalizer = $this->getNormalizer($denormalizerClass);
+            return $denormalizer->denormalize($data, $type, $format, $context);
+        }
+        private function getNormalizer(string $normalizerClass)
+        {
+            return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+        }
+        private function initNormalizer(string $normalizerClass)
+        {
+            $normalizer = new $normalizerClass();
+            $normalizer->setNormalizer($this->normalizer);
+            $normalizer->setDenormalizer($this->denormalizer);
+            $this->normalizersCache[$normalizerClass] = $normalizer;
+            return $normalizer;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [
+                
+                \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class => false,
+                \Jane\Component\OpenApi2\Tests\Client\Model\Error::class => false,
+                \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+            ];
+        }
     }
-    public function supportsNormalization($data, $format = null, $context = []) : bool
+} else {
+    class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
-    }
-    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
-    {
-        $normalizerClass = $this->normalizers[get_class($object)];
-        $normalizer = $this->getNormalizer($normalizerClass);
-        return $normalizer->normalize($object, $format, $context);
-    }
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []) : mixed
-    {
-        $denormalizerClass = $this->normalizers[$type];
-        $denormalizer = $this->getNormalizer($denormalizerClass);
-        return $denormalizer->denormalize($data, $type, $format, $context);
-    }
-    private function getNormalizer(string $normalizerClass)
-    {
-        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
-    }
-    private function initNormalizer(string $normalizerClass)
-    {
-        $normalizer = new $normalizerClass();
-        $normalizer->setNormalizer($this->normalizer);
-        $normalizer->setDenormalizer($this->denormalizer);
-        $this->normalizersCache[$normalizerClass] = $normalizer;
-        return $normalizer;
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        protected $normalizers = [
+            
+            \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class => \Jane\Component\OpenApi2\Tests\Client\Normalizer\SimpleResponseNormalizer::class,
+            
+            \Jane\Component\OpenApi2\Tests\Client\Model\Error::class => \Jane\Component\OpenApi2\Tests\Client\Normalizer\ErrorNormalizer::class,
+            
+            \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\ReferenceNormalizer::class,
+        ], $normalizersCache = [];
+        public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
+        {
+            return array_key_exists($type, $this->normalizers);
+        }
+        public function supportsNormalization($data, $format = null, array $context = []): bool
+        {
+            return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+        }
+        /**
+         * @return array|string|int|float|bool|\ArrayObject|null
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $normalizerClass = $this->normalizers[get_class($object)];
+            $normalizer = $this->getNormalizer($normalizerClass);
+            return $normalizer->normalize($object, $format, $context);
+        }
+        /**
+         * @return mixed
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            $denormalizerClass = $this->normalizers[$type];
+            $denormalizer = $this->getNormalizer($denormalizerClass);
+            return $denormalizer->denormalize($data, $type, $format, $context);
+        }
+        private function getNormalizer(string $normalizerClass)
+        {
+            return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+        }
+        private function initNormalizer(string $normalizerClass)
+        {
+            $normalizer = new $normalizerClass();
+            $normalizer->setNormalizer($this->normalizer);
+            $normalizer->setDenormalizer($this->denormalizer);
+            $this->normalizersCache[$normalizerClass] = $normalizer;
+            return $normalizer;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [
+                
+                \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class => false,
+                \Jane\Component\OpenApi2\Tests\Client\Model\Error::class => false,
+                \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+            ];
+        }
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Normalizer/SimpleResponseNormalizer.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Normalizer/SimpleResponseNormalizer.php
@@ -4,6 +4,7 @@ namespace Jane\Component\OpenApi2\Tests\Client\Normalizer;
 
 use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer\ValidatorTrait;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
@@ -11,48 +12,113 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class SimpleResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
-{
-    use DenormalizerAwareTrait;
-    use NormalizerAwareTrait;
-    use CheckArray;
-    public function supportsDenormalization($data, $type, $format = null)
+use Symfony\Component\HttpKernel\Kernel;
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class SimpleResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        return $type === 'Jane\\Component\\OpenApi2\\Tests\\Client\\Model\\SimpleResponse';
-    }
-    public function supportsNormalization($data, $format = null, $context = []) : bool
-    {
-        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi2\\Tests\\Client\\Model\\SimpleResponse';
-    }
-    public function denormalize($data, $type, $format = null, array $context = [])
-    {
-        if (isset($data['$ref'])) {
-            return new Reference($data['$ref'], $context['document-origin']);
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class;
         }
-        if (isset($data['$recursiveRef'])) {
-            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class;
         }
-        $object = new \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse();
-        if (null === $data || false === \is_array($data)) {
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse();
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('foo', $data)) {
+                $object->setFoo($data['foo']);
+            }
+            if (\array_key_exists('baz', $data)) {
+                $object->setBaz($data['baz']);
+            }
             return $object;
         }
-        if (\array_key_exists('foo', $data)) {
-            $object->setFoo($data['foo']);
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $data = [];
+            if ($object->isInitialized('foo') && null !== $object->getFoo()) {
+                $data['foo'] = $object->getFoo();
+            }
+            if ($object->isInitialized('baz') && null !== $object->getBaz()) {
+                $data['baz'] = $object->getBaz();
+            }
+            return $data;
         }
-        if (\array_key_exists('baz', $data)) {
-            $object->setBaz($data['baz']);
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class => false];
         }
-        return $object;
     }
-    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+} else {
+    class SimpleResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        $data = [];
-        if (null !== $object->getFoo()) {
-            $data['foo'] = $object->getFoo();
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization($data, $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class;
         }
-        if (null !== $object->getBaz()) {
-            $data['baz'] = $object->getBaz();
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class;
         }
-        return $data;
+        /**
+         * @return mixed
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse();
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('foo', $data)) {
+                $object->setFoo($data['foo']);
+            }
+            if (\array_key_exists('baz', $data)) {
+                $object->setBaz($data['baz']);
+            }
+            return $object;
+        }
+        /**
+         * @return array|string|int|float|bool|\ArrayObject|null
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $data = [];
+            if ($object->isInitialized('foo') && null !== $object->getFoo()) {
+                $data['foo'] = $object->getFoo();
+            }
+            if ($object->isInitialized('baz') && null !== $object->getBaz()) {
+                $data['baz'] = $object->getBaz();
+            }
+            return $data;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi2\Tests\Client\Model\SimpleResponse::class => false];
+        }
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/BaseEndpoint.php
@@ -3,23 +3,25 @@
 namespace Jane\Component\OpenApi2\Tests\Client\Runtime\Client;
 
 use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Serializer\SerializerInterface;
 abstract class BaseEndpoint implements Endpoint
 {
+    protected $formParameters = [];
     protected $queryParameters = [];
     protected $headerParameters = [];
     protected $body;
-    public abstract function getMethod() : string;
-    public abstract function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
-    public abstract function getUri() : string;
-    public abstract function getAuthenticationScopes() : array;
-    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
-    protected function getExtraHeaders() : array
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
     {
         return [];
     }
-    public function getQueryString() : string
+    public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
         $optionsResolved = array_map(function ($value) {
@@ -27,25 +29,25 @@ abstract class BaseEndpoint implements Endpoint
         }, $optionsResolved);
         return http_build_query($optionsResolved, '', '&', PHP_QUERY_RFC3986);
     }
-    public function getHeaders(array $baseHeaders = []) : array
+    public function getHeaders(array $baseHeaders = []): array
     {
         return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
     }
-    protected function getQueryOptionsResolver() : OptionsResolver
+    protected function getQueryOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
     }
-    protected function getHeadersOptionsResolver() : OptionsResolver
+    protected function getHeadersOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
     }
     // ----------------------------------------------------------------------------------------------------
     // Used for OpenApi2 compatibility
-    protected function getFormBody() : array
+    protected function getFormBody(): array
     {
         return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
     }
-    protected function getMultipartBody($streamFactory = null) : array
+    protected function getMultipartBody($streamFactory = null): array
     {
         $bodyBuilder = new MultipartStreamBuilder($streamFactory);
         $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
@@ -54,11 +56,11 @@ abstract class BaseEndpoint implements Endpoint
         }
         return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
     }
-    protected function getFormOptionsResolver() : OptionsResolver
+    protected function getFormOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
     }
-    protected function getSerializedBody(SerializerInterface $serializer) : array
+    protected function getSerializedBody(SerializerInterface $serializer): array
     {
         return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
     }

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Tests\Client\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -47,7 +60,8 @@ abstract class Client
                 $request = $request->withBody($body);
             } elseif (is_resource($body)) {
                 $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
-            } elseif (is_file($body)) {
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
                 $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
             } else {
                 $request = $request->withBody($this->streamFactory->createStream($body));
@@ -63,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/Endpoint.php
@@ -12,27 +12,27 @@ interface Endpoint
      * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
      * And the second value consist of the body object.
      */
-    public function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
     /**
      * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
      */
-    public function getQueryString() : string;
+    public function getQueryString(): string;
     /**
      * Get the URI of an endpoint (like /foo-uri).
      */
-    public function getUri() : string;
+    public function getUri(): string;
     /**
      * Get the HTTP method of an endpoint (like GET, POST, ...).
      */
-    public function getMethod() : string;
+    public function getMethod(): string;
     /**
      * Get the headers of an endpoint.
      */
-    public function getHeaders(array $baseHeaders = []) : array;
+    public function getHeaders(array $baseHeaders = []): array;
     /**
      * Get security scopes of an endpoint.
      */
-    public function getAuthenticationScopes() : array;
+    public function getAuthenticationScopes(): array;
     /**
      * Parse and transform a PSR7 Response into a different object.
      *

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Client/EndpointTrait.php
@@ -2,21 +2,14 @@
 
 namespace Jane\Component\OpenApi2\Tests\Client\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
 {
-    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Normalizer/CheckArray.php
@@ -4,7 +4,7 @@ namespace Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer;
 
 trait CheckArray
 {
-    public function isOnlyNumericKeys(array $array) : bool
+    public function isOnlyNumericKeys(array $array): bool
     {
         return count(array_filter($array, function ($key) {
             return is_numeric($key);

--- a/src/Component/OpenApi2/Tests/client/generated/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/client/generated/Runtime/Normalizer/ReferenceNormalizer.php
@@ -3,23 +3,53 @@
 namespace Jane\Component\OpenApi2\Tests\Client\Runtime\Normalizer;
 
 use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ReferenceNormalizer implements NormalizerInterface
-{
-    /**
-     * {@inheritdoc}
-     */
-    public function normalize(mixed $object, string $format = null, array $context = []) : array|string|int|float|bool|\ArrayObject|null
+if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_VERSION === 4) {
+    class ReferenceNormalizer implements NormalizerInterface
     {
-        $ref = [];
-        $ref['$ref'] = (string) $object->getReferenceUri();
-        return $ref;
+        /**
+         * {@inheritdoc}
+         */
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $ref = [];
+            $ref['$ref'] = (string) $object->getReferenceUri();
+            return $ref;
+        }
+        /**
+         * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
+         */
+        public function supportsNormalization($data, $format = null, array $context = []): bool
+        {
+            return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
+        }
     }
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsNormalization($data, $format = null, $context = []) : bool
+} else {
+    class ReferenceNormalizer implements NormalizerInterface
     {
-        return $data instanceof Reference;
+        /**
+         * {@inheritdoc}
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $ref = [];
+            $ref['$ref'] = (string) $object->getReferenceUri();
+            return $ref;
+        }
+        /**
+         * {@inheritdoc}
+         */
+        public function supportsNormalization($data, $format = null): bool
+        {
+            return $data instanceof Reference;
+        }
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Generator/EndpointGenerator.php
+++ b/src/Component/OpenApi3/Generator/EndpointGenerator.php
@@ -64,7 +64,7 @@ class EndpointGenerator implements EndpointGeneratorInterface
         NonBodyParameterGenerator $nonBodyParameterGenerator,
         DenormalizerInterface $denormalizer,
         ExceptionGenerator $exceptionGenerator,
-        RequestBodyGenerator $requestBodyGenerator
+        RequestBodyGenerator $requestBodyGenerator,
     ) {
         $this->operationNaming = $operationNaming;
         $this->nonBodyParameterGenerator = $nonBodyParameterGenerator;

--- a/src/Component/OpenApi3/Tests/client/generated/Authentication/ApiKeyAuthAuthentication.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Authentication/ApiKeyAuthAuthentication.php
@@ -9,12 +9,12 @@ class ApiKeyAuthAuthentication implements \Jane\Component\OpenApiRuntime\Client\
     {
         $this->{'apiKey'} = $apiKey;
     }
-    public function authentication(\Psr\Http\Message\RequestInterface $request) : \Psr\Http\Message\RequestInterface
+    public function authentication(\Psr\Http\Message\RequestInterface $request): \Psr\Http\Message\RequestInterface
     {
         $request = $request->withHeader('X-API-Key', $this->{'apiKey'});
         return $request;
     }
-    public function getScope() : string
+    public function getScope(): string
     {
         return 'ApiKeyAuth';
     }

--- a/src/Component/OpenApi3/Tests/client/generated/Client.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Client.php
@@ -14,12 +14,12 @@ class Client extends \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Client\Endpoint\GetEndpoint(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
             $plugins = [];
-            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUrlFactory()->createUri('http://127.0.0.1:4010/');
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('http://127.0.0.1:4010/');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
             if (count($additionalPlugins) > 0) {
@@ -29,10 +29,11 @@ class Client extends \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\Client
         }
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
-        $serializer = new \Symfony\Component\Serializer\Serializer(
-            [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Client\Normalizer\JaneObjectNormalizer()], 
-            [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))],
-        );
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Client\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
         return new static($httpClient, $requestFactory, $serializer, $streamFactory);
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Endpoint/GetEndpoint.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Endpoint/GetEndpoint.php
@@ -5,19 +5,19 @@ namespace Jane\Component\OpenApi3\Tests\Client\Endpoint;
 class GetEndpoint extends \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\Endpoint
 {
     use \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\EndpointTrait;
-    public function getMethod() : string
+    public function getMethod(): string
     {
         return 'GET';
     }
-    public function getUri() : string
+    public function getUri(): string
     {
         return '/endpoint';
     }
-    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null) : array
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         return [[], null];
     }
-    public function getExtraHeaders() : array
+    public function getExtraHeaders(): array
     {
         return ['Accept' => ['application/json']];
     }
@@ -28,16 +28,18 @@ class GetEndpoint extends \Jane\Component\OpenApi3\Tests\Client\Runtime\Client\B
      *
      * @return null|\Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse
      */
-    protected function transformResponseBody(string $body, int $status, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
         if (is_null($contentType) === false && (200 === $status && mb_strpos($contentType, 'application/json') !== false)) {
-            return $serializer->deserialize($body, 'Jane\\Component\\OpenApi3\\Tests\\Client\\Model\\SimpleResponse', 'json');
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse', 'json');
         }
         if (is_null($contentType) === false && (401 === $status && mb_strpos($contentType, 'application/json') !== false)) {
-            throw new \Jane\Component\OpenApi3\Tests\Client\Exception\GetEndpointUnauthorizedException($serializer->deserialize($body, 'Jane\\Component\\OpenApi3\\Tests\\Client\\Model\\Error', 'json'));
+            throw new \Jane\Component\OpenApi3\Tests\Client\Exception\GetEndpointUnauthorizedException($serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Client\Model\Error', 'json'), $response);
         }
     }
-    public function getAuthenticationScopes() : array
+    public function getAuthenticationScopes(): array
     {
         return ['ApiKeyAuth'];
     }

--- a/src/Component/OpenApi3/Tests/client/generated/Exception/GetEndpointUnauthorizedException.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Exception/GetEndpointUnauthorizedException.php
@@ -4,14 +4,26 @@ namespace Jane\Component\OpenApi3\Tests\Client\Exception;
 
 class GetEndpointUnauthorizedException extends UnauthorizedException
 {
+    /**
+     * @var \Jane\Component\OpenApi3\Tests\Client\Model\Error
+     */
     private $error;
-    public function __construct(\Jane\Component\OpenApi3\Tests\Client\Model\Error $error)
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi3\Tests\Client\Model\Error $error, \Psr\Http\Message\ResponseInterface $response)
     {
-        parent::__construct('Unauthaurized response', 401);
+        parent::__construct('Unauthaurized response');
         $this->error = $error;
+        $this->response = $response;
     }
-    public function getError()
+    public function getError(): \Jane\Component\OpenApi3\Tests\Client\Model\Error
     {
         return $this->error;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Model/Error.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Model/Error.php
@@ -2,8 +2,16 @@
 
 namespace Jane\Component\OpenApi3\Tests\Client\Model;
 
-class Error
+class Error extends \ArrayObject
 {
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
     /**
      * 
      *
@@ -15,7 +23,7 @@ class Error
      *
      * @return string
      */
-    public function getMessage() : string
+    public function getMessage(): string
     {
         return $this->message;
     }
@@ -26,8 +34,9 @@ class Error
      *
      * @return self
      */
-    public function setMessage(string $message) : self
+    public function setMessage(string $message): self
     {
+        $this->initialized['message'] = true;
         $this->message = $message;
         return $this;
     }

--- a/src/Component/OpenApi3/Tests/client/generated/Model/SimpleResponse.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Model/SimpleResponse.php
@@ -2,8 +2,16 @@
 
 namespace Jane\Component\OpenApi3\Tests\Client\Model;
 
-class SimpleResponse
+class SimpleResponse extends \ArrayObject
 {
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
     /**
      * 
      *
@@ -21,7 +29,7 @@ class SimpleResponse
      *
      * @return string
      */
-    public function getFoo() : string
+    public function getFoo(): string
     {
         return $this->foo;
     }
@@ -32,8 +40,9 @@ class SimpleResponse
      *
      * @return self
      */
-    public function setFoo(string $foo) : self
+    public function setFoo(string $foo): self
     {
+        $this->initialized['foo'] = true;
         $this->foo = $foo;
         return $this;
     }
@@ -42,7 +51,7 @@ class SimpleResponse
      *
      * @return bool
      */
-    public function getBaz() : bool
+    public function getBaz(): bool
     {
         return $this->baz;
     }
@@ -53,8 +62,9 @@ class SimpleResponse
      *
      * @return self
      */
-    public function setBaz(bool $baz) : self
+    public function setBaz(bool $baz): self
     {
+        $this->initialized['baz'] = true;
         $this->baz = $baz;
         return $this;
     }

--- a/src/Component/OpenApi3/Tests/client/generated/Normalizer/ErrorNormalizer.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Normalizer/ErrorNormalizer.php
@@ -4,6 +4,7 @@ namespace Jane\Component\OpenApi3\Tests\Client\Normalizer;
 
 use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\ValidatorTrait;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
@@ -11,42 +12,123 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
-{
-    use DenormalizerAwareTrait;
-    use NormalizerAwareTrait;
-    use CheckArray;
-    public function supportsDenormalization($data, $type, $format = null)
+use Symfony\Component\HttpKernel\Kernel;
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Client\\Model\\Error';
-    }
-    public function supportsNormalization($data, $format = null, $context = []) : bool
-    {
-        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Client\\Model\\Error';
-    }
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []) : mixed
-    {
-        if (isset($data['$ref'])) {
-            return new Reference($data['$ref'], $context['document-origin']);
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi3\Tests\Client\Model\Error::class;
         }
-        if (isset($data['$recursiveRef'])) {
-            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Client\Model\Error::class;
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Client\Model\Error();
-        if (null === $data || false === \is_array($data)) {
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi3\Tests\Client\Model\Error();
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('message', $data)) {
+                $object->setMessage($data['message']);
+                unset($data['message']);
+            }
+            foreach ($data as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $object[$key] = $value;
+                }
+            }
             return $object;
         }
-        if (\array_key_exists('message', $data)) {
-            $object->setMessage($data['message']);
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $data = [];
+            if ($object->isInitialized('message') && null !== $object->getMessage()) {
+                $data['message'] = $object->getMessage();
+            }
+            foreach ($object as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $data[$key] = $value;
+                }
+            }
+            return $data;
         }
-        return $object;
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi3\Tests\Client\Model\Error::class => false];
+        }
     }
-    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+} else {
+    class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        $data = [];
-        if (null !== $object->getMessage()) {
-            $data['message'] = $object->getMessage();
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization($data, $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi3\Tests\Client\Model\Error::class;
         }
-        return $data;
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Client\Model\Error::class;
+        }
+        /**
+         * @return mixed
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi3\Tests\Client\Model\Error();
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('message', $data)) {
+                $object->setMessage($data['message']);
+                unset($data['message']);
+            }
+            foreach ($data as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $object[$key] = $value;
+                }
+            }
+            return $object;
+        }
+        /**
+         * @return array|string|int|float|bool|\ArrayObject|null
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $data = [];
+            if ($object->isInitialized('message') && null !== $object->getMessage()) {
+                $data['message'] = $object->getMessage();
+            }
+            foreach ($object as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $data[$key] = $value;
+                }
+            }
+            return $data;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi3\Tests\Client\Model\Error::class => false];
+        }
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Normalizer/JaneObjectNormalizer.php
@@ -3,48 +3,132 @@
 namespace Jane\Component\OpenApi3\Tests\Client\Normalizer;
 
 use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\ValidatorTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
-{
-    use DenormalizerAwareTrait;
-    use NormalizerAwareTrait;
-    use CheckArray;
-    protected $normalizers = ['Jane\\Component\\OpenApi3\\Tests\\Client\\Model\\SimpleResponse' => 'Jane\\Component\\OpenApi3\\Tests\\Client\\Normalizer\\SimpleResponseNormalizer', 'Jane\\Component\\OpenApi3\\Tests\\Client\\Model\\Error' => 'Jane\\Component\\OpenApi3\\Tests\\Client\\Normalizer\\ErrorNormalizer', \Jane\Component\JsonSchemaRuntime\Reference::class => '\\Jane\\Component\\OpenApi3\\Tests\\Client\\Runtime\\Normalizer\\ReferenceNormalizer'], $normalizersCache = [];
-    public function supportsDenormalization($data, $type, $format = null)
+use Symfony\Component\HttpKernel\Kernel;
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        return array_key_exists($type, $this->normalizers);
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        protected $normalizers = [
+            
+            \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class => \Jane\Component\OpenApi3\Tests\Client\Normalizer\SimpleResponseNormalizer::class,
+            
+            \Jane\Component\OpenApi3\Tests\Client\Model\Error::class => \Jane\Component\OpenApi3\Tests\Client\Normalizer\ErrorNormalizer::class,
+            
+            \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\ReferenceNormalizer::class,
+        ], $normalizersCache = [];
+        public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
+        {
+            return array_key_exists($type, $this->normalizers);
+        }
+        public function supportsNormalization($data, $format = null, array $context = []): bool
+        {
+            return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+        }
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $normalizerClass = $this->normalizers[get_class($object)];
+            $normalizer = $this->getNormalizer($normalizerClass);
+            return $normalizer->normalize($object, $format, $context);
+        }
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+        {
+            $denormalizerClass = $this->normalizers[$type];
+            $denormalizer = $this->getNormalizer($denormalizerClass);
+            return $denormalizer->denormalize($data, $type, $format, $context);
+        }
+        private function getNormalizer(string $normalizerClass)
+        {
+            return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+        }
+        private function initNormalizer(string $normalizerClass)
+        {
+            $normalizer = new $normalizerClass();
+            $normalizer->setNormalizer($this->normalizer);
+            $normalizer->setDenormalizer($this->denormalizer);
+            $this->normalizersCache[$normalizerClass] = $normalizer;
+            return $normalizer;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [
+                
+                \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class => false,
+                \Jane\Component\OpenApi3\Tests\Client\Model\Error::class => false,
+                \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+            ];
+        }
     }
-    public function supportsNormalization($data, $format = null, $context = []) : bool
+} else {
+    class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
-    }
-    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
-    {
-        $normalizerClass = $this->normalizers[get_class($object)];
-        $normalizer = $this->getNormalizer($normalizerClass);
-        return $normalizer->normalize($object, $format, $context);
-    }
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []) : mixed
-    {
-        $denormalizerClass = $this->normalizers[$type];
-        $denormalizer = $this->getNormalizer($denormalizerClass);
-        return $denormalizer->denormalize($data, $type, $format, $context);
-    }
-    private function getNormalizer(string $normalizerClass)
-    {
-        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
-    }
-    private function initNormalizer(string $normalizerClass)
-    {
-        $normalizer = new $normalizerClass();
-        $normalizer->setNormalizer($this->normalizer);
-        $normalizer->setDenormalizer($this->denormalizer);
-        $this->normalizersCache[$normalizerClass] = $normalizer;
-        return $normalizer;
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        protected $normalizers = [
+            
+            \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class => \Jane\Component\OpenApi3\Tests\Client\Normalizer\SimpleResponseNormalizer::class,
+            
+            \Jane\Component\OpenApi3\Tests\Client\Model\Error::class => \Jane\Component\OpenApi3\Tests\Client\Normalizer\ErrorNormalizer::class,
+            
+            \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\ReferenceNormalizer::class,
+        ], $normalizersCache = [];
+        public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
+        {
+            return array_key_exists($type, $this->normalizers);
+        }
+        public function supportsNormalization($data, $format = null, array $context = []): bool
+        {
+            return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+        }
+        /**
+         * @return array|string|int|float|bool|\ArrayObject|null
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $normalizerClass = $this->normalizers[get_class($object)];
+            $normalizer = $this->getNormalizer($normalizerClass);
+            return $normalizer->normalize($object, $format, $context);
+        }
+        /**
+         * @return mixed
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            $denormalizerClass = $this->normalizers[$type];
+            $denormalizer = $this->getNormalizer($denormalizerClass);
+            return $denormalizer->denormalize($data, $type, $format, $context);
+        }
+        private function getNormalizer(string $normalizerClass)
+        {
+            return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+        }
+        private function initNormalizer(string $normalizerClass)
+        {
+            $normalizer = new $normalizerClass();
+            $normalizer->setNormalizer($this->normalizer);
+            $normalizer->setDenormalizer($this->denormalizer);
+            $this->normalizersCache[$normalizerClass] = $normalizer;
+            return $normalizer;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [
+                
+                \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class => false,
+                \Jane\Component\OpenApi3\Tests\Client\Model\Error::class => false,
+                \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+            ];
+        }
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Normalizer/SimpleResponseNormalizer.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Normalizer/SimpleResponseNormalizer.php
@@ -4,6 +4,7 @@ namespace Jane\Component\OpenApi3\Tests\Client\Normalizer;
 
 use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer\ValidatorTrait;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
@@ -11,48 +12,137 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class SimpleResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
-{
-    use DenormalizerAwareTrait;
-    use NormalizerAwareTrait;
-    use CheckArray;
-    public function supportsDenormalization($data, $type, $format = null)
+use Symfony\Component\HttpKernel\Kernel;
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class SimpleResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        return $type === 'Jane\\Component\\OpenApi3\\Tests\\Client\\Model\\SimpleResponse';
-    }
-    public function supportsNormalization($data, $format = null, $context = []) : bool
-    {
-        return is_object($data) && get_class($data) === 'Jane\\Component\\OpenApi3\\Tests\\Client\\Model\\SimpleResponse';
-    }
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []) : mixed
-    {
-        if (isset($data['$ref'])) {
-            return new Reference($data['$ref'], $context['document-origin']);
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class;
         }
-        if (isset($data['$recursiveRef'])) {
-            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class;
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse();
-        if (null === $data || false === \is_array($data)) {
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse();
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('foo', $data)) {
+                $object->setFoo($data['foo']);
+                unset($data['foo']);
+            }
+            if (\array_key_exists('baz', $data)) {
+                $object->setBaz($data['baz']);
+                unset($data['baz']);
+            }
+            foreach ($data as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $object[$key] = $value;
+                }
+            }
             return $object;
         }
-        if (\array_key_exists('foo', $data)) {
-            $object->setFoo($data['foo']);
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $data = [];
+            if ($object->isInitialized('foo') && null !== $object->getFoo()) {
+                $data['foo'] = $object->getFoo();
+            }
+            if ($object->isInitialized('baz') && null !== $object->getBaz()) {
+                $data['baz'] = $object->getBaz();
+            }
+            foreach ($object as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $data[$key] = $value;
+                }
+            }
+            return $data;
         }
-        if (\array_key_exists('baz', $data)) {
-            $object->setBaz($data['baz']);
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class => false];
         }
-        return $object;
     }
-    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+} else {
+    class SimpleResponseNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
     {
-        $data = [];
-        if (null !== $object->getFoo()) {
-            $data['foo'] = $object->getFoo();
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization($data, $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class;
         }
-        if (null !== $object->getBaz()) {
-            $data['baz'] = $object->getBaz();
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class;
         }
-        return $data;
+        /**
+         * @return mixed
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse();
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('foo', $data)) {
+                $object->setFoo($data['foo']);
+                unset($data['foo']);
+            }
+            if (\array_key_exists('baz', $data)) {
+                $object->setBaz($data['baz']);
+                unset($data['baz']);
+            }
+            foreach ($data as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $object[$key] = $value;
+                }
+            }
+            return $object;
+        }
+        /**
+         * @return array|string|int|float|bool|\ArrayObject|null
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $data = [];
+            if ($object->isInitialized('foo') && null !== $object->getFoo()) {
+                $data['foo'] = $object->getFoo();
+            }
+            if ($object->isInitialized('baz') && null !== $object->getBaz()) {
+                $data['baz'] = $object->getBaz();
+            }
+            foreach ($object as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $data[$key] = $value;
+                }
+            }
+            return $data;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi3\Tests\Client\Model\SimpleResponse::class => false];
+        }
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/BaseEndpoint.php
@@ -3,23 +3,25 @@
 namespace Jane\Component\OpenApi3\Tests\Client\Runtime\Client;
 
 use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Serializer\SerializerInterface;
 abstract class BaseEndpoint implements Endpoint
 {
+    protected $formParameters = [];
     protected $queryParameters = [];
     protected $headerParameters = [];
     protected $body;
-    public abstract function getMethod() : string;
-    public abstract function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
-    public abstract function getUri() : string;
-    public abstract function getAuthenticationScopes() : array;
-    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
-    protected function getExtraHeaders() : array
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
     {
         return [];
     }
-    public function getQueryString() : string
+    public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
         $optionsResolved = array_map(function ($value) {
@@ -27,25 +29,25 @@ abstract class BaseEndpoint implements Endpoint
         }, $optionsResolved);
         return http_build_query($optionsResolved, '', '&', PHP_QUERY_RFC3986);
     }
-    public function getHeaders(array $baseHeaders = []) : array
+    public function getHeaders(array $baseHeaders = []): array
     {
         return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
     }
-    protected function getQueryOptionsResolver() : OptionsResolver
+    protected function getQueryOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
     }
-    protected function getHeadersOptionsResolver() : OptionsResolver
+    protected function getHeadersOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
     }
     // ----------------------------------------------------------------------------------------------------
     // Used for OpenApi2 compatibility
-    protected function getFormBody() : array
+    protected function getFormBody(): array
     {
         return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
     }
-    protected function getMultipartBody($streamFactory = null) : array
+    protected function getMultipartBody($streamFactory = null): array
     {
         $bodyBuilder = new MultipartStreamBuilder($streamFactory);
         $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
@@ -54,11 +56,11 @@ abstract class BaseEndpoint implements Endpoint
         }
         return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
     }
-    protected function getFormOptionsResolver() : OptionsResolver
+    protected function getFormOptionsResolver(): OptionsResolver
     {
         return new OptionsResolver();
     }
-    protected function getSerializedBody(SerializerInterface $serializer) : array
+    protected function getSerializedBody(SerializerInterface $serializer): array
     {
         return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
     }

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/Client.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi3\Tests\Client\Runtime\Client;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -37,6 +38,18 @@ abstract class Client
     }
     public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
     {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
         [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
         $queryString = $endpoint->getQueryString();
         $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
@@ -47,7 +60,8 @@ abstract class Client
                 $request = $request->withBody($body);
             } elseif (is_resource($body)) {
                 $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
-            } elseif (is_file($body)) {
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
                 $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
             } else {
                 $request = $request->withBody($this->streamFactory->createStream($body));
@@ -63,6 +77,6 @@ abstract class Client
             }
             $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
         }
-        return $endpoint->parseResponse($this->httpClient->sendRequest($request), $this->serializer, $fetch);
+        return $this->httpClient->sendRequest($request);
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/Endpoint.php
@@ -12,27 +12,27 @@ interface Endpoint
      * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
      * And the second value consist of the body object.
      */
-    public function getBody(SerializerInterface $serializer, $streamFactory = null) : array;
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
     /**
      * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
      */
-    public function getQueryString() : string;
+    public function getQueryString(): string;
     /**
      * Get the URI of an endpoint (like /foo-uri).
      */
-    public function getUri() : string;
+    public function getUri(): string;
     /**
      * Get the HTTP method of an endpoint (like GET, POST, ...).
      */
-    public function getMethod() : string;
+    public function getMethod(): string;
     /**
      * Get the headers of an endpoint.
      */
-    public function getHeaders(array $baseHeaders = []) : array;
+    public function getHeaders(array $baseHeaders = []): array;
     /**
      * Get security scopes of an endpoint.
      */
-    public function getAuthenticationScopes() : array;
+    public function getAuthenticationScopes(): array;
     /**
      * Parse and transform a PSR7 Response into a different object.
      *

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Client/EndpointTrait.php
@@ -2,21 +2,14 @@
 
 namespace Jane\Component\OpenApi3\Tests\Client\Runtime\Client;
 
-use Jane\Component\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 trait EndpointTrait
 {
-    protected abstract function transformResponseBody(string $body, int $status, SerializerInterface $serializer, ?string $contentType = null);
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
     public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
-        if ($fetchMode === Client::FETCH_OBJECT) {
-            $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
-            return $this->transformResponseBody((string) $response->getBody(), $response->getStatusCode(), $serializer, $contentType);
-        }
-        if ($fetchMode === Client::FETCH_RESPONSE) {
-            return $response;
-        }
-        throw new InvalidFetchModeException(sprintf('Fetch mode %s is not supported', $fetchMode));
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
     }
 }

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Normalizer/CheckArray.php
@@ -4,7 +4,7 @@ namespace Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer;
 
 trait CheckArray
 {
-    public function isOnlyNumericKeys(array $array) : bool
+    public function isOnlyNumericKeys(array $array): bool
     {
         return count(array_filter($array, function ($key) {
             return is_numeric($key);

--- a/src/Component/OpenApi3/Tests/client/generated/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/client/generated/Runtime/Normalizer/ReferenceNormalizer.php
@@ -3,23 +3,53 @@
 namespace Jane\Component\OpenApi3\Tests\Client\Runtime\Normalizer;
 
 use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ReferenceNormalizer implements NormalizerInterface
-{
-    /**
-     * {@inheritdoc}
-     */
-    public function normalize(mixed $object, string $format = null, array $context = []) : array|string|int|float|bool|\ArrayObject|null
+if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_VERSION === 4) {
+    class ReferenceNormalizer implements NormalizerInterface
     {
-        $ref = [];
-        $ref['$ref'] = (string) $object->getReferenceUri();
-        return $ref;
+        /**
+         * {@inheritdoc}
+         */
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $ref = [];
+            $ref['$ref'] = (string) $object->getReferenceUri();
+            return $ref;
+        }
+        /**
+         * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
+         */
+        public function supportsNormalization($data, $format = null, array $context = []): bool
+        {
+            return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
+        }
     }
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsNormalization($data, $format = null, $context = []) : bool
+} else {
+    class ReferenceNormalizer implements NormalizerInterface
     {
-        return $data instanceof Reference;
+        /**
+         * {@inheritdoc}
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $ref = [];
+            $ref['$ref'] = (string) $object->getReferenceUri();
+            return $ref;
+        }
+        /**
+         * {@inheritdoc}
+         */
+        public function supportsNormalization($data, $format = null): bool
+        {
+            return $data instanceof Reference;
+        }
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -19,10 +19,17 @@ if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_V
         }
         /**
          * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
          */
-        public function supportsNormalization($data, $format = null): bool
+        public function supportsNormalization($data, $format = null, array $context = []): bool
         {
             return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
         }
     }
 } else {


### PR DESCRIPTION
Add Support of PHP 8.4 & Symfony 7.2.x

**Fixes**
- Fix Reference Normalizer not working with Symfony 7.2.x
- Run php-cs-fixer for PHP 8.4

Closes: #840