### PR TITLE
Bugfix: Content */* breaks generated Endpoint PHP class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [PHP] [GH#842](https://github.com/janephp/janephp/pull/842) Fix generated files to be compatible with PHP 8.4
 - [CI] [GH#850](https://github.com/janephp/janephp/pull/850) Update GH actions/cache to v4
+- [OpenApi] [GH#845](https://github.com/janephp/janephp/pull/845) Content */* breaks generated Endpoint PHP class
 
 ## [7.8.1] - 2024-07-29
 ### Fixed

--- a/src/Component/OpenApi3/Generator/Endpoint/GetConstructorTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetConstructorTrait.php
@@ -99,7 +99,8 @@ trait GetConstructorTrait
             $bodyDoc ? [$bodyDoc] : [],
             \count($queryParamsDoc) > 0 ? array_merge([' * @param array $queryParameters {'], $queryParamsDoc, [' * }']) : [],
             \count($headerParamsDoc) > 0 ? array_merge([' * @param array $headerParameters {'], $headerParamsDoc, [' * }']) : [],
-            \count($contentTypes) > 1 ? [' * @param array $accept Accept content header ' . implode('|', $this->getContentTypes($operation, $guessClass))] : []
+            \count($contentTypes) > 1 ? [' * @param array $accept Accept content header ' .
+                str_replace('*/', '*\\/', implode('|', $this->getContentTypes($operation, $guessClass)))] : []
         );
 
         $methodParamsDoc = <<<EOD

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.json',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Client.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * 
+     *
+     * @param string $requestBody 
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @param array $accept Accept content header *\/*|application/json
+     *
+     * @return null|\Psr\Http\Message\ResponseInterface
+     */
+    public function mimeTypeGeneratedValidDocBlock(string $requestBody, string $fetch = self::FETCH_OBJECT, array $accept = [])
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\MimeTypeGeneratedValidDocBlock($requestBody, $accept), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Endpoint/MimeTypeGeneratedValidDocBlock.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Endpoint/MimeTypeGeneratedValidDocBlock.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class MimeTypeGeneratedValidDocBlock extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    protected $accept;
+    /**
+     * 
+     *
+     * @param string $requestBody 
+     * @param array $accept Accept content header *\/*|application/json
+     */
+    public function __construct(string $requestBody, array $accept = [])
+    {
+        $this->body = $requestBody;
+        $this->accept = $accept;
+    }
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+    public function getUri(): string
+    {
+        return '/test-simple';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        if (is_string($this->body)) {
+            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+        }
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        if (empty($this->accept)) {
+            return ['Accept' => ['*/*', 'application/json']];
+        }
+        return $this->accept;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (404 === $status) {
+        }
+        if (is_null($contentType) === false && (200 === $status && mb_strpos($contentType, 'application/json') !== false)) {
+            return json_decode($body);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Model/Schema.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Model/Schema.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class Schema extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $stringProperty;
+    /**
+     * 
+     *
+     * @var \DateTime
+     */
+    protected $dateProperty;
+    /**
+     * 
+     *
+     * @var int
+     */
+    protected $integerProperty;
+    /**
+     * 
+     *
+     * @var float
+     */
+    protected $floatProperty;
+    /**
+     * 
+     *
+     * @var list<mixed>
+     */
+    protected $arrayProperty;
+    /**
+     * 
+     *
+     * @var array<string, string>
+     */
+    protected $mapProperty;
+    /**
+     * 
+     *
+     * @var SchemaObjectProperty
+     */
+    protected $objectProperty;
+    /**
+     * 
+     *
+     * @var Schema
+     */
+    protected $objectRefProperty;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getStringProperty(): string
+    {
+        return $this->stringProperty;
+    }
+    /**
+     * 
+     *
+     * @param string $stringProperty
+     *
+     * @return self
+     */
+    public function setStringProperty(string $stringProperty): self
+    {
+        $this->initialized['stringProperty'] = true;
+        $this->stringProperty = $stringProperty;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return \DateTime
+     */
+    public function getDateProperty(): \DateTime
+    {
+        return $this->dateProperty;
+    }
+    /**
+     * 
+     *
+     * @param \DateTime $dateProperty
+     *
+     * @return self
+     */
+    public function setDateProperty(\DateTime $dateProperty): self
+    {
+        $this->initialized['dateProperty'] = true;
+        $this->dateProperty = $dateProperty;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return int
+     */
+    public function getIntegerProperty(): int
+    {
+        return $this->integerProperty;
+    }
+    /**
+     * 
+     *
+     * @param int $integerProperty
+     *
+     * @return self
+     */
+    public function setIntegerProperty(int $integerProperty): self
+    {
+        $this->initialized['integerProperty'] = true;
+        $this->integerProperty = $integerProperty;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return float
+     */
+    public function getFloatProperty(): float
+    {
+        return $this->floatProperty;
+    }
+    /**
+     * 
+     *
+     * @param float $floatProperty
+     *
+     * @return self
+     */
+    public function setFloatProperty(float $floatProperty): self
+    {
+        $this->initialized['floatProperty'] = true;
+        $this->floatProperty = $floatProperty;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return list<mixed>
+     */
+    public function getArrayProperty(): array
+    {
+        return $this->arrayProperty;
+    }
+    /**
+     * 
+     *
+     * @param list<mixed> $arrayProperty
+     *
+     * @return self
+     */
+    public function setArrayProperty(array $arrayProperty): self
+    {
+        $this->initialized['arrayProperty'] = true;
+        $this->arrayProperty = $arrayProperty;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return array<string, string>
+     */
+    public function getMapProperty(): iterable
+    {
+        return $this->mapProperty;
+    }
+    /**
+     * 
+     *
+     * @param array<string, string> $mapProperty
+     *
+     * @return self
+     */
+    public function setMapProperty(iterable $mapProperty): self
+    {
+        $this->initialized['mapProperty'] = true;
+        $this->mapProperty = $mapProperty;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return SchemaObjectProperty
+     */
+    public function getObjectProperty(): SchemaObjectProperty
+    {
+        return $this->objectProperty;
+    }
+    /**
+     * 
+     *
+     * @param SchemaObjectProperty $objectProperty
+     *
+     * @return self
+     */
+    public function setObjectProperty(SchemaObjectProperty $objectProperty): self
+    {
+        $this->initialized['objectProperty'] = true;
+        $this->objectProperty = $objectProperty;
+        return $this;
+    }
+    /**
+     * 
+     *
+     * @return Schema
+     */
+    public function getObjectRefProperty(): Schema
+    {
+        return $this->objectRefProperty;
+    }
+    /**
+     * 
+     *
+     * @param Schema $objectRefProperty
+     *
+     * @return self
+     */
+    public function setObjectRefProperty(Schema $objectRefProperty): self
+    {
+        $this->initialized['objectRefProperty'] = true;
+        $this->objectRefProperty = $objectRefProperty;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Model/SchemaObjectProperty.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Model/SchemaObjectProperty.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class SchemaObjectProperty extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * 
+     *
+     * @var string
+     */
+    protected $stringProperty;
+    /**
+     * 
+     *
+     * @return string
+     */
+    public function getStringProperty(): string
+    {
+        return $this->stringProperty;
+    }
+    /**
+     * 
+     *
+     * @param string $stringProperty
+     *
+     * @return self
+     */
+    public function setStringProperty(string $stringProperty): self
+    {
+        $this->initialized['stringProperty'] = true;
+        $this->stringProperty = $stringProperty;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\HttpKernel\Kernel;
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+    {
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        protected $normalizers = [
+            
+            \Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\SchemaNormalizer::class,
+            
+            \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\SchemaObjectPropertyNormalizer::class,
+            
+            \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+        ], $normalizersCache = [];
+        public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
+        {
+            return array_key_exists($type, $this->normalizers);
+        }
+        public function supportsNormalization($data, $format = null, array $context = []): bool
+        {
+            return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+        }
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $normalizerClass = $this->normalizers[get_class($object)];
+            $normalizer = $this->getNormalizer($normalizerClass);
+            return $normalizer->normalize($object, $format, $context);
+        }
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+        {
+            $denormalizerClass = $this->normalizers[$type];
+            $denormalizer = $this->getNormalizer($denormalizerClass);
+            return $denormalizer->denormalize($data, $type, $format, $context);
+        }
+        private function getNormalizer(string $normalizerClass)
+        {
+            return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+        }
+        private function initNormalizer(string $normalizerClass)
+        {
+            $normalizer = new $normalizerClass();
+            $normalizer->setNormalizer($this->normalizer);
+            $normalizer->setDenormalizer($this->denormalizer);
+            $this->normalizersCache[$normalizerClass] = $normalizer;
+            return $normalizer;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [
+                
+                \Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class => false,
+                \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class => false,
+                \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+            ];
+        }
+    }
+} else {
+    class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+    {
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        protected $normalizers = [
+            
+            \Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\SchemaNormalizer::class,
+            
+            \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\SchemaObjectPropertyNormalizer::class,
+            
+            \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+        ], $normalizersCache = [];
+        public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
+        {
+            return array_key_exists($type, $this->normalizers);
+        }
+        public function supportsNormalization($data, $format = null, array $context = []): bool
+        {
+            return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+        }
+        /**
+         * @return array|string|int|float|bool|\ArrayObject|null
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $normalizerClass = $this->normalizers[get_class($object)];
+            $normalizer = $this->getNormalizer($normalizerClass);
+            return $normalizer->normalize($object, $format, $context);
+        }
+        /**
+         * @return mixed
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            $denormalizerClass = $this->normalizers[$type];
+            $denormalizer = $this->getNormalizer($denormalizerClass);
+            return $denormalizer->denormalize($data, $type, $format, $context);
+        }
+        private function getNormalizer(string $normalizerClass)
+        {
+            return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+        }
+        private function initNormalizer(string $normalizerClass)
+        {
+            $normalizer = new $normalizerClass();
+            $normalizer->setNormalizer($this->normalizer);
+            $normalizer->setDenormalizer($this->denormalizer);
+            $this->normalizersCache[$normalizerClass] = $normalizer;
+            return $normalizer;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [
+                
+                \Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class => false,
+                \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class => false,
+                \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+            ];
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Normalizer/SchemaNormalizer.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\HttpKernel\Kernel;
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+    {
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class;
+        }
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class;
+        }
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Schema();
+            if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
+                $data['floatProperty'] = (double) $data['floatProperty'];
+            }
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('stringProperty', $data)) {
+                $object->setStringProperty($data['stringProperty']);
+                unset($data['stringProperty']);
+            }
+            if (\array_key_exists('dateProperty', $data)) {
+                $object->setDateProperty(\DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateProperty']));
+                unset($data['dateProperty']);
+            }
+            if (\array_key_exists('integerProperty', $data)) {
+                $object->setIntegerProperty($data['integerProperty']);
+                unset($data['integerProperty']);
+            }
+            if (\array_key_exists('floatProperty', $data)) {
+                $object->setFloatProperty($data['floatProperty']);
+                unset($data['floatProperty']);
+            }
+            if (\array_key_exists('arrayProperty', $data)) {
+                $values = [];
+                foreach ($data['arrayProperty'] as $value) {
+                    $values[] = $value;
+                }
+                $object->setArrayProperty($values);
+                unset($data['arrayProperty']);
+            }
+            if (\array_key_exists('mapProperty', $data)) {
+                $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
+                foreach ($data['mapProperty'] as $key => $value_1) {
+                    $values_1[$key] = $value_1;
+                }
+                $object->setMapProperty($values_1);
+                unset($data['mapProperty']);
+            }
+            if (\array_key_exists('objectProperty', $data)) {
+                $object->setObjectProperty($this->denormalizer->denormalize($data['objectProperty'], \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class, 'json', $context));
+                unset($data['objectProperty']);
+            }
+            if (\array_key_exists('objectRefProperty', $data)) {
+                $object->setObjectRefProperty($this->denormalizer->denormalize($data['objectRefProperty'], \Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class, 'json', $context));
+                unset($data['objectRefProperty']);
+            }
+            foreach ($data as $key_1 => $value_2) {
+                if (preg_match('/.*/', (string) $key_1)) {
+                    $object[$key_1] = $value_2;
+                }
+            }
+            return $object;
+        }
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $data = [];
+            if ($object->isInitialized('stringProperty') && null !== $object->getStringProperty()) {
+                $data['stringProperty'] = $object->getStringProperty();
+            }
+            if ($object->isInitialized('dateProperty') && null !== $object->getDateProperty()) {
+                $data['dateProperty'] = $object->getDateProperty()?->format('Y-m-d\TH:i:sP');
+            }
+            if ($object->isInitialized('integerProperty') && null !== $object->getIntegerProperty()) {
+                $data['integerProperty'] = $object->getIntegerProperty();
+            }
+            if ($object->isInitialized('floatProperty') && null !== $object->getFloatProperty()) {
+                $data['floatProperty'] = $object->getFloatProperty();
+            }
+            if ($object->isInitialized('arrayProperty') && null !== $object->getArrayProperty()) {
+                $values = [];
+                foreach ($object->getArrayProperty() as $value) {
+                    $values[] = $value;
+                }
+                $data['arrayProperty'] = $values;
+            }
+            if ($object->isInitialized('mapProperty') && null !== $object->getMapProperty()) {
+                $values_1 = [];
+                foreach ($object->getMapProperty() as $key => $value_1) {
+                    $values_1[$key] = $value_1;
+                }
+                $data['mapProperty'] = $values_1;
+            }
+            if ($object->isInitialized('objectProperty') && null !== $object->getObjectProperty()) {
+                $data['objectProperty'] = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
+            }
+            if ($object->isInitialized('objectRefProperty') && null !== $object->getObjectRefProperty()) {
+                $data['objectRefProperty'] = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
+            }
+            foreach ($object as $key_1 => $value_2) {
+                if (preg_match('/.*/', (string) $key_1)) {
+                    $data[$key_1] = $value_2;
+                }
+            }
+            return $data;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class => false];
+        }
+    }
+} else {
+    class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+    {
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization($data, $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class;
+        }
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class;
+        }
+        /**
+         * @return mixed
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Schema();
+            if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
+                $data['floatProperty'] = (double) $data['floatProperty'];
+            }
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('stringProperty', $data)) {
+                $object->setStringProperty($data['stringProperty']);
+                unset($data['stringProperty']);
+            }
+            if (\array_key_exists('dateProperty', $data)) {
+                $object->setDateProperty(\DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateProperty']));
+                unset($data['dateProperty']);
+            }
+            if (\array_key_exists('integerProperty', $data)) {
+                $object->setIntegerProperty($data['integerProperty']);
+                unset($data['integerProperty']);
+            }
+            if (\array_key_exists('floatProperty', $data)) {
+                $object->setFloatProperty($data['floatProperty']);
+                unset($data['floatProperty']);
+            }
+            if (\array_key_exists('arrayProperty', $data)) {
+                $values = [];
+                foreach ($data['arrayProperty'] as $value) {
+                    $values[] = $value;
+                }
+                $object->setArrayProperty($values);
+                unset($data['arrayProperty']);
+            }
+            if (\array_key_exists('mapProperty', $data)) {
+                $values_1 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
+                foreach ($data['mapProperty'] as $key => $value_1) {
+                    $values_1[$key] = $value_1;
+                }
+                $object->setMapProperty($values_1);
+                unset($data['mapProperty']);
+            }
+            if (\array_key_exists('objectProperty', $data)) {
+                $object->setObjectProperty($this->denormalizer->denormalize($data['objectProperty'], \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class, 'json', $context));
+                unset($data['objectProperty']);
+            }
+            if (\array_key_exists('objectRefProperty', $data)) {
+                $object->setObjectRefProperty($this->denormalizer->denormalize($data['objectRefProperty'], \Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class, 'json', $context));
+                unset($data['objectRefProperty']);
+            }
+            foreach ($data as $key_1 => $value_2) {
+                if (preg_match('/.*/', (string) $key_1)) {
+                    $object[$key_1] = $value_2;
+                }
+            }
+            return $object;
+        }
+        /**
+         * @return array|string|int|float|bool|\ArrayObject|null
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $data = [];
+            if ($object->isInitialized('stringProperty') && null !== $object->getStringProperty()) {
+                $data['stringProperty'] = $object->getStringProperty();
+            }
+            if ($object->isInitialized('dateProperty') && null !== $object->getDateProperty()) {
+                $data['dateProperty'] = $object->getDateProperty()?->format('Y-m-d\TH:i:sP');
+            }
+            if ($object->isInitialized('integerProperty') && null !== $object->getIntegerProperty()) {
+                $data['integerProperty'] = $object->getIntegerProperty();
+            }
+            if ($object->isInitialized('floatProperty') && null !== $object->getFloatProperty()) {
+                $data['floatProperty'] = $object->getFloatProperty();
+            }
+            if ($object->isInitialized('arrayProperty') && null !== $object->getArrayProperty()) {
+                $values = [];
+                foreach ($object->getArrayProperty() as $value) {
+                    $values[] = $value;
+                }
+                $data['arrayProperty'] = $values;
+            }
+            if ($object->isInitialized('mapProperty') && null !== $object->getMapProperty()) {
+                $values_1 = [];
+                foreach ($object->getMapProperty() as $key => $value_1) {
+                    $values_1[$key] = $value_1;
+                }
+                $data['mapProperty'] = $values_1;
+            }
+            if ($object->isInitialized('objectProperty') && null !== $object->getObjectProperty()) {
+                $data['objectProperty'] = $this->normalizer->normalize($object->getObjectProperty(), 'json', $context);
+            }
+            if ($object->isInitialized('objectRefProperty') && null !== $object->getObjectRefProperty()) {
+                $data['objectRefProperty'] = $this->normalizer->normalize($object->getObjectRefProperty(), 'json', $context);
+            }
+            foreach ($object as $key_1 => $value_2) {
+                if (preg_match('/.*/', (string) $key_1)) {
+                    $data[$key_1] = $value_2;
+                }
+            }
+            return $data;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi3\Tests\Expected\Model\Schema::class => false];
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Normalizer/SchemaObjectPropertyNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Normalizer/SchemaObjectPropertyNormalizer.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\HttpKernel\Kernel;
+if (!class_exists(Kernel::class) or (Kernel::MAJOR_VERSION >= 7 or Kernel::MAJOR_VERSION === 6 and Kernel::MINOR_VERSION === 4)) {
+    class SchemaObjectPropertyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+    {
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class;
+        }
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class;
+        }
+        public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty();
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('stringProperty', $data)) {
+                $object->setStringProperty($data['stringProperty']);
+                unset($data['stringProperty']);
+            }
+            foreach ($data as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $object[$key] = $value;
+                }
+            }
+            return $object;
+        }
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $data = [];
+            if ($object->isInitialized('stringProperty') && null !== $object->getStringProperty()) {
+                $data['stringProperty'] = $object->getStringProperty();
+            }
+            foreach ($object as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $data[$key] = $value;
+                }
+            }
+            return $data;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class => false];
+        }
+    }
+} else {
+    class SchemaObjectPropertyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+    {
+        use DenormalizerAwareTrait;
+        use NormalizerAwareTrait;
+        use CheckArray;
+        use ValidatorTrait;
+        public function supportsDenormalization($data, $type, string $format = null, array $context = []): bool
+        {
+            return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class;
+        }
+        public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+        {
+            return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class;
+        }
+        /**
+         * @return mixed
+         */
+        public function denormalize($data, $type, $format = null, array $context = [])
+        {
+            if (isset($data['$ref'])) {
+                return new Reference($data['$ref'], $context['document-origin']);
+            }
+            if (isset($data['$recursiveRef'])) {
+                return new Reference($data['$recursiveRef'], $context['document-origin']);
+            }
+            $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty();
+            if (null === $data || false === \is_array($data)) {
+                return $object;
+            }
+            if (\array_key_exists('stringProperty', $data)) {
+                $object->setStringProperty($data['stringProperty']);
+                unset($data['stringProperty']);
+            }
+            foreach ($data as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $object[$key] = $value;
+                }
+            }
+            return $object;
+        }
+        /**
+         * @return array|string|int|float|bool|\ArrayObject|null
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $data = [];
+            if ($object->isInitialized('stringProperty') && null !== $object->getStringProperty()) {
+                $data['stringProperty'] = $object->getStringProperty();
+            }
+            foreach ($object as $key => $value) {
+                if (preg_match('/.*/', (string) $key)) {
+                    $data[$key] = $value;
+                }
+            }
+            return $data;
+        }
+        public function getSupportedTypes(?string $format = null): array
+        {
+            return [\Jane\Component\OpenApi3\Tests\Expected\Model\SchemaObjectProperty::class => false];
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected $formParameters = [];
+    protected $queryParameters = [];
+    protected $headerParameters = [];
+    protected $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(function ($value) {
+            return null !== $value ? $value : '';
+        }, $optionsResolved);
+        return http_build_query($optionsResolved, '', '&', PHP_QUERY_RFC3986);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Client.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    /**
+     * @var ClientInterface
+     */
+    protected $httpClient;
+    /**
+     * @var RequestFactoryInterface
+     */
+    protected $requestFactory;
+    /**
+     * @var SerializerInterface
+     */
+    protected $serializer;
+    /**
+     * @var StreamFactoryInterface
+     */
+    protected $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = false === strpos($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+if (Kernel::MAJOR_VERSION >= 7 || Kernel::MAJOR_VERSION === 6 && Kernel::MINOR_VERSION === 4) {
+    class ReferenceNormalizer implements NormalizerInterface
+    {
+        /**
+         * {@inheritdoc}
+         */
+        public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+        {
+            $ref = [];
+            $ref['$ref'] = (string) $object->getReferenceUri();
+            return $ref;
+        }
+        /**
+         * {@inheritdoc}
+         * @param mixed $data
+         * @param null $format
+         * @param array $context
+         */
+        public function supportsNormalization($data, $format = null, array $context = []): bool
+        {
+            return $data instanceof Reference;
+        }
+        public function getSupportedTypes(?string $format): array
+        {
+            return [Reference::class => false];
+        }
+    }
+} else {
+    class ReferenceNormalizer implements NormalizerInterface
+    {
+        /**
+         * {@inheritdoc}
+         */
+        public function normalize($object, $format = null, array $context = [])
+        {
+            $ref = [];
+            $ref['$ref'] = (string) $object->getReferenceUri();
+            return $ref;
+        }
+        /**
+         * {@inheritdoc}
+         */
+        public function supportsNormalization($data, $format = null): bool
+        {
+            return $data instanceof Reference;
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    /** @var ConstraintViolationListInterface */
+    private $violationList;
+    public function __construct(ConstraintViolationListInterface $violationList)
+    {
+        $this->violationList = $violationList;
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/swagger.json
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/swagger.json
@@ -1,0 +1,93 @@
+{
+    "openapi": "3.0.0",
+    "paths": {
+        "/test-simple": {
+            "post": {
+                "operationId": "MimeType generated valid doc block",
+                "responses": {
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "tags": [
+                    "Test"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+    },
+    "info": {
+        "version": "",
+        "title": ""
+    },
+    "components": {
+        "schemas": {
+            "Schema": {
+                "type": "object",
+                "properties": {
+                    "stringProperty": {
+                        "type": "string"
+                    },
+                    "dateProperty": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "integerProperty": {
+                        "type": "integer"
+                    },
+                    "floatProperty": {
+                        "type": "number"
+                    },
+                    "arrayProperty": {
+                        "type": "array",
+                        "items": {
+                        }
+                    },
+                    "mapProperty": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "objectProperty": {
+                        "type": "object",
+                        "properties": {
+                            "stringProperty": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "objectRefProperty": {
+                        "$ref": "#/components/schemas/Schema"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes [810](https://github.com/janephp/janephp/issues/810) by escaping `*/*` with `*\\/*`
