### PR TITLE
Handle any content-type starting with application/json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [OpenApi3] [GH#862](https://github.com/janephp/janephp/pull/862) Fix [GH#828](https://github.com/janephp/janephp/issues/828) with simpler array type check
 - [OpenApi3] [GH#874](https://github.com/janephp/janephp/pull/874) Fix error for anyOf in endpoint parameters
 - [JsonSchema] [GH#877](https://github.com/janephp/janephp/pull/877) Do no generate a MinLength constraint when value is zero
+- [OpenApi3] [GH#878](https://github.com/janephp/janephp/pull/878) Handle any content-type starting with application/json
 
 ## [7.9.0] - 2025-04-17
 ### Added

--- a/src/Component/OpenApi3/Generator/RequestBodyGenerator.php
+++ b/src/Component/OpenApi3/Generator/RequestBodyGenerator.php
@@ -112,9 +112,9 @@ class RequestBodyGenerator
         foreach ($requestBody->getContent() as $contentType => $content) {
             $generator = $this->defaultRequestBodyGenerator;
 
-            if (isset($this->generators[$contentType])) {
+            if (\array_key_exists($contentType, $this->generators)) {
                 $generator = $this->generators[$contentType];
-            } elseif (str_ends_with($contentType, '+json')) {
+            } elseif (str_starts_with($contentType, 'application/json') || str_ends_with($contentType, '+json')) {
                 $generator = $this->generators['application/json'];
             }
 

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Endpoint/BodyParameterTriggersContentTypeBeingSet.php
@@ -23,7 +23,7 @@ class BodyParameterTriggersContentTypeBeingSet extends \Jane\Component\OpenApi3\
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
         if (is_string($this->body)) {
-            return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+            return [['Content-Type' => ['application/json;charset=utf-8']], $serializer->serialize($this->body, 'json')];
         }
         return [[], null];
     }

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/swagger.json
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/swagger.json
@@ -14,7 +14,7 @@
                 ],
                 "requestBody": {
                     "content": {
-                        "application/json": {
+                        "application/json;charset=utf-8": {
                             "schema": {
                                 "type": "string"
                             }


### PR DESCRIPTION
Fixes #767

When we have content type as following: `application/json`, it is working fine. But when we include charset (which is valid) as following: `application/json; charset=utf8` it didn't work before.

This PR solves this.