### PR TITLE
Add support for object type in query parameters

### DIFF
--- a/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
@@ -195,6 +195,7 @@ class NonBodyParameterGenerator extends ParameterGenerator
             'boolean' => ['bool'],
             'integer' => ['int'],
             'array' => ['array'],
+            'object' => ['array'],
             'file' => ['string', 'resource', '\\' . StreamInterface::class],
         ];
 

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php
@@ -134,6 +134,18 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\TestDictionary($queryParameters), $fetch);
     }
+    /**
+     * @param array $queryParameters {
+     *     @var array $filter
+     * }
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     */
+    public function testObjectQuery(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\TestObjectQuery($queryParameters), $fetch);
+    }
     public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
         if (null === $httpClient) {

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestObjectQuery.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestObjectQuery.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class TestObjectQuery extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    /**
+     * @param array $queryParameters {
+     *     @var array $filter
+     * }
+     */
+    public function __construct(array $queryParameters = [])
+    {
+        $this->queryParameters = $queryParameters;
+    }
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/test-object-query';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(['filter']);
+        $optionsResolver->setRequired([]);
+        $optionsResolver->setDefaults([]);
+        $optionsResolver->addAllowedTypes('filter', ['array']);
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (200 === $status) {
+            return null;
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/swagger.json
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/swagger.json
@@ -345,6 +345,38 @@
                     }
                 ]
             }
+        },
+        "/test-object-query": {
+            "get": {
+                "tags": [
+                    "example"
+                ],
+                "operationId": "testObjectQuery",
+                "parameters": [
+                    {
+                        "name": "filter",
+                        "in": "query",
+                        "style": "deepObject",
+                        "explode": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "from": {
+                                    "type": "string"
+                                },
+                                "to": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                }
+            }
         }
     },
     "info": {


### PR DESCRIPTION
## Summary

Add support for `object` type in query parameters (e.g., `style: deepObject`).

Previously, using a query parameter with `type: object` would cause a fatal error:
```
TypeError: Return value must be of type array, null returned in NonBodyParameterGenerator.php
```

This is common when using OpenAPI 3.0 `deepObject` style for filtering:
```yaml
parameters:
  - name: filter
    in: query
    style: deepObject
    explode: true
    schema:
      type: object
      properties:
        from:
          type: string
        to:
          type: string
```

## Changes

- Added `'object' => ['array']` mapping in `NonBodyParameterGenerator::convertParameterType()`
- Added test fixture for object query parameter with `deepObject` style

## Result

Object type query parameters now correctly map to PHP `array` type:
```php
$optionsResolver->addAllowedTypes('filter', ['array']);
```