### PR TITLE
Fix version constraint for symfony 8

### DIFF
--- a/src/Bundle/JsonSchemaBundle/composer.json
+++ b/src/Bundle/JsonSchemaBundle/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "conflict": {
         "symfony/framework-bundle": "5.1.0"

--- a/src/Bundle/OpenApiBundle/composer.json
+++ b/src/Bundle/OpenApiBundle/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "conflict": {
         "symfony/framework-bundle": "5.1.0"

--- a/src/Component/JsonSchema/composer.json
+++ b/src/Component/JsonSchema/composer.json
@@ -31,17 +31,17 @@
         "doctrine/inflector": "^1.4 || ^2.0",
         "jane-php/json-schema-runtime": "^7.5",
         "nikic/php-parser": "^4.19 || ^5.1",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/options-resolver": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/serializer": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/validator": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/console": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/options-resolver": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/serializer": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/validator": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "symfony/finder": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/finder": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "suggest": {
         "friendsofphp/php-cs-fixer": "Allow to automatically fix cs on generated code for better visualisation"

--- a/src/Component/JsonSchemaRuntime/composer.json
+++ b/src/Component/JsonSchemaRuntime/composer.json
@@ -26,8 +26,8 @@
         "ext-json": "*",
         "league/uri": "^6.7.2 || ^7.4",
         "php-jsonpointer/php-jsonpointer": "^3.0 || ^4.0",
-        "symfony/serializer": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/serializer": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5"

--- a/src/Component/OpenApi2/composer.json
+++ b/src/Component/OpenApi2/composer.json
@@ -38,12 +38,12 @@
         "jane-php/open-api-common": "^7.5",
         "nikic/php-parser": "^4.19 || ^5.1",
         "nyholm/psr7": "^1.8",
-        "symfony/serializer": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/serializer": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "symfony/finder": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/finder": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "suggest": {
         "friendsofphp/php-cs-fixer": "To have a nice formatting of the generated files"

--- a/src/Component/OpenApi3/composer.json
+++ b/src/Component/OpenApi3/composer.json
@@ -37,12 +37,12 @@
         "jane-php/json-schema": "^7.5",
         "jane-php/open-api-common": "^7.5",
         "nikic/php-parser": "^4.19 || ^5.1",
-        "symfony/serializer": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/serializer": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "symfony/finder": "^5.4 || ^6.4 || ^7.0 || 8.0",
+        "symfony/finder": "^5.4 || ^6.4 || ^7.0 || ^8.0",
         "kriswallsmith/buzz": "^1.2",
         "nyholm/psr7": "^1.8"
     },

--- a/src/Component/OpenApiCommon/composer.json
+++ b/src/Component/OpenApiCommon/composer.json
@@ -30,10 +30,10 @@
         "jane-php/json-schema": "^7.5",
         "jane-php/open-api-runtime": "^7.0",
         "nyholm/psr7": "^1.8",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/string": "^5.4 || ^6.4 || ^7.0 || 8.0",
-        "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/console": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/filesystem": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/string": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/var-dumper": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "extra": {
         "branch-alias": {

--- a/src/Component/OpenApiRuntime/composer.json
+++ b/src/Component/OpenApiRuntime/composer.json
@@ -30,11 +30,11 @@
         "php-http/multipart-stream-builder": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "symfony/options-resolver": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/options-resolver": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5",
-        "symfony/serializer": "^5.4 || ^6.4 || ^7.0 || 8.0"
+        "symfony/serializer": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
As mentioned in https://github.com/janephp/janephp/pull/871#discussion_r2597904717 symfony 8 was pinned to `8.0` by accident.

This PR changes the affected version constraints from `8.0` to `^8.0`.