### PR TITLE
Switch to new documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [Jane] [GH#894](https://github.com/janephp/janephp/pull/894) New documentation with MkDocs & Mike (available at: https://jane.jolicode.com/)
+
+### Changed
+- [Jane] [GH#894](https://github.com/janephp/janephp/pull/894) Improved tooling to use [castor](https://castor.jolicode.com/)
 
 ## [7.10.3] - 2025-12-24
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Documentation
 
-[Documentation is available at http://jane.readthedocs.io/en/latest/](http://jane.readthedocs.io/en/latest/)
+[Documentation is available at https://jane.jolicode.com/](https://jane.jolicode.com/)
 
 ## Changes
 

--- a/src/Component/JsonSchema/README.md
+++ b/src/Component/JsonSchema/README.md
@@ -8,11 +8,11 @@ View the [LICENSE](LICENSE) file attach to this project.
 
 ## Resources
 
- * [Documentation](http://jane.readthedocs.io/en/latest/)
+ * [Documentation](https://jane.jolicode.com/)
  * [Contributing](https://github.com/janephp/janephp/blob/master/CONTRIBUTING.md)
- * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls) 
+ * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls)
  in the [main Jane Repository](https://github.com/janephp/janephp)
- 
+
 ## Sponsor
 
 [![JoliCode](https://jolicode.com/images/logo.svg)](https://jolicode.com)

--- a/src/Component/JsonSchemaRuntime/README.md
+++ b/src/Component/JsonSchemaRuntime/README.md
@@ -8,11 +8,11 @@ View the [LICENSE](LICENSE) file attach to this project.
 
 ## Resources
 
- * [Documentation](http://jane.readthedocs.io/en/latest/)
+ * [Documentation](https://jane.jolicode.com/)
  * [Contributing](https://github.com/janephp/janephp/blob/master/CONTRIBUTING.md)
- * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls) 
+ * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls)
  in the [main Jane Repository](https://github.com/janephp/janephp)
- 
+
 ## Sponsor
 
 [![JoliCode](https://jolicode.com/images/logo.svg)](https://jolicode.com)

--- a/src/Component/OpenApi2/README.md
+++ b/src/Component/OpenApi2/README.md
@@ -8,11 +8,11 @@ View the [LICENSE](LICENSE) file attach to this project.
 
 ## Resources
 
- * [Documentation](http://jane.readthedocs.io/en/latest/)
+ * [Documentation](https://jane.jolicode.com/)
  * [Contributing](https://github.com/janephp/janephp/blob/master/CONTRIBUTING.md)
- * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls) 
+ * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls)
  in the [main Jane Repository](https://github.com/janephp/janephp)
- 
+
 ## Sponsor
 
 [![JoliCode](https://jolicode.com/images/logo.svg)](https://jolicode.com)

--- a/src/Component/OpenApi3/README.md
+++ b/src/Component/OpenApi3/README.md
@@ -8,11 +8,11 @@ View the [LICENSE](LICENSE) file attach to this project.
 
 ## Resources
 
- * [Documentation](http://jane.readthedocs.io/en/latest/)
+ * [Documentation](https://jane.jolicode.com/)
  * [Contributing](https://github.com/janephp/janephp/blob/master/CONTRIBUTING.md)
- * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls) 
+ * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls)
  in the [main Jane Repository](https://github.com/janephp/janephp)
- 
+
 ## Sponsor
 
 [![JoliCode](https://jolicode.com/images/logo.svg)](https://jolicode.com)

--- a/src/Component/OpenApiRuntime/README.md
+++ b/src/Component/OpenApiRuntime/README.md
@@ -8,11 +8,11 @@ View the [LICENSE](LICENSE) file attach to this project.
 
 ## Resources
 
- * [Documentation](http://jane.readthedocs.io/en/latest/)
+ * [Documentation](https://jane.jolicode.com/)
  * [Contributing](https://github.com/janephp/janephp/blob/master/CONTRIBUTING.md)
- * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls) 
+ * [Report Issues](https://github.com/janephp/janephp/issues) and [send Pull Requests](https://github.com/janephp/janephp/pulls)
  in the [main Jane Repository](https://github.com/janephp/janephp)
- 
+
 ## Sponsor
 
 [![JoliCode](https://jolicode.com/images/logo.svg)](https://jolicode.com)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates project to the new documentation site and records related tooling changes.
> 
> - Replace `readthedocs` links with `https://jane.jolicode.com/` in root and component `README`s
> - Add Unreleased changelog entries: new docs using MkDocs & Mike; tooling updated to use `castor`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bfff4a8f50a7a86c938a6c7bdd786b27e8d6b04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->