### PR TITLE
use json serializer instead of json_encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Jane] [GH#856](https://github.com/janephp/janephp/pull/856) Modernize bundle configuration
 - [Jane] [GH#857](https://github.com/janephp/janephp/pull/857) Modernize classes
 - [Jane] [GH#827](https://github.com/janephp/janephp/pull/827) Make doctypes with less whitespace and unnecessary new lines
+- [OpenApi3] [GH#864](https://github.com/janephp/janephp/pull/864) Use serializer rather than `json_encode` in generated `getBody` for requests
 
 ### Fixed
 - [JsonSchema] [GH#841](https://github.com/janephp/janephp/pull/841) Fix "nullable" property handing in generated normalizers

--- a/src/Component/OpenApi3/Generator/RequestBodyContent/JsonBodyContentGenerator.php
+++ b/src/Component/OpenApi3/Generator/RequestBodyContent/JsonBodyContentGenerator.php
@@ -6,7 +6,6 @@ use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\OpenApi3\JsonSchema\Model\MediaType;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
-use PhpParser\Node;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt;
 
@@ -23,27 +22,6 @@ class JsonBodyContentGenerator extends AbstractBodyContentGenerator
 
     public function getSerializeStatements(MediaType $content, string $contentType, string $reference, Context $context): array
     {
-        $schema = $content->getSchema();
-        $classGuess = $this->guessClass->guessClass($schema, $reference . '/schema', $context->getRegistry(), $array);
-
-        if (null === $classGuess) {
-            return [new Stmt\Return_(new Expr\Array_([
-                new Expr\Array_([
-                    new Expr\ArrayItem(
-                        new Expr\Array_([new Expr\ArrayItem(new Scalar\String_($contentType))]),
-                        new Scalar\String_('Content-Type')
-                    ),
-                ]),
-                new Expr\MethodCall(
-                    new Expr\Variable('serializer'),
-                    new Node\Identifier('serialize'),
-                    [
-                        new Node\Arg(new Expr\PropertyFetch(new Expr\Variable('this'), new Node\Identifier('body'))),
-                        new Node\Arg(new Scalar\String_('json')),
-                    ]
-                ),
-            ]))];
-        }
 
         return [new Stmt\Return_(new Expr\Array_([
             new Expr\Array_([

--- a/src/Component/OpenApi3/Generator/RequestBodyContent/JsonBodyContentGenerator.php
+++ b/src/Component/OpenApi3/Generator/RequestBodyContent/JsonBodyContentGenerator.php
@@ -22,7 +22,6 @@ class JsonBodyContentGenerator extends AbstractBodyContentGenerator
 
     public function getSerializeStatements(MediaType $content, string $contentType, string $reference, Context $context): array
     {
-
         return [new Stmt\Return_(new Expr\Array_([
             new Expr\Array_([
                 new Expr\ArrayItem(

--- a/src/Component/OpenApi3/Generator/RequestBodyContent/JsonBodyContentGenerator.php
+++ b/src/Component/OpenApi3/Generator/RequestBodyContent/JsonBodyContentGenerator.php
@@ -6,7 +6,7 @@ use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\OpenApi3\JsonSchema\Model\MediaType;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Name;
+use PhpParser\Node;
 use PhpParser\Node\Scalar;
 use PhpParser\Node\Stmt;
 
@@ -34,9 +34,14 @@ class JsonBodyContentGenerator extends AbstractBodyContentGenerator
                         new Scalar\String_('Content-Type')
                     ),
                 ]),
-                new Expr\FuncCall(new Name('json_encode'), [
-                    new Arg(new Expr\PropertyFetch(new Expr\Variable('this'), 'body')),
-                ]),
+                new Expr\MethodCall(
+                    new Expr\Variable('serializer'),
+                    new Node\Identifier('serialize'),
+                    [
+                        new Node\Arg(new Expr\PropertyFetch(new Expr\Variable('this'), new Node\Identifier('body'))),
+                        new Node\Arg(new Scalar\String_('json')),
+                    ]
+                ),
             ]))];
         }
 

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Endpoint/TestMixedRequestBody.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Endpoint/TestMixedRequestBody.php
@@ -23,7 +23,7 @@ class TestMixedRequestBody extends \Jane\Component\OpenApi3\Tests\Expected\Runti
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (isset($this->body)) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
@@ -23,7 +23,7 @@ class BodyParameterTriggersContentTypeBeingSet extends \Jane\Component\OpenApi3\
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_string($this->body)) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsCreateCard.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ProjectsCreateCard.php
@@ -29,7 +29,7 @@ class ProjectsCreateCard extends \Github\Runtime\Client\BaseEndpoint implements 
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (isset($this->body)) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposAddAppAccessRestrictions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposAddAppAccessRestrictions.php
@@ -39,7 +39,7 @@ class ReposAddAppAccessRestrictions extends \Github\Runtime\Client\BaseEndpoint 
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposAddStatusCheckContexts.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposAddStatusCheckContexts.php
@@ -33,7 +33,7 @@ class ReposAddStatusCheckContexts extends \Github\Runtime\Client\BaseEndpoint im
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposAddTeamAccessRestrictions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposAddTeamAccessRestrictions.php
@@ -39,7 +39,7 @@ class ReposAddTeamAccessRestrictions extends \Github\Runtime\Client\BaseEndpoint
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposAddUserAccessRestrictions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposAddUserAccessRestrictions.php
@@ -39,7 +39,7 @@ class ReposAddUserAccessRestrictions extends \Github\Runtime\Client\BaseEndpoint
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposRemoveAppAccessRestrictions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposRemoveAppAccessRestrictions.php
@@ -39,7 +39,7 @@ class ReposRemoveAppAccessRestrictions extends \Github\Runtime\Client\BaseEndpoi
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposRemoveStatusCheckContexts.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposRemoveStatusCheckContexts.php
@@ -33,7 +33,7 @@ class ReposRemoveStatusCheckContexts extends \Github\Runtime\Client\BaseEndpoint
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposRemoveTeamAccessRestrictions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposRemoveTeamAccessRestrictions.php
@@ -39,7 +39,7 @@ class ReposRemoveTeamAccessRestrictions extends \Github\Runtime\Client\BaseEndpo
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposRemoveUserAccessRestrictions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposRemoveUserAccessRestrictions.php
@@ -39,7 +39,7 @@ class ReposRemoveUserAccessRestrictions extends \Github\Runtime\Client\BaseEndpo
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposSetAppAccessRestrictions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposSetAppAccessRestrictions.php
@@ -39,7 +39,7 @@ class ReposSetAppAccessRestrictions extends \Github\Runtime\Client\BaseEndpoint 
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposSetStatusCheckContexts.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposSetStatusCheckContexts.php
@@ -33,7 +33,7 @@ class ReposSetStatusCheckContexts extends \Github\Runtime\Client\BaseEndpoint im
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposSetTeamAccessRestrictions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposSetTeamAccessRestrictions.php
@@ -39,7 +39,7 @@ class ReposSetTeamAccessRestrictions extends \Github\Runtime\Client\BaseEndpoint
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposSetUserAccessRestrictions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposSetUserAccessRestrictions.php
@@ -39,7 +39,7 @@ class ReposSetUserAccessRestrictions extends \Github\Runtime\Client\BaseEndpoint
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_array($this->body) and isset($this->body[0]) and is_array($this->body[0])) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersAddEmailForAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersAddEmailForAuthenticated.php
@@ -24,7 +24,7 @@ class UsersAddEmailForAuthenticated extends \Github\Runtime\Client\BaseEndpoint 
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (isset($this->body)) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersDeleteEmailForAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersDeleteEmailForAuthenticated.php
@@ -24,7 +24,7 @@ class UsersDeleteEmailForAuthenticated extends \Github\Runtime\Client\BaseEndpoi
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (isset($this->body)) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/RunDecisionTree.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/RunDecisionTree.php
@@ -37,7 +37,7 @@ class RunDecisionTree extends \CreditSafe\API\Runtime\Client\BaseEndpoint implem
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if ($this->body instanceof \stdClass) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/OutputFormatSetDownloadFileNamePatterns.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/OutputFormatSetDownloadFileNamePatterns.php
@@ -27,7 +27,7 @@ class OutputFormatSetDownloadFileNamePatterns extends \PicturePark\API\Runtime\C
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if ($this->body instanceof \stdClass) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Endpoint/PostFoo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Endpoint/PostFoo.php
@@ -23,7 +23,7 @@ class PostFoo extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Bas
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (isset($this->body)) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Endpoint/MimeTypeGeneratedValidDocBlock.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Endpoint/MimeTypeGeneratedValidDocBlock.php
@@ -26,7 +26,7 @@ class MimeTypeGeneratedValidDocBlock extends \Jane\Component\OpenApi3\Tests\Expe
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_string($this->body)) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/AddOrDeleteRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/AddOrDeleteRules.php
@@ -31,7 +31,7 @@ class AddOrDeleteRules extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\C
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (isset($this->body)) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/AddOrDeleteRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/AddOrDeleteRules.php
@@ -31,7 +31,7 @@ class AddOrDeleteRules extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\Base
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (isset($this->body)) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/AddOrDeleteRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/AddOrDeleteRules.php
@@ -31,7 +31,7 @@ class AddOrDeleteRules extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\C
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (isset($this->body)) {
-            return [['Content-Type' => ['application/json']], json_encode($this->body)];
+            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }


### PR DESCRIPTION
its already available and will handle a few more cases.
I can see that `BaseEndpoint` has a `getSerializedBody` which is used for object parameters and is pretty similar. maybe the should be combined - but currently getBody is also doing some typechecking so thought I'd leave that