### PR TITLE
Fix lowercase class name suffix for inline properties in allOf schemas

### DIFF
--- a/src/Component/JsonSchema/Guesser/JsonSchema/AllOfGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/AllOfGuesser.php
@@ -83,7 +83,7 @@ class AllOfGuesser implements GuesserInterface, TypeGuesserInterface, ChainGuess
                 if (is_a($allOf, $this->getSchemaClass())) {
                     if ($allOf->getProperties()) {
                         foreach ($allOf->getProperties() as $key => $property) {
-                            $this->chainGuesser->guessClass($property, $name . $key, $reference . '/allOf/' . $allOfIndex . '/properties/' . $key, $registry);
+                            $this->chainGuesser->guessClass($property, $name . ucfirst($key), $reference . '/allOf/' . $allOfIndex . '/properties/' . $key, $registry);
                         }
                     }
                 }

--- a/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Model/Baz.php
+++ b/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Model/Baz.php
@@ -25,6 +25,10 @@ class Baz
      */
     protected $baz;
     /**
+     * @var BazInlineProperty
+     */
+    protected $inlineProperty;
+    /**
      * @return string
      */
     public function getFoo(): string
@@ -76,6 +80,24 @@ class Baz
     {
         $this->initialized['baz'] = true;
         $this->baz = $baz;
+        return $this;
+    }
+    /**
+     * @return BazInlineProperty
+     */
+    public function getInlineProperty(): BazInlineProperty
+    {
+        return $this->inlineProperty;
+    }
+    /**
+     * @param BazInlineProperty $inlineProperty
+     *
+     * @return self
+     */
+    public function setInlineProperty(BazInlineProperty $inlineProperty): self
+    {
+        $this->initialized['inlineProperty'] = true;
+        $this->inlineProperty = $inlineProperty;
         return $this;
     }
 }

--- a/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Model/BazInlineProperty.php
+++ b/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Model/BazInlineProperty.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests\Expected\Model;
+
+class BazInlineProperty
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $inline;
+    /**
+     * @return string
+     */
+    public function getInline(): string
+    {
+        return $this->inline;
+    }
+    /**
+     * @param string $inline
+     *
+     * @return self
+     */
+    public function setInline(string $inline): self
+    {
+        $this->initialized['inline'] = true;
+        $this->inline = $inline;
+        return $this;
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazInlinePropertyNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazInlinePropertyNormalizer.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\JsonSchema\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\JsonSchema\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class BazInlinePropertyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\JsonSchema\Tests\Expected\Model\BazInlineProperty::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof \Jane\Component\JsonSchema\Tests\Expected\Model\BazInlineProperty;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\JsonSchema\Tests\Expected\Model\BazInlineProperty();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (\array_key_exists('inline', $data)) {
+            $object->setInline($data['inline']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('inline') && null !== $data->getInline()) {
+            $dataArray['inline'] = $data->getInline();
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\JsonSchema\Tests\Expected\Model\BazInlineProperty::class => false];
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/BazNormalizer.php
@@ -40,6 +40,9 @@ class BazNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
         if (\array_key_exists('Baz', $data)) {
             $object->setBaz($this->denormalizer->denormalize($data['Baz'], \Jane\Component\JsonSchema\Tests\Expected\Model\BazBaz::class, 'json', $context));
         }
+        if (\array_key_exists('inlineProperty', $data)) {
+            $object->setInlineProperty($this->denormalizer->denormalize($data['inlineProperty'], \Jane\Component\JsonSchema\Tests\Expected\Model\BazInlineProperty::class, 'json', $context));
+        }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
@@ -53,6 +56,9 @@ class BazNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
         }
         if ($data->isInitialized('baz') && null !== $data->getBaz()) {
             $dataArray['Baz'] = $this->normalizer->normalize($data->getBaz(), 'json', $context);
+        }
+        if ($data->isInitialized('inlineProperty') && null !== $data->getInlineProperty()) {
+            $dataArray['inlineProperty'] = $this->normalizer->normalize($data->getInlineProperty(), 'json', $context);
         }
         return $dataArray;
     }

--- a/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/all-of/expected/Normalizer/JaneObjectNormalizer.php
@@ -33,6 +33,8 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         \Jane\Component\JsonSchema\Tests\Expected\Model\Baz::class => \Jane\Component\JsonSchema\Tests\Expected\Normalizer\BazNormalizer::class,
         
         \Jane\Component\JsonSchema\Tests\Expected\Model\BazBaz::class => \Jane\Component\JsonSchema\Tests\Expected\Normalizer\BazBazNormalizer::class,
+        
+        \Jane\Component\JsonSchema\Tests\Expected\Model\BazInlineProperty::class => \Jane\Component\JsonSchema\Tests\Expected\Normalizer\BazInlinePropertyNormalizer::class,
     ], $normalizersCache = [];
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
@@ -78,6 +80,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Component\JsonSchema\Tests\Expected\Model\Bar::class => false,
             \Jane\Component\JsonSchema\Tests\Expected\Model\Baz::class => false,
             \Jane\Component\JsonSchema\Tests\Expected\Model\BazBaz::class => false,
+            \Jane\Component\JsonSchema\Tests\Expected\Model\BazInlineProperty::class => false,
         ];
     }
 }

--- a/src/Component/JsonSchema/Tests/fixtures/all-of/schema.json
+++ b/src/Component/JsonSchema/Tests/fixtures/all-of/schema.json
@@ -81,6 +81,14 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "inlineProperty": {
+                            "type": "object",
+                            "properties": {
+                                "inline": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ApQueryQueryCriteria.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ApQueryQueryCriteria.php
@@ -15,25 +15,25 @@ class ApQueryQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @var list<ApQueryQueryCriteriafiltersItem>
+     * @var list<ApQueryQueryCriteriaFiltersItem>
      */
     protected $filters;
     /**
      * "AND" condition for multiple filters
      *
-     * @var list<ApQueryQueryCriteriaextraFiltersItem>
+     * @var list<ApQueryQueryCriteriaExtraFiltersItem>
      */
     protected $extraFilters;
     /**
      * "NOT" condition for multiple filters
      *
-     * @var list<ApQueryQueryCriteriaextraNotFiltersItem>
+     * @var list<ApQueryQueryCriteriaExtraNotFiltersItem>
      */
     protected $extraNotFilters;
     /**
      * specified feature required informaion
      *
-     * @var ApQueryQueryCriteriaoptions
+     * @var ApQueryQueryCriteriaOptions
      */
     protected $options;
     /**
@@ -89,7 +89,7 @@ class ApQueryQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @return list<ApQueryQueryCriteriafiltersItem>
+     * @return list<ApQueryQueryCriteriaFiltersItem>
      */
     public function getFilters(): array
     {
@@ -98,7 +98,7 @@ class ApQueryQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @param list<ApQueryQueryCriteriafiltersItem> $filters
+     * @param list<ApQueryQueryCriteriaFiltersItem> $filters
      *
      * @return self
      */
@@ -111,7 +111,7 @@ class ApQueryQueryCriteria
     /**
      * "AND" condition for multiple filters
      *
-     * @return list<ApQueryQueryCriteriaextraFiltersItem>
+     * @return list<ApQueryQueryCriteriaExtraFiltersItem>
      */
     public function getExtraFilters(): array
     {
@@ -120,7 +120,7 @@ class ApQueryQueryCriteria
     /**
      * "AND" condition for multiple filters
      *
-     * @param list<ApQueryQueryCriteriaextraFiltersItem> $extraFilters
+     * @param list<ApQueryQueryCriteriaExtraFiltersItem> $extraFilters
      *
      * @return self
      */
@@ -133,7 +133,7 @@ class ApQueryQueryCriteria
     /**
      * "NOT" condition for multiple filters
      *
-     * @return list<ApQueryQueryCriteriaextraNotFiltersItem>
+     * @return list<ApQueryQueryCriteriaExtraNotFiltersItem>
      */
     public function getExtraNotFilters(): array
     {
@@ -142,7 +142,7 @@ class ApQueryQueryCriteria
     /**
      * "NOT" condition for multiple filters
      *
-     * @param list<ApQueryQueryCriteriaextraNotFiltersItem> $extraNotFilters
+     * @param list<ApQueryQueryCriteriaExtraNotFiltersItem> $extraNotFilters
      *
      * @return self
      */
@@ -155,20 +155,20 @@ class ApQueryQueryCriteria
     /**
      * specified feature required informaion
      *
-     * @return ApQueryQueryCriteriaoptions
+     * @return ApQueryQueryCriteriaOptions
      */
-    public function getOptions(): ApQueryQueryCriteriaoptions
+    public function getOptions(): ApQueryQueryCriteriaOptions
     {
         return $this->options;
     }
     /**
      * specified feature required informaion
      *
-     * @param ApQueryQueryCriteriaoptions $options
+     * @param ApQueryQueryCriteriaOptions $options
      *
      * @return self
      */
-    public function setOptions(ApQueryQueryCriteriaoptions $options): self
+    public function setOptions(ApQueryQueryCriteriaOptions $options): self
     {
         $this->initialized['options'] = true;
         $this->options = $options;

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ApQueryQueryCriteriaextraFiltersItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ApQueryQueryCriteriaextraFiltersItem.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class ApQueryQueryCriteriaextraFiltersItem
+class ApQueryQueryCriteriaExtraFiltersItem
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ApQueryQueryCriteriaextraNotFiltersItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ApQueryQueryCriteriaextraNotFiltersItem.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class ApQueryQueryCriteriaextraNotFiltersItem
+class ApQueryQueryCriteriaExtraNotFiltersItem
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ApQueryQueryCriteriafiltersItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ApQueryQueryCriteriafiltersItem.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class ApQueryQueryCriteriafiltersItem
+class ApQueryQueryCriteriaFiltersItem
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ApQueryQueryCriteriaoptions.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ApQueryQueryCriteriaoptions.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class ApQueryQueryCriteriaoptions
+class ApQueryQueryCriteriaOptions
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/IdentityQueryCriteria.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/IdentityQueryCriteria.php
@@ -15,7 +15,7 @@ class IdentityQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @var list<IdentityQueryCriteriafiltersItem>
+     * @var list<IdentityQueryCriteriaFiltersItem>
      */
     protected $filters;
     /**
@@ -29,7 +29,7 @@ class IdentityQueryCriteria
     /**
      * Specified feature required information
      *
-     * @var IdentityQueryCriteriaoptions
+     * @var IdentityQueryCriteriaOptions
      */
     protected $options;
     /**
@@ -85,7 +85,7 @@ class IdentityQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @return list<IdentityQueryCriteriafiltersItem>
+     * @return list<IdentityQueryCriteriaFiltersItem>
      */
     public function getFilters(): array
     {
@@ -94,7 +94,7 @@ class IdentityQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @param list<IdentityQueryCriteriafiltersItem> $filters
+     * @param list<IdentityQueryCriteriaFiltersItem> $filters
      *
      * @return self
      */
@@ -143,20 +143,20 @@ class IdentityQueryCriteria
     /**
      * Specified feature required information
      *
-     * @return IdentityQueryCriteriaoptions
+     * @return IdentityQueryCriteriaOptions
      */
-    public function getOptions(): IdentityQueryCriteriaoptions
+    public function getOptions(): IdentityQueryCriteriaOptions
     {
         return $this->options;
     }
     /**
      * Specified feature required information
      *
-     * @param IdentityQueryCriteriaoptions $options
+     * @param IdentityQueryCriteriaOptions $options
      *
      * @return self
      */
-    public function setOptions(IdentityQueryCriteriaoptions $options): self
+    public function setOptions(IdentityQueryCriteriaOptions $options): self
     {
         $this->initialized['options'] = true;
         $this->options = $options;

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/IdentityQueryCriteriafiltersItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/IdentityQueryCriteriafiltersItem.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class IdentityQueryCriteriafiltersItem
+class IdentityQueryCriteriaFiltersItem
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/IdentityQueryCriteriaoptions.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/IdentityQueryCriteriaoptions.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class IdentityQueryCriteriaoptions
+class IdentityQueryCriteriaOptions
 {
     /**
      * @var array
@@ -39,7 +39,7 @@ class IdentityQueryCriteriaoptions
     /**
      * Audit time of local users
      *
-     * @var IdentityQueryCriteriaoptionsLocalUserAuditTime
+     * @var IdentityQueryCriteriaOptionsLocalUserAuditTime
      */
     protected $localUserAuditTime;
     /**
@@ -105,7 +105,7 @@ class IdentityQueryCriteriaoptions
     /**
      * Expiration time of guest pass
      *
-     * @var IdentityQueryCriteriaoptionsGuestPassExpiration
+     * @var IdentityQueryCriteriaOptionsGuestPassExpiration
      */
     protected $guestPassExpiration;
     /**
@@ -205,20 +205,20 @@ class IdentityQueryCriteriaoptions
     /**
      * Audit time of local users
      *
-     * @return IdentityQueryCriteriaoptionsLocalUserAuditTime
+     * @return IdentityQueryCriteriaOptionsLocalUserAuditTime
      */
-    public function getLocalUserAuditTime(): IdentityQueryCriteriaoptionsLocalUserAuditTime
+    public function getLocalUserAuditTime(): IdentityQueryCriteriaOptionsLocalUserAuditTime
     {
         return $this->localUserAuditTime;
     }
     /**
      * Audit time of local users
      *
-     * @param IdentityQueryCriteriaoptionsLocalUserAuditTime $localUserAuditTime
+     * @param IdentityQueryCriteriaOptionsLocalUserAuditTime $localUserAuditTime
      *
      * @return self
      */
-    public function setLocalUserAuditTime(IdentityQueryCriteriaoptionsLocalUserAuditTime $localUserAuditTime): self
+    public function setLocalUserAuditTime(IdentityQueryCriteriaOptionsLocalUserAuditTime $localUserAuditTime): self
     {
         $this->initialized['localUserAuditTime'] = true;
         $this->localUserAuditTime = $localUserAuditTime;
@@ -447,20 +447,20 @@ class IdentityQueryCriteriaoptions
     /**
      * Expiration time of guest pass
      *
-     * @return IdentityQueryCriteriaoptionsGuestPassExpiration
+     * @return IdentityQueryCriteriaOptionsGuestPassExpiration
      */
-    public function getGuestPassExpiration(): IdentityQueryCriteriaoptionsGuestPassExpiration
+    public function getGuestPassExpiration(): IdentityQueryCriteriaOptionsGuestPassExpiration
     {
         return $this->guestPassExpiration;
     }
     /**
      * Expiration time of guest pass
      *
-     * @param IdentityQueryCriteriaoptionsGuestPassExpiration $guestPassExpiration
+     * @param IdentityQueryCriteriaOptionsGuestPassExpiration $guestPassExpiration
      *
      * @return self
      */
-    public function setGuestPassExpiration(IdentityQueryCriteriaoptionsGuestPassExpiration $guestPassExpiration): self
+    public function setGuestPassExpiration(IdentityQueryCriteriaOptionsGuestPassExpiration $guestPassExpiration): self
     {
         $this->initialized['guestPassExpiration'] = true;
         $this->guestPassExpiration = $guestPassExpiration;

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/IdentityQueryCriteriaoptionsGuestPassExpiration.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/IdentityQueryCriteriaoptionsGuestPassExpiration.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class IdentityQueryCriteriaoptionsGuestPassExpiration
+class IdentityQueryCriteriaOptionsGuestPassExpiration
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/IdentityQueryCriteriaoptionsLocalUserAuditTime.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/IdentityQueryCriteriaoptionsLocalUserAuditTime.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class IdentityQueryCriteriaoptionsLocalUserAuditTime
+class IdentityQueryCriteriaOptionsLocalUserAuditTime
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ProfileFirewallProfileQueryCriteria.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ProfileFirewallProfileQueryCriteria.php
@@ -33,7 +33,7 @@ class ProfileFirewallProfileQueryCriteria
     /**
      * Specified feature required information.
      *
-     * @var ProfileFirewallProfileQueryCriteriaoptions
+     * @var ProfileFirewallProfileQueryCriteriaOptions
      */
     protected $options;
     /**
@@ -155,20 +155,20 @@ class ProfileFirewallProfileQueryCriteria
     /**
      * Specified feature required information.
      *
-     * @return ProfileFirewallProfileQueryCriteriaoptions
+     * @return ProfileFirewallProfileQueryCriteriaOptions
      */
-    public function getOptions(): ProfileFirewallProfileQueryCriteriaoptions
+    public function getOptions(): ProfileFirewallProfileQueryCriteriaOptions
     {
         return $this->options;
     }
     /**
      * Specified feature required information.
      *
-     * @param ProfileFirewallProfileQueryCriteriaoptions $options
+     * @param ProfileFirewallProfileQueryCriteriaOptions $options
      *
      * @return self
      */
-    public function setOptions(ProfileFirewallProfileQueryCriteriaoptions $options): self
+    public function setOptions(ProfileFirewallProfileQueryCriteriaOptions $options): self
     {
         $this->initialized['options'] = true;
         $this->options = $options;

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ProfileFirewallProfileQueryCriteriaoptions.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ProfileFirewallProfileQueryCriteriaoptions.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class ProfileFirewallProfileQueryCriteriaoptions
+class ProfileFirewallProfileQueryCriteriaOptions
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ProfileQueryCriteriaWithProfileId.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ProfileQueryCriteriaWithProfileId.php
@@ -21,7 +21,7 @@ class ProfileQueryCriteriaWithProfileId
     /**
      * "AND" condition for multiple filters
      *
-     * @var list<ProfileQueryCriteriaWithProfileIdextraFiltersItem>
+     * @var list<ProfileQueryCriteriaWithProfileIdExtraFiltersItem>
      */
     protected $extraFilters;
     /**
@@ -111,7 +111,7 @@ class ProfileQueryCriteriaWithProfileId
     /**
      * "AND" condition for multiple filters
      *
-     * @return list<ProfileQueryCriteriaWithProfileIdextraFiltersItem>
+     * @return list<ProfileQueryCriteriaWithProfileIdExtraFiltersItem>
      */
     public function getExtraFilters(): array
     {
@@ -120,7 +120,7 @@ class ProfileQueryCriteriaWithProfileId
     /**
      * "AND" condition for multiple filters
      *
-     * @param list<ProfileQueryCriteriaWithProfileIdextraFiltersItem> $extraFilters
+     * @param list<ProfileQueryCriteriaWithProfileIdExtraFiltersItem> $extraFilters
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ProfileQueryCriteriaWithProfileIdextraFiltersItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ProfileQueryCriteriaWithProfileIdextraFiltersItem.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class ProfileQueryCriteriaWithProfileIdextraFiltersItem
+class ProfileQueryCriteriaWithProfileIdExtraFiltersItem
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ScguserQueryCriteria.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ScguserQueryCriteria.php
@@ -15,7 +15,7 @@ class ScguserQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @var list<ScguserQueryCriteriafiltersItem>
+     * @var list<ScguserQueryCriteriaFiltersItem>
      */
     protected $filters;
     /**
@@ -83,7 +83,7 @@ class ScguserQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @return list<ScguserQueryCriteriafiltersItem>
+     * @return list<ScguserQueryCriteriaFiltersItem>
      */
     public function getFilters(): array
     {
@@ -92,7 +92,7 @@ class ScguserQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @param list<ScguserQueryCriteriafiltersItem> $filters
+     * @param list<ScguserQueryCriteriaFiltersItem> $filters
      *
      * @return self
      */

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ScguserQueryCriteriafiltersItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ScguserQueryCriteriafiltersItem.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class ScguserQueryCriteriafiltersItem
+class ScguserQueryCriteriaFiltersItem
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ZoneQueryCriteria.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ZoneQueryCriteria.php
@@ -15,13 +15,13 @@ class ZoneQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @var list<ZoneQueryCriteriafiltersItem>
+     * @var list<ZoneQueryCriteriaFiltersItem>
      */
     protected $filters;
     /**
      * "AND" condition for multiple filters
      *
-     * @var list<ZoneQueryCriteriaextraFiltersItem>
+     * @var list<ZoneQueryCriteriaExtraFiltersItem>
      */
     protected $extraFilters;
     /**
@@ -31,7 +31,7 @@ class ZoneQueryCriteria
     /**
      * Specified feature required information.
      *
-     * @var ZoneQueryCriteriaoptions
+     * @var ZoneQueryCriteriaOptions
      */
     protected $options;
     /**
@@ -87,7 +87,7 @@ class ZoneQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @return list<ZoneQueryCriteriafiltersItem>
+     * @return list<ZoneQueryCriteriaFiltersItem>
      */
     public function getFilters(): array
     {
@@ -96,7 +96,7 @@ class ZoneQueryCriteria
     /**
      * Filters used to select specific resource scope
      *
-     * @param list<ZoneQueryCriteriafiltersItem> $filters
+     * @param list<ZoneQueryCriteriaFiltersItem> $filters
      *
      * @return self
      */
@@ -109,7 +109,7 @@ class ZoneQueryCriteria
     /**
      * "AND" condition for multiple filters
      *
-     * @return list<ZoneQueryCriteriaextraFiltersItem>
+     * @return list<ZoneQueryCriteriaExtraFiltersItem>
      */
     public function getExtraFilters(): array
     {
@@ -118,7 +118,7 @@ class ZoneQueryCriteria
     /**
      * "AND" condition for multiple filters
      *
-     * @param list<ZoneQueryCriteriaextraFiltersItem> $extraFilters
+     * @param list<ZoneQueryCriteriaExtraFiltersItem> $extraFilters
      *
      * @return self
      */
@@ -149,20 +149,20 @@ class ZoneQueryCriteria
     /**
      * Specified feature required information.
      *
-     * @return ZoneQueryCriteriaoptions
+     * @return ZoneQueryCriteriaOptions
      */
-    public function getOptions(): ZoneQueryCriteriaoptions
+    public function getOptions(): ZoneQueryCriteriaOptions
     {
         return $this->options;
     }
     /**
      * Specified feature required information.
      *
-     * @param ZoneQueryCriteriaoptions $options
+     * @param ZoneQueryCriteriaOptions $options
      *
      * @return self
      */
-    public function setOptions(ZoneQueryCriteriaoptions $options): self
+    public function setOptions(ZoneQueryCriteriaOptions $options): self
     {
         $this->initialized['options'] = true;
         $this->options = $options;

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ZoneQueryCriteriaextraFiltersItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ZoneQueryCriteriaextraFiltersItem.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class ZoneQueryCriteriaextraFiltersItem
+class ZoneQueryCriteriaExtraFiltersItem
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ZoneQueryCriteriafiltersItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ZoneQueryCriteriafiltersItem.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class ZoneQueryCriteriafiltersItem
+class ZoneQueryCriteriaFiltersItem
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ZoneQueryCriteriaoptions.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Model/ZoneQueryCriteriaoptions.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Model;
 
-class ZoneQueryCriteriaoptions
+class ZoneQueryCriteriaOptions
 {
     /**
      * @var array

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryQueryCriteriaNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryQueryCriteriaNormalizer.php
@@ -43,26 +43,26 @@ class ApQueryQueryCriteriaNormalizer implements DenormalizerInterface, Normalize
         if (\array_key_exists('filters', $data)) {
             $values = [];
             foreach ($data['filters'] as $value) {
-                $values[] = $this->denormalizer->denormalize($value, \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriafiltersItem::class, 'json', $context);
+                $values[] = $this->denormalizer->denormalize($value, \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaFiltersItem::class, 'json', $context);
             }
             $object->setFilters($values);
         }
         if (\array_key_exists('extraFilters', $data)) {
             $values_1 = [];
             foreach ($data['extraFilters'] as $value_1) {
-                $values_1[] = $this->denormalizer->denormalize($value_1, \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraFiltersItem::class, 'json', $context);
+                $values_1[] = $this->denormalizer->denormalize($value_1, \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraFiltersItem::class, 'json', $context);
             }
             $object->setExtraFilters($values_1);
         }
         if (\array_key_exists('extraNotFilters', $data)) {
             $values_2 = [];
             foreach ($data['extraNotFilters'] as $value_2) {
-                $values_2[] = $this->denormalizer->denormalize($value_2, \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraNotFiltersItem::class, 'json', $context);
+                $values_2[] = $this->denormalizer->denormalize($value_2, \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraNotFiltersItem::class, 'json', $context);
             }
             $object->setExtraNotFilters($values_2);
         }
         if (\array_key_exists('options', $data)) {
-            $object->setOptions($this->denormalizer->denormalize($data['options'], \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaoptions::class, 'json', $context));
+            $object->setOptions($this->denormalizer->denormalize($data['options'], \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaOptions::class, 'json', $context));
         }
         if (\array_key_exists('extraTimeRange', $data)) {
             $object->setExtraTimeRange($this->denormalizer->denormalize($data['extraTimeRange'], \Jane\Component\OpenApi3\Tests\Expected\Model\CommonTimeRange::class, 'json', $context));

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryQueryCriteriaextraFiltersItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryQueryCriteriaextraFiltersItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ApQueryQueryCriteriaextraFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ApQueryQueryCriteriaExtraFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class ApQueryQueryCriteriaextraFiltersItemNormalizer implements DenormalizerInte
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraFiltersItem::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraFiltersItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraFiltersItem::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraFiltersItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class ApQueryQueryCriteriaextraFiltersItemNormalizer implements DenormalizerInte
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraFiltersItem();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraFiltersItem();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -64,6 +64,6 @@ class ApQueryQueryCriteriaextraFiltersItemNormalizer implements DenormalizerInte
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraFiltersItem::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraFiltersItem::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryQueryCriteriaextraNotFiltersItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryQueryCriteriaextraNotFiltersItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ApQueryQueryCriteriaextraNotFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ApQueryQueryCriteriaExtraNotFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class ApQueryQueryCriteriaextraNotFiltersItemNormalizer implements DenormalizerI
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraNotFiltersItem::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraNotFiltersItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraNotFiltersItem::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraNotFiltersItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class ApQueryQueryCriteriaextraNotFiltersItemNormalizer implements DenormalizerI
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraNotFiltersItem();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraNotFiltersItem();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -58,6 +58,6 @@ class ApQueryQueryCriteriaextraNotFiltersItemNormalizer implements DenormalizerI
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraNotFiltersItem::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraNotFiltersItem::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryQueryCriteriafiltersItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryQueryCriteriafiltersItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ApQueryQueryCriteriafiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ApQueryQueryCriteriaFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class ApQueryQueryCriteriafiltersItemNormalizer implements DenormalizerInterface
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriafiltersItem::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaFiltersItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriafiltersItem::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaFiltersItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class ApQueryQueryCriteriafiltersItemNormalizer implements DenormalizerInterface
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriafiltersItem();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaFiltersItem();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -64,6 +64,6 @@ class ApQueryQueryCriteriafiltersItemNormalizer implements DenormalizerInterface
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriafiltersItem::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaFiltersItem::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryQueryCriteriaoptionsNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryQueryCriteriaoptionsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ApQueryQueryCriteriaoptionsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ApQueryQueryCriteriaOptionsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class ApQueryQueryCriteriaoptionsNormalizer implements DenormalizerInterface, No
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaoptions::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaOptions::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaoptions::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaOptions::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class ApQueryQueryCriteriaoptionsNormalizer implements DenormalizerInterface, No
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaoptions();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaOptions();
         if (\array_key_exists('auth_includeNa', $data) && \is_int($data['auth_includeNa'])) {
             $data['auth_includeNa'] = (bool) $data['auth_includeNa'];
         }
@@ -208,6 +208,6 @@ class ApQueryQueryCriteriaoptionsNormalizer implements DenormalizerInterface, No
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaoptions::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaOptions::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaNormalizer.php
@@ -43,7 +43,7 @@ class IdentityQueryCriteriaNormalizer implements DenormalizerInterface, Normaliz
         if (\array_key_exists('filters', $data)) {
             $values = [];
             foreach ($data['filters'] as $value) {
-                $values[] = $this->denormalizer->denormalize($value, \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriafiltersItem::class, 'json', $context);
+                $values[] = $this->denormalizer->denormalize($value, \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaFiltersItem::class, 'json', $context);
             }
             $object->setFilters($values);
         }
@@ -54,7 +54,7 @@ class IdentityQueryCriteriaNormalizer implements DenormalizerInterface, Normaliz
             $object->setExtraNotFilters($data['extraNotFilters']);
         }
         if (\array_key_exists('options', $data)) {
-            $object->setOptions($this->denormalizer->denormalize($data['options'], \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptions::class, 'json', $context));
+            $object->setOptions($this->denormalizer->denormalize($data['options'], \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptions::class, 'json', $context));
         }
         if (\array_key_exists('extraTimeRange', $data)) {
             $object->setExtraTimeRange($this->denormalizer->denormalize($data['extraTimeRange'], \Jane\Component\OpenApi3\Tests\Expected\Model\CommonTimeRange::class, 'json', $context));

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriafiltersItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriafiltersItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class IdentityQueryCriteriafiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class IdentityQueryCriteriaFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class IdentityQueryCriteriafiltersItemNormalizer implements DenormalizerInterfac
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriafiltersItem::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaFiltersItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriafiltersItem::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaFiltersItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class IdentityQueryCriteriafiltersItemNormalizer implements DenormalizerInterfac
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriafiltersItem();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaFiltersItem();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -60,6 +60,6 @@ class IdentityQueryCriteriafiltersItemNormalizer implements DenormalizerInterfac
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriafiltersItem::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaFiltersItem::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaoptionsGuestPassExpirationNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaoptionsGuestPassExpirationNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class IdentityQueryCriteriaoptionsGuestPassExpirationNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class IdentityQueryCriteriaOptionsGuestPassExpirationNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class IdentityQueryCriteriaoptionsGuestPassExpirationNormalizer implements Denor
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsGuestPassExpiration::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsGuestPassExpiration::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsGuestPassExpiration::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsGuestPassExpiration::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class IdentityQueryCriteriaoptionsGuestPassExpirationNormalizer implements Denor
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsGuestPassExpiration();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsGuestPassExpiration();
         if (\array_key_exists('start', $data) && \is_int($data['start'])) {
             $data['start'] = (double) $data['start'];
         }
@@ -73,6 +73,6 @@ class IdentityQueryCriteriaoptionsGuestPassExpirationNormalizer implements Denor
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsGuestPassExpiration::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsGuestPassExpiration::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaoptionsLocalUserAuditTimeNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaoptionsLocalUserAuditTimeNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class IdentityQueryCriteriaoptionsLocalUserAuditTimeNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class IdentityQueryCriteriaOptionsLocalUserAuditTimeNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class IdentityQueryCriteriaoptionsLocalUserAuditTimeNormalizer implements Denorm
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsLocalUserAuditTime::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsLocalUserAuditTime::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsLocalUserAuditTime::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsLocalUserAuditTime::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class IdentityQueryCriteriaoptionsLocalUserAuditTimeNormalizer implements Denorm
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsLocalUserAuditTime();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsLocalUserAuditTime();
         if (\array_key_exists('start', $data) && \is_int($data['start'])) {
             $data['start'] = (double) $data['start'];
         }
@@ -73,6 +73,6 @@ class IdentityQueryCriteriaoptionsLocalUserAuditTimeNormalizer implements Denorm
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsLocalUserAuditTime::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsLocalUserAuditTime::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaoptionsNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaoptionsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class IdentityQueryCriteriaoptionsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class IdentityQueryCriteriaOptionsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class IdentityQueryCriteriaoptionsNormalizer implements DenormalizerInterface, N
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptions::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptions::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptions::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptions::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class IdentityQueryCriteriaoptionsNormalizer implements DenormalizerInterface, N
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptions();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptions();
         if (\array_key_exists('includeSharedResources', $data) && \is_int($data['includeSharedResources'])) {
             $data['includeSharedResources'] = (bool) $data['includeSharedResources'];
         }
@@ -56,7 +56,7 @@ class IdentityQueryCriteriaoptionsNormalizer implements DenormalizerInterface, N
             $object->setGlobalFilterId($data['globalFilterId']);
         }
         if (\array_key_exists('localUser_auditTime', $data)) {
-            $object->setLocalUserAuditTime($this->denormalizer->denormalize($data['localUser_auditTime'], \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsLocalUserAuditTime::class, 'json', $context));
+            $object->setLocalUserAuditTime($this->denormalizer->denormalize($data['localUser_auditTime'], \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsLocalUserAuditTime::class, 'json', $context));
         }
         if (\array_key_exists('localUser_firstName', $data)) {
             $object->setLocalUserFirstName($data['localUser_firstName']);
@@ -89,7 +89,7 @@ class IdentityQueryCriteriaoptionsNormalizer implements DenormalizerInterface, N
             $object->setGuestPassDisplayName($data['guestPass_displayName']);
         }
         if (\array_key_exists('guestPass_expiration', $data)) {
-            $object->setGuestPassExpiration($this->denormalizer->denormalize($data['guestPass_expiration'], \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsGuestPassExpiration::class, 'json', $context));
+            $object->setGuestPassExpiration($this->denormalizer->denormalize($data['guestPass_expiration'], \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsGuestPassExpiration::class, 'json', $context));
         }
         if (\array_key_exists('guestPass_wlan', $data)) {
             $object->setGuestPassWlan($data['guestPass_wlan']);
@@ -154,6 +154,6 @@ class IdentityQueryCriteriaoptionsNormalizer implements DenormalizerInterface, N
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptions::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptions::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/JaneObjectNormalizer.php
@@ -28,7 +28,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteria::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ScguserQueryCriteriaNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriafiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ScguserQueryCriteriafiltersItemNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriaFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ScguserQueryCriteriaFiltersItemNormalizer::class,
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserScgUserList::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ScguserScgUserListNormalizer::class,
         
@@ -84,13 +84,13 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteria::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ApQueryQueryCriteriaNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriafiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ApQueryQueryCriteriafiltersItemNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ApQueryQueryCriteriaFiltersItemNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ApQueryQueryCriteriaextraFiltersItemNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ApQueryQueryCriteriaExtraFiltersItemNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraNotFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ApQueryQueryCriteriaextraNotFiltersItemNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraNotFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ApQueryQueryCriteriaExtraNotFiltersItemNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaoptions::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ApQueryQueryCriteriaoptionsNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaOptions::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ApQueryQueryCriteriaOptionsNormalizer::class,
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryApQueryList::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ApQueryApQueryListNormalizer::class,
         
@@ -366,7 +366,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileId::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ProfileQueryCriteriaWithProfileIdNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdextraFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ProfileQueryCriteriaWithProfileIdextraFiltersItemNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdExtraFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ProfileQueryCriteriaWithProfileIdExtraFiltersItemNormalizer::class,
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileAccountingProfileList::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ProfileAccountingProfileListNormalizer::class,
         
@@ -528,13 +528,13 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteria::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\IdentityQueryCriteriaNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriafiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\IdentityQueryCriteriafiltersItemNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\IdentityQueryCriteriaFiltersItemNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptions::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\IdentityQueryCriteriaoptionsNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptions::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\IdentityQueryCriteriaOptionsNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsLocalUserAuditTime::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\IdentityQueryCriteriaoptionsLocalUserAuditTimeNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsLocalUserAuditTime::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\IdentityQueryCriteriaOptionsLocalUserAuditTimeNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsGuestPassExpiration::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\IdentityQueryCriteriaoptionsGuestPassExpirationNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsGuestPassExpiration::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\IdentityQueryCriteriaOptionsGuestPassExpirationNormalizer::class,
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\IdentitySubscriptionPackageList::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\IdentitySubscriptionPackageListNormalizer::class,
         
@@ -826,11 +826,11 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteria::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ZoneQueryCriteriaNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriafiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ZoneQueryCriteriafiltersItemNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ZoneQueryCriteriaFiltersItemNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaextraFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ZoneQueryCriteriaextraFiltersItemNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaExtraFiltersItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ZoneQueryCriteriaExtraFiltersItemNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaoptions::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ZoneQueryCriteriaoptionsNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaOptions::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ZoneQueryCriteriaOptionsNormalizer::class,
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneDhcpSiteConfigList::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ZoneDhcpSiteConfigListNormalizer::class,
         
@@ -1172,7 +1172,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteria::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ProfileFirewallProfileQueryCriteriaNormalizer::class,
         
-        \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaoptions::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ProfileFirewallProfileQueryCriteriaoptionsNormalizer::class,
+        \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaOptions::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ProfileFirewallProfileQueryCriteriaOptionsNormalizer::class,
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileArray::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ProfileFirewallProfileArrayNormalizer::class,
         
@@ -2017,7 +2017,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserModifyScgUser::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserCreateScgUser::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteria::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriafiltersItem::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriaFiltersItem::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserScgUserList::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\UrlFilteringUrlFilteringPolicyList::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\UrlFilteringUrlFilteringPolicy::class => false,
@@ -2045,10 +2045,10 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileBonjourFencingPolicyList::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\WlanQueryWlanQueryList::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteria::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriafiltersItem::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraFiltersItem::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaextraNotFiltersItem::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaoptions::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaFiltersItem::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraFiltersItem::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaExtraNotFiltersItem::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryQueryCriteriaOptions::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ApQueryApQueryList::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\WlanQueryApWlanBssidQueryList::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\RacStatsRadiusProxyList::class => false,
@@ -2186,7 +2186,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileModifyAuthenticationProfile::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileDeleteBulkAuthenticationProfile::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileId::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdextraFiltersItem::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdExtraFiltersItem::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileAccountingProfileList::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileDeleteBulkAccountingProfile::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileUpdateL3RoamingConfig::class => false,
@@ -2267,10 +2267,10 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityIdentityGuestPassList::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityModifyGuestPass::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteria::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriafiltersItem::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptions::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsLocalUserAuditTime::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaoptionsGuestPassExpiration::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaFiltersItem::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptions::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsLocalUserAuditTime::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityQueryCriteriaOptionsGuestPassExpiration::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\IdentitySubscriptionPackageList::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\IdentitySubscriptionPackageListListItem::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\IdentityCreateSubscriptionPackage::class => false,
@@ -2416,9 +2416,9 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Component\OpenApi3\Tests\Expected\Model\ApCloudOnBoardingSyncResultFailAps::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ApCloudOnBoardingSyncResultFailApsApsItem::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteria::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriafiltersItem::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaextraFiltersItem::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaoptions::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaFiltersItem::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaExtraFiltersItem::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaOptions::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneDhcpSiteConfigList::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileCreateBonjourFencingPolicy::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneCreateZone::class => false,
@@ -2589,7 +2589,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Component\OpenApi3\Tests\Expected\Model\DpskDeleteExpiredDpskConfig::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfile::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteria::class => false,
-            \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaoptions::class => false,
+            \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaOptions::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileArray::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileCreateFirewallProfile::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileModifyFirewallProfile::class => false,

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileFirewallProfileQueryCriteriaNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileFirewallProfileQueryCriteriaNormalizer.php
@@ -62,7 +62,7 @@ class ProfileFirewallProfileQueryCriteriaNormalizer implements DenormalizerInter
             $object->setExtraNotFilters($values_2);
         }
         if (\array_key_exists('options', $data)) {
-            $object->setOptions($this->denormalizer->denormalize($data['options'], \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaoptions::class, 'json', $context));
+            $object->setOptions($this->denormalizer->denormalize($data['options'], \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaOptions::class, 'json', $context));
         }
         if (\array_key_exists('extraTimeRange', $data)) {
             $object->setExtraTimeRange($this->denormalizer->denormalize($data['extraTimeRange'], \Jane\Component\OpenApi3\Tests\Expected\Model\CommonTimeRange::class, 'json', $context));

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileFirewallProfileQueryCriteriaoptionsNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileFirewallProfileQueryCriteriaoptionsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ProfileFirewallProfileQueryCriteriaoptionsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ProfileFirewallProfileQueryCriteriaOptionsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class ProfileFirewallProfileQueryCriteriaoptionsNormalizer implements Denormaliz
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaoptions::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaOptions::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaoptions::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaOptions::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class ProfileFirewallProfileQueryCriteriaoptionsNormalizer implements Denormaliz
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaoptions();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaOptions();
         if (\array_key_exists('auth_includeNa', $data) && \is_int($data['auth_includeNa'])) {
             $data['auth_includeNa'] = (bool) $data['auth_includeNa'];
         }
@@ -223,6 +223,6 @@ class ProfileFirewallProfileQueryCriteriaoptionsNormalizer implements Denormaliz
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaoptions::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ProfileFirewallProfileQueryCriteriaOptions::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileQueryCriteriaWithProfileIdNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileQueryCriteriaWithProfileIdNormalizer.php
@@ -50,7 +50,7 @@ class ProfileQueryCriteriaWithProfileIdNormalizer implements DenormalizerInterfa
         if (\array_key_exists('extraFilters', $data)) {
             $values_1 = [];
             foreach ($data['extraFilters'] as $value_1) {
-                $values_1[] = $this->denormalizer->denormalize($value_1, \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdextraFiltersItem::class, 'json', $context);
+                $values_1[] = $this->denormalizer->denormalize($value_1, \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdExtraFiltersItem::class, 'json', $context);
             }
             $object->setExtraFilters($values_1);
         }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileQueryCriteriaWithProfileIdextraFiltersItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileQueryCriteriaWithProfileIdextraFiltersItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ProfileQueryCriteriaWithProfileIdextraFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ProfileQueryCriteriaWithProfileIdExtraFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class ProfileQueryCriteriaWithProfileIdextraFiltersItemNormalizer implements Den
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdextraFiltersItem::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdExtraFiltersItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdextraFiltersItem::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdExtraFiltersItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class ProfileQueryCriteriaWithProfileIdextraFiltersItemNormalizer implements Den
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdextraFiltersItem();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdExtraFiltersItem();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -64,6 +64,6 @@ class ProfileQueryCriteriaWithProfileIdextraFiltersItemNormalizer implements Den
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdextraFiltersItem::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ProfileQueryCriteriaWithProfileIdExtraFiltersItem::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ScguserQueryCriteriaNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ScguserQueryCriteriaNormalizer.php
@@ -43,7 +43,7 @@ class ScguserQueryCriteriaNormalizer implements DenormalizerInterface, Normalize
         if (\array_key_exists('filters', $data)) {
             $values = [];
             foreach ($data['filters'] as $value) {
-                $values[] = $this->denormalizer->denormalize($value, \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriafiltersItem::class, 'json', $context);
+                $values[] = $this->denormalizer->denormalize($value, \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriaFiltersItem::class, 'json', $context);
             }
             $object->setFilters($values);
         }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ScguserQueryCriteriafiltersItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ScguserQueryCriteriafiltersItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ScguserQueryCriteriafiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ScguserQueryCriteriaFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class ScguserQueryCriteriafiltersItemNormalizer implements DenormalizerInterface
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriafiltersItem::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriaFiltersItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriafiltersItem::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriaFiltersItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class ScguserQueryCriteriafiltersItemNormalizer implements DenormalizerInterface
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriafiltersItem();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriaFiltersItem();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -60,6 +60,6 @@ class ScguserQueryCriteriafiltersItemNormalizer implements DenormalizerInterface
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriafiltersItem::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ScguserQueryCriteriaFiltersItem::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneQueryCriteriaNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneQueryCriteriaNormalizer.php
@@ -43,14 +43,14 @@ class ZoneQueryCriteriaNormalizer implements DenormalizerInterface, NormalizerIn
         if (\array_key_exists('filters', $data)) {
             $values = [];
             foreach ($data['filters'] as $value) {
-                $values[] = $this->denormalizer->denormalize($value, \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriafiltersItem::class, 'json', $context);
+                $values[] = $this->denormalizer->denormalize($value, \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaFiltersItem::class, 'json', $context);
             }
             $object->setFilters($values);
         }
         if (\array_key_exists('extraFilters', $data)) {
             $values_1 = [];
             foreach ($data['extraFilters'] as $value_1) {
-                $values_1[] = $this->denormalizer->denormalize($value_1, \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaextraFiltersItem::class, 'json', $context);
+                $values_1[] = $this->denormalizer->denormalize($value_1, \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaExtraFiltersItem::class, 'json', $context);
             }
             $object->setExtraFilters($values_1);
         }
@@ -58,7 +58,7 @@ class ZoneQueryCriteriaNormalizer implements DenormalizerInterface, NormalizerIn
             $object->setExtraNotFilters($data['extraNotFilters']);
         }
         if (\array_key_exists('options', $data)) {
-            $object->setOptions($this->denormalizer->denormalize($data['options'], \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaoptions::class, 'json', $context));
+            $object->setOptions($this->denormalizer->denormalize($data['options'], \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaOptions::class, 'json', $context));
         }
         if (\array_key_exists('extraTimeRange', $data)) {
             $object->setExtraTimeRange($this->denormalizer->denormalize($data['extraTimeRange'], \Jane\Component\OpenApi3\Tests\Expected\Model\CommonTimeRange::class, 'json', $context));

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneQueryCriteriaextraFiltersItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneQueryCriteriaextraFiltersItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ZoneQueryCriteriaextraFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ZoneQueryCriteriaExtraFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class ZoneQueryCriteriaextraFiltersItemNormalizer implements DenormalizerInterfa
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaextraFiltersItem::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaExtraFiltersItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaextraFiltersItem::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaExtraFiltersItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class ZoneQueryCriteriaextraFiltersItemNormalizer implements DenormalizerInterfa
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaextraFiltersItem();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaExtraFiltersItem();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -60,6 +60,6 @@ class ZoneQueryCriteriaextraFiltersItemNormalizer implements DenormalizerInterfa
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaextraFiltersItem::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaExtraFiltersItem::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneQueryCriteriafiltersItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneQueryCriteriafiltersItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ZoneQueryCriteriafiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ZoneQueryCriteriaFiltersItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class ZoneQueryCriteriafiltersItemNormalizer implements DenormalizerInterface, N
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriafiltersItem::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaFiltersItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriafiltersItem::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaFiltersItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class ZoneQueryCriteriafiltersItemNormalizer implements DenormalizerInterface, N
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriafiltersItem();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaFiltersItem();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -60,6 +60,6 @@ class ZoneQueryCriteriafiltersItemNormalizer implements DenormalizerInterface, N
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriafiltersItem::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaFiltersItem::class => false];
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneQueryCriteriaoptionsNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneQueryCriteriaoptionsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class ZoneQueryCriteriaoptionsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class ZoneQueryCriteriaOptionsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class ZoneQueryCriteriaoptionsNormalizer implements DenormalizerInterface, Norma
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaoptions::class;
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaOptions::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaoptions::class;
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaOptions::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class ZoneQueryCriteriaoptionsNormalizer implements DenormalizerInterface, Norma
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaoptions();
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaOptions();
         if (\array_key_exists('includeSharedResources', $data) && \is_int($data['includeSharedResources'])) {
             $data['includeSharedResources'] = (bool) $data['includeSharedResources'];
         }
@@ -61,6 +61,6 @@ class ZoneQueryCriteriaoptionsNormalizer implements DenormalizerInterface, Norma
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaoptions::class => false];
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\ZoneQueryCriteriaOptions::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFull.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFull.php
@@ -87,15 +87,15 @@ class GistFull extends \ArrayObject
      */
     protected $truncated;
     /**
-     * @var list<GistFullforksItem>
+     * @var list<GistFullForksItem>
      */
     protected $forks;
     /**
-     * @var list<GistFullhistoryItem>
+     * @var list<GistFullHistoryItem>
      */
     protected $history;
     /**
-     * @var GistFullforkOf|null
+     * @var GistFullForkOf|null
      */
     protected $forkOf;
     /**
@@ -427,14 +427,14 @@ class GistFull extends \ArrayObject
         return $this;
     }
     /**
-     * @return list<GistFullforksItem>
+     * @return list<GistFullForksItem>
      */
     public function getForks(): array
     {
         return $this->forks;
     }
     /**
-     * @param list<GistFullforksItem> $forks
+     * @param list<GistFullForksItem> $forks
      *
      * @return self
      */
@@ -445,14 +445,14 @@ class GistFull extends \ArrayObject
         return $this;
     }
     /**
-     * @return list<GistFullhistoryItem>
+     * @return list<GistFullHistoryItem>
      */
     public function getHistory(): array
     {
         return $this->history;
     }
     /**
-     * @param list<GistFullhistoryItem> $history
+     * @param list<GistFullHistoryItem> $history
      *
      * @return self
      */
@@ -463,18 +463,18 @@ class GistFull extends \ArrayObject
         return $this;
     }
     /**
-     * @return GistFullforkOf|null
+     * @return GistFullForkOf|null
      */
-    public function getForkOf(): ?GistFullforkOf
+    public function getForkOf(): ?GistFullForkOf
     {
         return $this->forkOf;
     }
     /**
-     * @param GistFullforkOf|null $forkOf
+     * @param GistFullForkOf|null $forkOf
      *
      * @return self
      */
-    public function setForkOf(?GistFullforkOf $forkOf): self
+    public function setForkOf(?GistFullForkOf $forkOf): self
     {
         $this->initialized['forkOf'] = true;
         $this->forkOf = $forkOf;

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullforkOf.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullforkOf.php
@@ -2,7 +2,7 @@
 
 namespace Github\Model;
 
-class GistFullforkOf extends \ArrayObject
+class GistFullForkOf extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullforksItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullforksItem.php
@@ -2,7 +2,7 @@
 
 namespace Github\Model;
 
-class GistFullforksItem extends \ArrayObject
+class GistFullForksItem extends \ArrayObject
 {
     /**
      * @var array
@@ -13,7 +13,7 @@ class GistFullforksItem extends \ArrayObject
         return array_key_exists($property, $this->initialized);
     }
     /**
-     * @var GistFullforksItemUser
+     * @var GistFullForksItemUser
      */
     protected $user;
     /**
@@ -33,18 +33,18 @@ class GistFullforksItem extends \ArrayObject
      */
     protected $updatedAt;
     /**
-     * @return GistFullforksItemUser
+     * @return GistFullForksItemUser
      */
-    public function getUser(): GistFullforksItemUser
+    public function getUser(): GistFullForksItemUser
     {
         return $this->user;
     }
     /**
-     * @param GistFullforksItemUser $user
+     * @param GistFullForksItemUser $user
      *
      * @return self
      */
-    public function setUser(GistFullforksItemUser $user): self
+    public function setUser(GistFullForksItemUser $user): self
     {
         $this->initialized['user'] = true;
         $this->user = $user;

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullforksItemUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullforksItemUser.php
@@ -2,7 +2,7 @@
 
 namespace Github\Model;
 
-class GistFullforksItemUser extends \ArrayObject
+class GistFullForksItemUser extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullhistoryItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullhistoryItem.php
@@ -2,7 +2,7 @@
 
 namespace Github\Model;
 
-class GistFullhistoryItem extends \ArrayObject
+class GistFullHistoryItem extends \ArrayObject
 {
     /**
      * @var array
@@ -21,11 +21,11 @@ class GistFullhistoryItem extends \ArrayObject
      */
     protected $version;
     /**
-     * @var GistFullhistoryItemUser|null
+     * @var GistFullHistoryItemUser|null
      */
     protected $user;
     /**
-     * @var GistFullhistoryItemChangeStatus
+     * @var GistFullHistoryItemChangeStatus
      */
     protected $changeStatus;
     /**
@@ -69,36 +69,36 @@ class GistFullhistoryItem extends \ArrayObject
         return $this;
     }
     /**
-     * @return GistFullhistoryItemUser|null
+     * @return GistFullHistoryItemUser|null
      */
-    public function getUser(): ?GistFullhistoryItemUser
+    public function getUser(): ?GistFullHistoryItemUser
     {
         return $this->user;
     }
     /**
-     * @param GistFullhistoryItemUser|null $user
+     * @param GistFullHistoryItemUser|null $user
      *
      * @return self
      */
-    public function setUser(?GistFullhistoryItemUser $user): self
+    public function setUser(?GistFullHistoryItemUser $user): self
     {
         $this->initialized['user'] = true;
         $this->user = $user;
         return $this;
     }
     /**
-     * @return GistFullhistoryItemChangeStatus
+     * @return GistFullHistoryItemChangeStatus
      */
-    public function getChangeStatus(): GistFullhistoryItemChangeStatus
+    public function getChangeStatus(): GistFullHistoryItemChangeStatus
     {
         return $this->changeStatus;
     }
     /**
-     * @param GistFullhistoryItemChangeStatus $changeStatus
+     * @param GistFullHistoryItemChangeStatus $changeStatus
      *
      * @return self
      */
-    public function setChangeStatus(GistFullhistoryItemChangeStatus $changeStatus): self
+    public function setChangeStatus(GistFullHistoryItemChangeStatus $changeStatus): self
     {
         $this->initialized['changeStatus'] = true;
         $this->changeStatus = $changeStatus;

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullhistoryItemChangeStatus.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullhistoryItemChangeStatus.php
@@ -2,7 +2,7 @@
 
 namespace Github\Model;
 
-class GistFullhistoryItemChangeStatus extends \ArrayObject
+class GistFullHistoryItemChangeStatus extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullhistoryItemUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Model/GistFullhistoryItemUser.php
@@ -2,7 +2,7 @@
 
 namespace Github\Model;
 
-class GistFullhistoryItemUser extends \ArrayObject
+class GistFullHistoryItemUser extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullNormalizer.php
@@ -134,7 +134,7 @@ class GistFullNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (\array_key_exists('forks', $data)) {
             $values_1 = [];
             foreach ($data['forks'] as $value_1) {
-                $values_1[] = $this->denormalizer->denormalize($value_1, \Github\Model\GistFullforksItem::class, 'json', $context);
+                $values_1[] = $this->denormalizer->denormalize($value_1, \Github\Model\GistFullForksItem::class, 'json', $context);
             }
             $object->setForks($values_1);
             unset($data['forks']);
@@ -142,13 +142,13 @@ class GistFullNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (\array_key_exists('history', $data)) {
             $values_2 = [];
             foreach ($data['history'] as $value_2) {
-                $values_2[] = $this->denormalizer->denormalize($value_2, \Github\Model\GistFullhistoryItem::class, 'json', $context);
+                $values_2[] = $this->denormalizer->denormalize($value_2, \Github\Model\GistFullHistoryItem::class, 'json', $context);
             }
             $object->setHistory($values_2);
             unset($data['history']);
         }
         if (\array_key_exists('fork_of', $data) && $data['fork_of'] !== null) {
-            $object->setForkOf($this->denormalizer->denormalize($data['fork_of'], \Github\Model\GistFullforkOf::class, 'json', $context));
+            $object->setForkOf($this->denormalizer->denormalize($data['fork_of'], \Github\Model\GistFullForkOf::class, 'json', $context));
             unset($data['fork_of']);
         }
         elseif (\array_key_exists('fork_of', $data) && $data['fork_of'] === null) {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullforkOfNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullforkOfNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class GistFullforkOfNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class GistFullForkOfNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class GistFullforkOfNormalizer implements DenormalizerInterface, NormalizerInter
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Github\Model\GistFullforkOf::class;
+        return $type === \Github\Model\GistFullForkOf::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Github\Model\GistFullforkOf::class;
+        return is_object($data) && get_class($data) === \Github\Model\GistFullForkOf::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class GistFullforkOfNormalizer implements DenormalizerInterface, NormalizerInter
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Github\Model\GistFullforkOf();
+        $object = new \Github\Model\GistFullForkOf();
         if (\array_key_exists('public', $data) && \is_int($data['public'])) {
             $data['public'] = (bool) $data['public'];
         }
@@ -41,7 +41,7 @@ class GistFullforkOfNormalizer implements DenormalizerInterface, NormalizerInter
             $data['truncated'] = (bool) $data['truncated'];
         }
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($data, new \Github\Validator\GistFullforkOfConstraint());
+            $this->validate($data, new \Github\Validator\GistFullForkOfConstraint());
         }
         if (null === $data || false === \is_array($data)) {
             return $object;
@@ -205,12 +205,12 @@ class GistFullforkOfNormalizer implements DenormalizerInterface, NormalizerInter
             }
         }
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($dataArray, new \Github\Validator\GistFullforkOfConstraint());
+            $this->validate($dataArray, new \Github\Validator\GistFullForkOfConstraint());
         }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Github\Model\GistFullforkOf::class => false];
+        return [\Github\Model\GistFullForkOf::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullforksItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullforksItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class GistFullforksItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class GistFullForksItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class GistFullforksItemNormalizer implements DenormalizerInterface, NormalizerIn
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Github\Model\GistFullforksItem::class;
+        return $type === \Github\Model\GistFullForksItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Github\Model\GistFullforksItem::class;
+        return is_object($data) && get_class($data) === \Github\Model\GistFullForksItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,15 +33,15 @@ class GistFullforksItemNormalizer implements DenormalizerInterface, NormalizerIn
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Github\Model\GistFullforksItem();
+        $object = new \Github\Model\GistFullForksItem();
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($data, new \Github\Validator\GistFullforksItemConstraint());
+            $this->validate($data, new \Github\Validator\GistFullForksItemConstraint());
         }
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
         if (\array_key_exists('user', $data)) {
-            $object->setUser($this->denormalizer->denormalize($data['user'], \Github\Model\GistFullforksItemUser::class, 'json', $context));
+            $object->setUser($this->denormalizer->denormalize($data['user'], \Github\Model\GistFullForksItemUser::class, 'json', $context));
             unset($data['user']);
         }
         if (\array_key_exists('url', $data)) {
@@ -91,12 +91,12 @@ class GistFullforksItemNormalizer implements DenormalizerInterface, NormalizerIn
             }
         }
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($dataArray, new \Github\Validator\GistFullforksItemConstraint());
+            $this->validate($dataArray, new \Github\Validator\GistFullForksItemConstraint());
         }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Github\Model\GistFullforksItem::class => false];
+        return [\Github\Model\GistFullForksItem::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullforksItemUserNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullforksItemUserNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class GistFullforksItemUserNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class GistFullForksItemUserNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class GistFullforksItemUserNormalizer implements DenormalizerInterface, Normaliz
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Github\Model\GistFullforksItemUser::class;
+        return $type === \Github\Model\GistFullForksItemUser::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Github\Model\GistFullforksItemUser::class;
+        return is_object($data) && get_class($data) === \Github\Model\GistFullForksItemUser::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,12 +33,12 @@ class GistFullforksItemUserNormalizer implements DenormalizerInterface, Normaliz
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Github\Model\GistFullforksItemUser();
+        $object = new \Github\Model\GistFullForksItemUser();
         if (\array_key_exists('site_admin', $data) && \is_int($data['site_admin'])) {
             $data['site_admin'] = (bool) $data['site_admin'];
         }
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($data, new \Github\Validator\GistFullforksItemUserConstraint());
+            $this->validate($data, new \Github\Validator\GistFullForksItemUserConstraint());
         }
         if (null === $data || false === \is_array($data)) {
             return $object;
@@ -185,12 +185,12 @@ class GistFullforksItemUserNormalizer implements DenormalizerInterface, Normaliz
             }
         }
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($dataArray, new \Github\Validator\GistFullforksItemUserConstraint());
+            $this->validate($dataArray, new \Github\Validator\GistFullForksItemUserConstraint());
         }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Github\Model\GistFullforksItemUser::class => false];
+        return [\Github\Model\GistFullForksItemUser::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullhistoryItemChangeStatusNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullhistoryItemChangeStatusNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class GistFullhistoryItemChangeStatusNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class GistFullHistoryItemChangeStatusNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class GistFullhistoryItemChangeStatusNormalizer implements DenormalizerInterface
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Github\Model\GistFullhistoryItemChangeStatus::class;
+        return $type === \Github\Model\GistFullHistoryItemChangeStatus::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Github\Model\GistFullhistoryItemChangeStatus::class;
+        return is_object($data) && get_class($data) === \Github\Model\GistFullHistoryItemChangeStatus::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,9 +33,9 @@ class GistFullhistoryItemChangeStatusNormalizer implements DenormalizerInterface
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Github\Model\GistFullhistoryItemChangeStatus();
+        $object = new \Github\Model\GistFullHistoryItemChangeStatus();
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($data, new \Github\Validator\GistFullhistoryItemChangeStatusConstraint());
+            $this->validate($data, new \Github\Validator\GistFullHistoryItemChangeStatusConstraint());
         }
         if (null === $data || false === \is_array($data)) {
             return $object;
@@ -77,12 +77,12 @@ class GistFullhistoryItemChangeStatusNormalizer implements DenormalizerInterface
             }
         }
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($dataArray, new \Github\Validator\GistFullhistoryItemChangeStatusConstraint());
+            $this->validate($dataArray, new \Github\Validator\GistFullHistoryItemChangeStatusConstraint());
         }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Github\Model\GistFullhistoryItemChangeStatus::class => false];
+        return [\Github\Model\GistFullHistoryItemChangeStatus::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullhistoryItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullhistoryItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class GistFullhistoryItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class GistFullHistoryItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class GistFullhistoryItemNormalizer implements DenormalizerInterface, Normalizer
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Github\Model\GistFullhistoryItem::class;
+        return $type === \Github\Model\GistFullHistoryItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Github\Model\GistFullhistoryItem::class;
+        return is_object($data) && get_class($data) === \Github\Model\GistFullHistoryItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,9 +33,9 @@ class GistFullhistoryItemNormalizer implements DenormalizerInterface, Normalizer
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Github\Model\GistFullhistoryItem();
+        $object = new \Github\Model\GistFullHistoryItem();
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($data, new \Github\Validator\GistFullhistoryItemConstraint());
+            $this->validate($data, new \Github\Validator\GistFullHistoryItemConstraint());
         }
         if (null === $data || false === \is_array($data)) {
             return $object;
@@ -49,14 +49,14 @@ class GistFullhistoryItemNormalizer implements DenormalizerInterface, Normalizer
             unset($data['version']);
         }
         if (\array_key_exists('user', $data) && $data['user'] !== null) {
-            $object->setUser($this->denormalizer->denormalize($data['user'], \Github\Model\GistFullhistoryItemUser::class, 'json', $context));
+            $object->setUser($this->denormalizer->denormalize($data['user'], \Github\Model\GistFullHistoryItemUser::class, 'json', $context));
             unset($data['user']);
         }
         elseif (\array_key_exists('user', $data) && $data['user'] === null) {
             $object->setUser(null);
         }
         if (\array_key_exists('change_status', $data)) {
-            $object->setChangeStatus($this->denormalizer->denormalize($data['change_status'], \Github\Model\GistFullhistoryItemChangeStatus::class, 'json', $context));
+            $object->setChangeStatus($this->denormalizer->denormalize($data['change_status'], \Github\Model\GistFullHistoryItemChangeStatus::class, 'json', $context));
             unset($data['change_status']);
         }
         if (\array_key_exists('committed_at', $data)) {
@@ -94,12 +94,12 @@ class GistFullhistoryItemNormalizer implements DenormalizerInterface, Normalizer
             }
         }
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($dataArray, new \Github\Validator\GistFullhistoryItemConstraint());
+            $this->validate($dataArray, new \Github\Validator\GistFullHistoryItemConstraint());
         }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Github\Model\GistFullhistoryItem::class => false];
+        return [\Github\Model\GistFullHistoryItem::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullhistoryItemUserNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/GistFullhistoryItemUserNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class GistFullhistoryItemUserNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class GistFullHistoryItemUserNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class GistFullhistoryItemUserNormalizer implements DenormalizerInterface, Normal
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Github\Model\GistFullhistoryItemUser::class;
+        return $type === \Github\Model\GistFullHistoryItemUser::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Github\Model\GistFullhistoryItemUser::class;
+        return is_object($data) && get_class($data) === \Github\Model\GistFullHistoryItemUser::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,12 +33,12 @@ class GistFullhistoryItemUserNormalizer implements DenormalizerInterface, Normal
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Github\Model\GistFullhistoryItemUser();
+        $object = new \Github\Model\GistFullHistoryItemUser();
         if (\array_key_exists('site_admin', $data) && \is_int($data['site_admin'])) {
             $data['site_admin'] = (bool) $data['site_admin'];
         }
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($data, new \Github\Validator\GistFullhistoryItemUserConstraint());
+            $this->validate($data, new \Github\Validator\GistFullHistoryItemUserConstraint());
         }
         if (null === $data || false === \is_array($data)) {
             return $object;
@@ -185,12 +185,12 @@ class GistFullhistoryItemUserNormalizer implements DenormalizerInterface, Normal
             }
         }
         if (!($context['skip_validation'] ?? false)) {
-            $this->validate($dataArray, new \Github\Validator\GistFullhistoryItemUserConstraint());
+            $this->validate($dataArray, new \Github\Validator\GistFullHistoryItemUserConstraint());
         }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Github\Model\GistFullhistoryItemUser::class => false];
+        return [\Github\Model\GistFullHistoryItemUser::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Normalizer/JaneObjectNormalizer.php
@@ -848,17 +848,17 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Github\Model\GistFull::class => \Github\Normalizer\GistFullNormalizer::class,
         
-        \Github\Model\GistFullforksItem::class => \Github\Normalizer\GistFullforksItemNormalizer::class,
+        \Github\Model\GistFullForksItem::class => \Github\Normalizer\GistFullForksItemNormalizer::class,
         
-        \Github\Model\GistFullforksItemUser::class => \Github\Normalizer\GistFullforksItemUserNormalizer::class,
+        \Github\Model\GistFullForksItemUser::class => \Github\Normalizer\GistFullForksItemUserNormalizer::class,
         
-        \Github\Model\GistFullhistoryItem::class => \Github\Normalizer\GistFullhistoryItemNormalizer::class,
+        \Github\Model\GistFullHistoryItem::class => \Github\Normalizer\GistFullHistoryItemNormalizer::class,
         
-        \Github\Model\GistFullhistoryItemUser::class => \Github\Normalizer\GistFullhistoryItemUserNormalizer::class,
+        \Github\Model\GistFullHistoryItemUser::class => \Github\Normalizer\GistFullHistoryItemUserNormalizer::class,
         
-        \Github\Model\GistFullhistoryItemChangeStatus::class => \Github\Normalizer\GistFullhistoryItemChangeStatusNormalizer::class,
+        \Github\Model\GistFullHistoryItemChangeStatus::class => \Github\Normalizer\GistFullHistoryItemChangeStatusNormalizer::class,
         
-        \Github\Model\GistFullforkOf::class => \Github\Normalizer\GistFullforkOfNormalizer::class,
+        \Github\Model\GistFullForkOf::class => \Github\Normalizer\GistFullForkOfNormalizer::class,
         
         \Github\Model\GistCommit::class => \Github\Normalizer\GistCommitNormalizer::class,
         
@@ -1859,12 +1859,12 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Github\Model\GistSimple::class => false,
             \Github\Model\GistSimpleFilesItem::class => false,
             \Github\Model\GistFull::class => false,
-            \Github\Model\GistFullforksItem::class => false,
-            \Github\Model\GistFullforksItemUser::class => false,
-            \Github\Model\GistFullhistoryItem::class => false,
-            \Github\Model\GistFullhistoryItemUser::class => false,
-            \Github\Model\GistFullhistoryItemChangeStatus::class => false,
-            \Github\Model\GistFullforkOf::class => false,
+            \Github\Model\GistFullForksItem::class => false,
+            \Github\Model\GistFullForksItemUser::class => false,
+            \Github\Model\GistFullHistoryItem::class => false,
+            \Github\Model\GistFullHistoryItemUser::class => false,
+            \Github\Model\GistFullHistoryItemChangeStatus::class => false,
+            \Github\Model\GistFullForkOf::class => false,
             \Github\Model\GistCommit::class => false,
             \Github\Model\GistCommitUser::class => false,
             \Github\Model\GistCommitChangeStatus::class => false,

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullforkOfConstraint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullforkOfConstraint.php
@@ -2,7 +2,7 @@
 
 namespace Github\Validator;
 
-class GistFullforkOfConstraint extends \Symfony\Component\Validator\Constraints\Compound
+class GistFullForkOfConstraint extends \Symfony\Component\Validator\Constraints\Compound
 {
     protected function getConstraints($options): array
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullforksItemConstraint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullforksItemConstraint.php
@@ -2,7 +2,7 @@
 
 namespace Github\Validator;
 
-class GistFullforksItemConstraint extends \Symfony\Component\Validator\Constraints\Compound
+class GistFullForksItemConstraint extends \Symfony\Component\Validator\Constraints\Compound
 {
     protected function getConstraints($options): array
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullforksItemUserConstraint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullforksItemUserConstraint.php
@@ -2,7 +2,7 @@
 
 namespace Github\Validator;
 
-class GistFullforksItemUserConstraint extends \Symfony\Component\Validator\Constraints\Compound
+class GistFullForksItemUserConstraint extends \Symfony\Component\Validator\Constraints\Compound
 {
     protected function getConstraints($options): array
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullhistoryItemChangeStatusConstraint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullhistoryItemChangeStatusConstraint.php
@@ -2,7 +2,7 @@
 
 namespace Github\Validator;
 
-class GistFullhistoryItemChangeStatusConstraint extends \Symfony\Component\Validator\Constraints\Compound
+class GistFullHistoryItemChangeStatusConstraint extends \Symfony\Component\Validator\Constraints\Compound
 {
     protected function getConstraints($options): array
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullhistoryItemConstraint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullhistoryItemConstraint.php
@@ -2,7 +2,7 @@
 
 namespace Github\Validator;
 
-class GistFullhistoryItemConstraint extends \Symfony\Component\Validator\Constraints\Compound
+class GistFullHistoryItemConstraint extends \Symfony\Component\Validator\Constraints\Compound
 {
     protected function getConstraints($options): array
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullhistoryItemUserConstraint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Validator/GistFullhistoryItemUserConstraint.php
@@ -2,7 +2,7 @@
 
 namespace Github\Validator;
 
-class GistFullhistoryItemUserConstraint extends \Symfony\Component\Validator\Constraints\Compound
+class GistFullHistoryItemUserConstraint extends \Symfony\Component\Validator\Constraints\Compound
 {
     protected function getConstraints($options): array
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/AppServiceSpec.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/AppServiceSpec.php
@@ -99,7 +99,7 @@ class AppServiceSpec extends \ArrayObject
      */
     protected $autoscaling;
     /**
-     * @var AppServiceSpeccors
+     * @var AppServiceSpecCors
      */
     protected $cors;
     /**
@@ -478,18 +478,18 @@ class AppServiceSpec extends \ArrayObject
         return $this;
     }
     /**
-     * @return AppServiceSpeccors
+     * @return AppServiceSpecCors
      */
-    public function getCors(): AppServiceSpeccors
+    public function getCors(): AppServiceSpecCors
     {
         return $this->cors;
     }
     /**
-     * @param AppServiceSpeccors $cors
+     * @param AppServiceSpecCors $cors
      *
      * @return self
      */
-    public function setCors(AppServiceSpeccors $cors): self
+    public function setCors(AppServiceSpecCors $cors): self
     {
         $this->initialized['cors'] = true;
         $this->cors = $cors;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/AppServiceSpeccors.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/AppServiceSpeccors.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class AppServiceSpeccors extends \ArrayObject
+class AppServiceSpecCors extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/AppStaticSiteSpec.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/AppStaticSiteSpec.php
@@ -105,7 +105,7 @@ class AppStaticSiteSpec extends \ArrayObject
      */
     protected $outputDir;
     /**
-     * @var AppStaticSiteSpeccors
+     * @var AppStaticSiteSpecCors
      */
     protected $cors;
     /**
@@ -471,18 +471,18 @@ class AppStaticSiteSpec extends \ArrayObject
         return $this;
     }
     /**
-     * @return AppStaticSiteSpeccors
+     * @return AppStaticSiteSpecCors
      */
-    public function getCors(): AppStaticSiteSpeccors
+    public function getCors(): AppStaticSiteSpecCors
     {
         return $this->cors;
     }
     /**
-     * @param AppStaticSiteSpeccors $cors
+     * @param AppStaticSiteSpecCors $cors
      *
      * @return self
      */
-    public function setCors(AppStaticSiteSpeccors $cors): self
+    public function setCors(AppStaticSiteSpecCors $cors): self
     {
         $this->initialized['cors'] = true;
         $this->cors = $cors;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/AppStaticSiteSpeccors.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/AppStaticSiteSpeccors.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class AppStaticSiteSpeccors extends \ArrayObject
+class AppStaticSiteSpecCors extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/DropletActionChangeBackupPolicy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/DropletActionChangeBackupPolicy.php
@@ -19,7 +19,7 @@ class DropletActionChangeBackupPolicy extends \ArrayObject
      */
     protected $type;
     /**
-     * @var DropletActionChangeBackupPolicybackupPolicy
+     * @var DropletActionChangeBackupPolicyBackupPolicy
      */
     protected $backupPolicy;
     /**
@@ -45,18 +45,18 @@ class DropletActionChangeBackupPolicy extends \ArrayObject
         return $this;
     }
     /**
-     * @return DropletActionChangeBackupPolicybackupPolicy
+     * @return DropletActionChangeBackupPolicyBackupPolicy
      */
-    public function getBackupPolicy(): DropletActionChangeBackupPolicybackupPolicy
+    public function getBackupPolicy(): DropletActionChangeBackupPolicyBackupPolicy
     {
         return $this->backupPolicy;
     }
     /**
-     * @param DropletActionChangeBackupPolicybackupPolicy $backupPolicy
+     * @param DropletActionChangeBackupPolicyBackupPolicy $backupPolicy
      *
      * @return self
      */
-    public function setBackupPolicy(DropletActionChangeBackupPolicybackupPolicy $backupPolicy): self
+    public function setBackupPolicy(DropletActionChangeBackupPolicyBackupPolicy $backupPolicy): self
     {
         $this->initialized['backupPolicy'] = true;
         $this->backupPolicy = $backupPolicy;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/DropletActionChangeBackupPolicybackupPolicy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/DropletActionChangeBackupPolicybackupPolicy.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class DropletActionChangeBackupPolicybackupPolicy extends \ArrayObject
+class DropletActionChangeBackupPolicyBackupPolicy extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/DropletActionEnableBackups.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/DropletActionEnableBackups.php
@@ -19,7 +19,7 @@ class DropletActionEnableBackups extends \ArrayObject
      */
     protected $type;
     /**
-     * @var DropletActionEnableBackupsbackupPolicy
+     * @var DropletActionEnableBackupsBackupPolicy
      */
     protected $backupPolicy;
     /**
@@ -45,18 +45,18 @@ class DropletActionEnableBackups extends \ArrayObject
         return $this;
     }
     /**
-     * @return DropletActionEnableBackupsbackupPolicy
+     * @return DropletActionEnableBackupsBackupPolicy
      */
-    public function getBackupPolicy(): DropletActionEnableBackupsbackupPolicy
+    public function getBackupPolicy(): DropletActionEnableBackupsBackupPolicy
     {
         return $this->backupPolicy;
     }
     /**
-     * @param DropletActionEnableBackupsbackupPolicy $backupPolicy
+     * @param DropletActionEnableBackupsBackupPolicy $backupPolicy
      *
      * @return self
      */
-    public function setBackupPolicy(DropletActionEnableBackupsbackupPolicy $backupPolicy): self
+    public function setBackupPolicy(DropletActionEnableBackupsBackupPolicy $backupPolicy): self
     {
         $this->initialized['backupPolicy'] = true;
         $this->backupPolicy = $backupPolicy;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/DropletActionEnableBackupsbackupPolicy.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/DropletActionEnableBackupsbackupPolicy.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class DropletActionEnableBackupsbackupPolicy extends \ArrayObject
+class DropletActionEnableBackupsBackupPolicy extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/Firewall.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/Firewall.php
@@ -33,7 +33,7 @@ class Firewall extends \ArrayObject
     /**
      * An array of objects each containing the fields "droplet_id", "removing", and "status". It is provided to detail exactly which Droplets are having their security policies updated. When empty, all changes have been successfully applied.
      *
-     * @var list<FirewallpendingChangesItem>
+     * @var list<FirewallPendingChangesItem>
      */
     protected $pendingChanges;
     /**
@@ -129,7 +129,7 @@ class Firewall extends \ArrayObject
     /**
      * An array of objects each containing the fields "droplet_id", "removing", and "status". It is provided to detail exactly which Droplets are having their security policies updated. When empty, all changes have been successfully applied.
      *
-     * @return list<FirewallpendingChangesItem>
+     * @return list<FirewallPendingChangesItem>
      */
     public function getPendingChanges(): array
     {
@@ -138,7 +138,7 @@ class Firewall extends \ArrayObject
     /**
      * An array of objects each containing the fields "droplet_id", "removing", and "status". It is provided to detail exactly which Droplets are having their security policies updated. When empty, all changes have been successfully applied.
      *
-     * @param list<FirewallpendingChangesItem> $pendingChanges
+     * @param list<FirewallPendingChangesItem> $pendingChanges
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/FirewallRulesInboundRulesItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/FirewallRulesInboundRulesItem.php
@@ -25,7 +25,7 @@ class FirewallRulesInboundRulesItem extends \ArrayObject
      */
     protected $ports;
     /**
-     * @var FirewallRulesInboundRulesItemsources
+     * @var FirewallRulesInboundRulesItemSources
      */
     protected $sources;
     /**
@@ -73,18 +73,18 @@ class FirewallRulesInboundRulesItem extends \ArrayObject
         return $this;
     }
     /**
-     * @return FirewallRulesInboundRulesItemsources
+     * @return FirewallRulesInboundRulesItemSources
      */
-    public function getSources(): FirewallRulesInboundRulesItemsources
+    public function getSources(): FirewallRulesInboundRulesItemSources
     {
         return $this->sources;
     }
     /**
-     * @param FirewallRulesInboundRulesItemsources $sources
+     * @param FirewallRulesInboundRulesItemSources $sources
      *
      * @return self
      */
-    public function setSources(FirewallRulesInboundRulesItemsources $sources): self
+    public function setSources(FirewallRulesInboundRulesItemSources $sources): self
     {
         $this->initialized['sources'] = true;
         $this->sources = $sources;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/FirewallRulesInboundRulesItemsources.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/FirewallRulesInboundRulesItemsources.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class FirewallRulesInboundRulesItemsources extends \ArrayObject
+class FirewallRulesInboundRulesItemSources extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/FirewallRulesOutboundRulesItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/FirewallRulesOutboundRulesItem.php
@@ -25,7 +25,7 @@ class FirewallRulesOutboundRulesItem extends \ArrayObject
      */
     protected $ports;
     /**
-     * @var FirewallRulesOutboundRulesItemdestinations
+     * @var FirewallRulesOutboundRulesItemDestinations
      */
     protected $destinations;
     /**
@@ -73,18 +73,18 @@ class FirewallRulesOutboundRulesItem extends \ArrayObject
         return $this;
     }
     /**
-     * @return FirewallRulesOutboundRulesItemdestinations
+     * @return FirewallRulesOutboundRulesItemDestinations
      */
-    public function getDestinations(): FirewallRulesOutboundRulesItemdestinations
+    public function getDestinations(): FirewallRulesOutboundRulesItemDestinations
     {
         return $this->destinations;
     }
     /**
-     * @param FirewallRulesOutboundRulesItemdestinations $destinations
+     * @param FirewallRulesOutboundRulesItemDestinations $destinations
      *
      * @return self
      */
-    public function setDestinations(FirewallRulesOutboundRulesItemdestinations $destinations): self
+    public function setDestinations(FirewallRulesOutboundRulesItemDestinations $destinations): self
     {
         $this->initialized['destinations'] = true;
         $this->destinations = $destinations;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/FirewallRulesOutboundRulesItemdestinations.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/FirewallRulesOutboundRulesItemdestinations.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class FirewallRulesOutboundRulesItemdestinations extends \ArrayObject
+class FirewallRulesOutboundRulesItemDestinations extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/FirewallpendingChangesItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/FirewallpendingChangesItem.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class FirewallpendingChangesItem extends \ArrayObject
+class FirewallPendingChangesItem extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/LoadBalancerregion.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/LoadBalancerregion.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class LoadBalancerregion extends \ArrayObject
+class LoadBalancerRegion extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionAttach.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionAttach.php
@@ -25,7 +25,7 @@ class NfsActionAttach extends \ArrayObject
      */
     protected $region;
     /**
-     * @var NfsActionAttachparams
+     * @var NfsActionAttachParams
      */
     protected $params;
     /**
@@ -73,18 +73,18 @@ class NfsActionAttach extends \ArrayObject
         return $this;
     }
     /**
-     * @return NfsActionAttachparams
+     * @return NfsActionAttachParams
      */
-    public function getParams(): NfsActionAttachparams
+    public function getParams(): NfsActionAttachParams
     {
         return $this->params;
     }
     /**
-     * @param NfsActionAttachparams $params
+     * @param NfsActionAttachParams $params
      *
      * @return self
      */
-    public function setParams(NfsActionAttachparams $params): self
+    public function setParams(NfsActionAttachParams $params): self
     {
         $this->initialized['params'] = true;
         $this->params = $params;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionAttachparams.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionAttachparams.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class NfsActionAttachparams extends \ArrayObject
+class NfsActionAttachParams extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionDetach.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionDetach.php
@@ -25,7 +25,7 @@ class NfsActionDetach extends \ArrayObject
      */
     protected $region;
     /**
-     * @var NfsActionDetachparams
+     * @var NfsActionDetachParams
      */
     protected $params;
     /**
@@ -73,18 +73,18 @@ class NfsActionDetach extends \ArrayObject
         return $this;
     }
     /**
-     * @return NfsActionDetachparams
+     * @return NfsActionDetachParams
      */
-    public function getParams(): NfsActionDetachparams
+    public function getParams(): NfsActionDetachParams
     {
         return $this->params;
     }
     /**
-     * @param NfsActionDetachparams $params
+     * @param NfsActionDetachParams $params
      *
      * @return self
      */
-    public function setParams(NfsActionDetachparams $params): self
+    public function setParams(NfsActionDetachParams $params): self
     {
         $this->initialized['params'] = true;
         $this->params = $params;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionDetachparams.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionDetachparams.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class NfsActionDetachparams extends \ArrayObject
+class NfsActionDetachParams extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionResize.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionResize.php
@@ -25,7 +25,7 @@ class NfsActionResize extends \ArrayObject
      */
     protected $region;
     /**
-     * @var NfsActionResizeparams
+     * @var NfsActionResizeParams
      */
     protected $params;
     /**
@@ -73,18 +73,18 @@ class NfsActionResize extends \ArrayObject
         return $this;
     }
     /**
-     * @return NfsActionResizeparams
+     * @return NfsActionResizeParams
      */
-    public function getParams(): NfsActionResizeparams
+    public function getParams(): NfsActionResizeParams
     {
         return $this->params;
     }
     /**
-     * @param NfsActionResizeparams $params
+     * @param NfsActionResizeParams $params
      *
      * @return self
      */
-    public function setParams(NfsActionResizeparams $params): self
+    public function setParams(NfsActionResizeParams $params): self
     {
         $this->initialized['params'] = true;
         $this->params = $params;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionResizeparams.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionResizeparams.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class NfsActionResizeparams extends \ArrayObject
+class NfsActionResizeParams extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionSnapshot.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionSnapshot.php
@@ -25,7 +25,7 @@ class NfsActionSnapshot extends \ArrayObject
      */
     protected $region;
     /**
-     * @var NfsActionSnapshotparams
+     * @var NfsActionSnapshotParams
      */
     protected $params;
     /**
@@ -73,18 +73,18 @@ class NfsActionSnapshot extends \ArrayObject
         return $this;
     }
     /**
-     * @return NfsActionSnapshotparams
+     * @return NfsActionSnapshotParams
      */
-    public function getParams(): NfsActionSnapshotparams
+    public function getParams(): NfsActionSnapshotParams
     {
         return $this->params;
     }
     /**
-     * @param NfsActionSnapshotparams $params
+     * @param NfsActionSnapshotParams $params
      *
      * @return self
      */
-    public function setParams(NfsActionSnapshotparams $params): self
+    public function setParams(NfsActionSnapshotParams $params): self
     {
         $this->initialized['params'] = true;
         $this->params = $params;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionSnapshotparams.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/NfsActionSnapshotparams.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class NfsActionSnapshotparams extends \ArrayObject
+class NfsActionSnapshotParams extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/Registry.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/Registry.php
@@ -43,7 +43,7 @@ class Registry extends \ArrayObject
      */
     protected $storageUsageBytesUpdatedAt;
     /**
-     * @var Registrysubscription
+     * @var RegistrySubscription
      */
     protected $subscription;
     /**
@@ -157,18 +157,18 @@ class Registry extends \ArrayObject
         return $this;
     }
     /**
-     * @return Registrysubscription
+     * @return RegistrySubscription
      */
-    public function getSubscription(): Registrysubscription
+    public function getSubscription(): RegistrySubscription
     {
         return $this->subscription;
     }
     /**
-     * @param Registrysubscription $subscription
+     * @param RegistrySubscription $subscription
      *
      * @return self
      */
-    public function setSubscription(Registrysubscription $subscription): self
+    public function setSubscription(RegistrySubscription $subscription): self
     {
         $this->initialized['subscription'] = true;
         $this->subscription = $subscription;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/Registrysubscription.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/Registrysubscription.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class Registrysubscription extends \ArrayObject
+class RegistrySubscription extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResources.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResources.php
@@ -25,23 +25,23 @@ class TagsResources extends \ArrayObject
      */
     protected $lastTaggedUri;
     /**
-     * @var TagsResourcesdroplets
+     * @var TagsResourcesDroplets
      */
     protected $droplets;
     /**
-     * @var TagsResourcesimgages
+     * @var TagsResourcesImgages
      */
     protected $imgages;
     /**
-     * @var TagsResourcesvolumes
+     * @var TagsResourcesVolumes
      */
     protected $volumes;
     /**
-     * @var TagsResourcesvolumeSnapshots
+     * @var TagsResourcesVolumeSnapshots
      */
     protected $volumeSnapshots;
     /**
-     * @var TagsResourcesdatabases
+     * @var TagsResourcesDatabases
      */
     protected $databases;
     /**
@@ -89,90 +89,90 @@ class TagsResources extends \ArrayObject
         return $this;
     }
     /**
-     * @return TagsResourcesdroplets
+     * @return TagsResourcesDroplets
      */
-    public function getDroplets(): TagsResourcesdroplets
+    public function getDroplets(): TagsResourcesDroplets
     {
         return $this->droplets;
     }
     /**
-     * @param TagsResourcesdroplets $droplets
+     * @param TagsResourcesDroplets $droplets
      *
      * @return self
      */
-    public function setDroplets(TagsResourcesdroplets $droplets): self
+    public function setDroplets(TagsResourcesDroplets $droplets): self
     {
         $this->initialized['droplets'] = true;
         $this->droplets = $droplets;
         return $this;
     }
     /**
-     * @return TagsResourcesimgages
+     * @return TagsResourcesImgages
      */
-    public function getImgages(): TagsResourcesimgages
+    public function getImgages(): TagsResourcesImgages
     {
         return $this->imgages;
     }
     /**
-     * @param TagsResourcesimgages $imgages
+     * @param TagsResourcesImgages $imgages
      *
      * @return self
      */
-    public function setImgages(TagsResourcesimgages $imgages): self
+    public function setImgages(TagsResourcesImgages $imgages): self
     {
         $this->initialized['imgages'] = true;
         $this->imgages = $imgages;
         return $this;
     }
     /**
-     * @return TagsResourcesvolumes
+     * @return TagsResourcesVolumes
      */
-    public function getVolumes(): TagsResourcesvolumes
+    public function getVolumes(): TagsResourcesVolumes
     {
         return $this->volumes;
     }
     /**
-     * @param TagsResourcesvolumes $volumes
+     * @param TagsResourcesVolumes $volumes
      *
      * @return self
      */
-    public function setVolumes(TagsResourcesvolumes $volumes): self
+    public function setVolumes(TagsResourcesVolumes $volumes): self
     {
         $this->initialized['volumes'] = true;
         $this->volumes = $volumes;
         return $this;
     }
     /**
-     * @return TagsResourcesvolumeSnapshots
+     * @return TagsResourcesVolumeSnapshots
      */
-    public function getVolumeSnapshots(): TagsResourcesvolumeSnapshots
+    public function getVolumeSnapshots(): TagsResourcesVolumeSnapshots
     {
         return $this->volumeSnapshots;
     }
     /**
-     * @param TagsResourcesvolumeSnapshots $volumeSnapshots
+     * @param TagsResourcesVolumeSnapshots $volumeSnapshots
      *
      * @return self
      */
-    public function setVolumeSnapshots(TagsResourcesvolumeSnapshots $volumeSnapshots): self
+    public function setVolumeSnapshots(TagsResourcesVolumeSnapshots $volumeSnapshots): self
     {
         $this->initialized['volumeSnapshots'] = true;
         $this->volumeSnapshots = $volumeSnapshots;
         return $this;
     }
     /**
-     * @return TagsResourcesdatabases
+     * @return TagsResourcesDatabases
      */
-    public function getDatabases(): TagsResourcesdatabases
+    public function getDatabases(): TagsResourcesDatabases
     {
         return $this->databases;
     }
     /**
-     * @param TagsResourcesdatabases $databases
+     * @param TagsResourcesDatabases $databases
      *
      * @return self
      */
-    public function setDatabases(TagsResourcesdatabases $databases): self
+    public function setDatabases(TagsResourcesDatabases $databases): self
     {
         $this->initialized['databases'] = true;
         $this->databases = $databases;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResourcesdatabases.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResourcesdatabases.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class TagsResourcesdatabases extends \ArrayObject
+class TagsResourcesDatabases extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResourcesdroplets.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResourcesdroplets.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class TagsResourcesdroplets extends \ArrayObject
+class TagsResourcesDroplets extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResourcesimgages.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResourcesimgages.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class TagsResourcesimgages extends \ArrayObject
+class TagsResourcesImgages extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResourcesvolumeSnapshots.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResourcesvolumeSnapshots.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class TagsResourcesvolumeSnapshots extends \ArrayObject
+class TagsResourcesVolumeSnapshots extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResourcesvolumes.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/TagsResourcesvolumes.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class TagsResourcesvolumes extends \ArrayObject
+class TagsResourcesVolumes extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/V2FirewallsFirewallIdPutBody.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/V2FirewallsFirewallIdPutBody.php
@@ -33,7 +33,7 @@ class V2FirewallsFirewallIdPutBody extends \ArrayObject
     /**
      * An array of objects each containing the fields "droplet_id", "removing", and "status". It is provided to detail exactly which Droplets are having their security policies updated. When empty, all changes have been successfully applied.
      *
-     * @var list<FirewallpendingChangesItem>
+     * @var list<FirewallPendingChangesItem>
      */
     protected $pendingChanges;
     /**
@@ -129,7 +129,7 @@ class V2FirewallsFirewallIdPutBody extends \ArrayObject
     /**
      * An array of objects each containing the fields "droplet_id", "removing", and "status". It is provided to detail exactly which Droplets are having their security policies updated. When empty, all changes have been successfully applied.
      *
-     * @return list<FirewallpendingChangesItem>
+     * @return list<FirewallPendingChangesItem>
      */
     public function getPendingChanges(): array
     {
@@ -138,7 +138,7 @@ class V2FirewallsFirewallIdPutBody extends \ArrayObject
     /**
      * An array of objects each containing the fields "droplet_id", "removing", and "status". It is provided to detail exactly which Droplets are having their security policies updated. When empty, all changes have been successfully applied.
      *
-     * @param list<FirewallpendingChangesItem> $pendingChanges
+     * @param list<FirewallPendingChangesItem> $pendingChanges
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/V2FirewallsPostBody.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/V2FirewallsPostBody.php
@@ -33,7 +33,7 @@ class V2FirewallsPostBody extends \ArrayObject
     /**
      * An array of objects each containing the fields "droplet_id", "removing", and "status". It is provided to detail exactly which Droplets are having their security policies updated. When empty, all changes have been successfully applied.
      *
-     * @var list<FirewallpendingChangesItem>
+     * @var list<FirewallPendingChangesItem>
      */
     protected $pendingChanges;
     /**
@@ -129,7 +129,7 @@ class V2FirewallsPostBody extends \ArrayObject
     /**
      * An array of objects each containing the fields "droplet_id", "removing", and "status". It is provided to detail exactly which Droplets are having their security policies updated. When empty, all changes have been successfully applied.
      *
-     * @return list<FirewallpendingChangesItem>
+     * @return list<FirewallPendingChangesItem>
      */
     public function getPendingChanges(): array
     {
@@ -138,7 +138,7 @@ class V2FirewallsPostBody extends \ArrayObject
     /**
      * An array of objects each containing the fields "droplet_id", "removing", and "status". It is provided to detail exactly which Droplets are having their security policies updated. When empty, all changes have been successfully applied.
      *
-     * @param list<FirewallpendingChangesItem> $pendingChanges
+     * @param list<FirewallPendingChangesItem> $pendingChanges
      *
      * @return self
      */

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/VolumeFull.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/VolumeFull.php
@@ -55,7 +55,7 @@ class VolumeFull extends \ArrayObject
      */
     protected $tags;
     /**
-     * @var VolumeFullregion
+     * @var VolumeFullRegion
      */
     protected $region;
     /**
@@ -225,18 +225,18 @@ class VolumeFull extends \ArrayObject
         return $this;
     }
     /**
-     * @return VolumeFullregion
+     * @return VolumeFullRegion
      */
-    public function getRegion(): VolumeFullregion
+    public function getRegion(): VolumeFullRegion
     {
         return $this->region;
     }
     /**
-     * @param VolumeFullregion $region
+     * @param VolumeFullRegion $region
      *
      * @return self
      */
-    public function setRegion(VolumeFullregion $region): self
+    public function setRegion(VolumeFullRegion $region): self
     {
         $this->initialized['region'] = true;
         $this->region = $region;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/VolumeFullregion.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Model/VolumeFullregion.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Model;
 
-class VolumeFullregion extends \ArrayObject
+class VolumeFullRegion extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppServiceSpecNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppServiceSpecNormalizer.php
@@ -110,7 +110,7 @@ class AppServiceSpecNormalizer implements DenormalizerInterface, NormalizerInter
             unset($data['autoscaling']);
         }
         if (\array_key_exists('cors', $data)) {
-            $object->setCors($this->denormalizer->denormalize($data['cors'], \Jane\Generated\DigitalOcean\Model\AppServiceSpeccors::class, 'json', $context));
+            $object->setCors($this->denormalizer->denormalize($data['cors'], \Jane\Generated\DigitalOcean\Model\AppServiceSpecCors::class, 'json', $context));
             unset($data['cors']);
         }
         if (\array_key_exists('health_check', $data)) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppServiceSpeccorsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppServiceSpeccorsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class AppServiceSpeccorsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class AppServiceSpecCorsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class AppServiceSpeccorsNormalizer implements DenormalizerInterface, NormalizerI
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\AppServiceSpeccors::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\AppServiceSpecCors::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\AppServiceSpeccors::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\AppServiceSpecCors::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class AppServiceSpeccorsNormalizer implements DenormalizerInterface, NormalizerI
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\AppServiceSpeccors();
+        $object = new \Jane\Generated\DigitalOcean\Model\AppServiceSpecCors();
         if (\array_key_exists('allow_credentials', $data) && \is_int($data['allow_credentials'])) {
             $data['allow_credentials'] = (bool) $data['allow_credentials'];
         }
@@ -133,6 +133,6 @@ class AppServiceSpeccorsNormalizer implements DenormalizerInterface, NormalizerI
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\AppServiceSpeccors::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\AppServiceSpecCors::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppStaticSiteSpecNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppStaticSiteSpecNormalizer.php
@@ -114,7 +114,7 @@ class AppStaticSiteSpecNormalizer implements DenormalizerInterface, NormalizerIn
             unset($data['output_dir']);
         }
         if (\array_key_exists('cors', $data)) {
-            $object->setCors($this->denormalizer->denormalize($data['cors'], \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpeccors::class, 'json', $context));
+            $object->setCors($this->denormalizer->denormalize($data['cors'], \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpecCors::class, 'json', $context));
             unset($data['cors']);
         }
         if (\array_key_exists('routes', $data)) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppStaticSiteSpeccorsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppStaticSiteSpeccorsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class AppStaticSiteSpeccorsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class AppStaticSiteSpecCorsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class AppStaticSiteSpeccorsNormalizer implements DenormalizerInterface, Normaliz
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpeccors::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpecCors::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpeccors::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpecCors::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class AppStaticSiteSpeccorsNormalizer implements DenormalizerInterface, Normaliz
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpeccors();
+        $object = new \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpecCors();
         if (\array_key_exists('allow_credentials', $data) && \is_int($data['allow_credentials'])) {
             $data['allow_credentials'] = (bool) $data['allow_credentials'];
         }
@@ -133,6 +133,6 @@ class AppStaticSiteSpeccorsNormalizer implements DenormalizerInterface, Normaliz
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\AppStaticSiteSpeccors::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\AppStaticSiteSpecCors::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletActionChangeBackupPolicyNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletActionChangeBackupPolicyNormalizer.php
@@ -42,7 +42,7 @@ class DropletActionChangeBackupPolicyNormalizer implements DenormalizerInterface
             unset($data['type']);
         }
         if (\array_key_exists('backup_policy', $data)) {
-            $object->setBackupPolicy($this->denormalizer->denormalize($data['backup_policy'], \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicybackupPolicy::class, 'json', $context));
+            $object->setBackupPolicy($this->denormalizer->denormalize($data['backup_policy'], \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicyBackupPolicy::class, 'json', $context));
             unset($data['backup_policy']);
         }
         foreach ($data as $key => $value) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletActionChangeBackupPolicybackupPolicyNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletActionChangeBackupPolicybackupPolicyNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class DropletActionChangeBackupPolicybackupPolicyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class DropletActionChangeBackupPolicyBackupPolicyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class DropletActionChangeBackupPolicybackupPolicyNormalizer implements Denormali
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicybackupPolicy::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicyBackupPolicy::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicybackupPolicy::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicyBackupPolicy::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class DropletActionChangeBackupPolicybackupPolicyNormalizer implements Denormali
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicybackupPolicy();
+        $object = new \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicyBackupPolicy();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -85,6 +85,6 @@ class DropletActionChangeBackupPolicybackupPolicyNormalizer implements Denormali
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicybackupPolicy::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicyBackupPolicy::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletActionEnableBackupsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletActionEnableBackupsNormalizer.php
@@ -42,7 +42,7 @@ class DropletActionEnableBackupsNormalizer implements DenormalizerInterface, Nor
             unset($data['type']);
         }
         if (\array_key_exists('backup_policy', $data)) {
-            $object->setBackupPolicy($this->denormalizer->denormalize($data['backup_policy'], \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsbackupPolicy::class, 'json', $context));
+            $object->setBackupPolicy($this->denormalizer->denormalize($data['backup_policy'], \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsBackupPolicy::class, 'json', $context));
             unset($data['backup_policy']);
         }
         foreach ($data as $key => $value) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletActionEnableBackupsbackupPolicyNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletActionEnableBackupsbackupPolicyNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class DropletActionEnableBackupsbackupPolicyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class DropletActionEnableBackupsBackupPolicyNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class DropletActionEnableBackupsbackupPolicyNormalizer implements DenormalizerIn
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsbackupPolicy::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsBackupPolicy::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsbackupPolicy::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsBackupPolicy::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class DropletActionEnableBackupsbackupPolicyNormalizer implements DenormalizerIn
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsbackupPolicy();
+        $object = new \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsBackupPolicy();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -85,6 +85,6 @@ class DropletActionEnableBackupsbackupPolicyNormalizer implements DenormalizerIn
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsbackupPolicy::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsBackupPolicy::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallNormalizer.php
@@ -52,7 +52,7 @@ class FirewallNormalizer implements DenormalizerInterface, NormalizerInterface, 
         if (\array_key_exists('pending_changes', $data)) {
             $values = [];
             foreach ($data['pending_changes'] as $value) {
-                $values[] = $this->denormalizer->denormalize($value, \Jane\Generated\DigitalOcean\Model\FirewallpendingChangesItem::class, 'json', $context);
+                $values[] = $this->denormalizer->denormalize($value, \Jane\Generated\DigitalOcean\Model\FirewallPendingChangesItem::class, 'json', $context);
             }
             $object->setPendingChanges($values);
             unset($data['pending_changes']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallRulesInboundRulesItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallRulesInboundRulesItemNormalizer.php
@@ -46,7 +46,7 @@ class FirewallRulesInboundRulesItemNormalizer implements DenormalizerInterface, 
             unset($data['ports']);
         }
         if (\array_key_exists('sources', $data)) {
-            $object->setSources($this->denormalizer->denormalize($data['sources'], \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemsources::class, 'json', $context));
+            $object->setSources($this->denormalizer->denormalize($data['sources'], \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemSources::class, 'json', $context));
             unset($data['sources']);
         }
         foreach ($data as $key => $value) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallRulesInboundRulesItemsourcesNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallRulesInboundRulesItemsourcesNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class FirewallRulesInboundRulesItemsourcesNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class FirewallRulesInboundRulesItemSourcesNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class FirewallRulesInboundRulesItemsourcesNormalizer implements DenormalizerInte
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemsources::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemSources::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemsources::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemSources::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class FirewallRulesInboundRulesItemsourcesNormalizer implements DenormalizerInte
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemsources();
+        $object = new \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemSources();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -131,6 +131,6 @@ class FirewallRulesInboundRulesItemsourcesNormalizer implements DenormalizerInte
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemsources::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemSources::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallRulesOutboundRulesItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallRulesOutboundRulesItemNormalizer.php
@@ -46,7 +46,7 @@ class FirewallRulesOutboundRulesItemNormalizer implements DenormalizerInterface,
             unset($data['ports']);
         }
         if (\array_key_exists('destinations', $data)) {
-            $object->setDestinations($this->denormalizer->denormalize($data['destinations'], \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemdestinations::class, 'json', $context));
+            $object->setDestinations($this->denormalizer->denormalize($data['destinations'], \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemDestinations::class, 'json', $context));
             unset($data['destinations']);
         }
         foreach ($data as $key => $value) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallRulesOutboundRulesItemdestinationsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallRulesOutboundRulesItemdestinationsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class FirewallRulesOutboundRulesItemdestinationsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class FirewallRulesOutboundRulesItemDestinationsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class FirewallRulesOutboundRulesItemdestinationsNormalizer implements Denormaliz
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemdestinations::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemDestinations::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemdestinations::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemDestinations::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class FirewallRulesOutboundRulesItemdestinationsNormalizer implements Denormaliz
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemdestinations();
+        $object = new \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemDestinations();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -131,6 +131,6 @@ class FirewallRulesOutboundRulesItemdestinationsNormalizer implements Denormaliz
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemdestinations::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemDestinations::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallpendingChangesItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/FirewallpendingChangesItemNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class FirewallpendingChangesItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class FirewallPendingChangesItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class FirewallpendingChangesItemNormalizer implements DenormalizerInterface, Nor
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\FirewallpendingChangesItem::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\FirewallPendingChangesItem::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\FirewallpendingChangesItem::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\FirewallPendingChangesItem::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class FirewallpendingChangesItemNormalizer implements DenormalizerInterface, Nor
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\FirewallpendingChangesItem();
+        $object = new \Jane\Generated\DigitalOcean\Model\FirewallPendingChangesItem();
         if (\array_key_exists('removing', $data) && \is_int($data['removing'])) {
             $data['removing'] = (bool) $data['removing'];
         }
@@ -80,6 +80,6 @@ class FirewallpendingChangesItemNormalizer implements DenormalizerInterface, Nor
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\FirewallpendingChangesItem::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\FirewallPendingChangesItem::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/JaneObjectNormalizer.php
@@ -138,11 +138,11 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Generated\DigitalOcean\Model\AppServiceSpec::class => \Jane\Generated\DigitalOcean\Normalizer\AppServiceSpecNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\AppServiceSpeccors::class => \Jane\Generated\DigitalOcean\Normalizer\AppServiceSpeccorsNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\AppServiceSpecCors::class => \Jane\Generated\DigitalOcean\Normalizer\AppServiceSpecCorsNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpec::class => \Jane\Generated\DigitalOcean\Normalizer\AppStaticSiteSpecNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpeccors::class => \Jane\Generated\DigitalOcean\Normalizer\AppStaticSiteSpeccorsNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpecCors::class => \Jane\Generated\DigitalOcean\Normalizer\AppStaticSiteSpecCorsNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\AppJobSpecTermination::class => \Jane\Generated\DigitalOcean\Normalizer\AppJobSpecTerminationNormalizer::class,
         
@@ -630,11 +630,11 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackups::class => \Jane\Generated\DigitalOcean\Normalizer\DropletActionEnableBackupsNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsbackupPolicy::class => \Jane\Generated\DigitalOcean\Normalizer\DropletActionEnableBackupsbackupPolicyNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsBackupPolicy::class => \Jane\Generated\DigitalOcean\Normalizer\DropletActionEnableBackupsBackupPolicyNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicy::class => \Jane\Generated\DigitalOcean\Normalizer\DropletActionChangeBackupPolicyNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicybackupPolicy::class => \Jane\Generated\DigitalOcean\Normalizer\DropletActionChangeBackupPolicybackupPolicyNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicyBackupPolicy::class => \Jane\Generated\DigitalOcean\Normalizer\DropletActionChangeBackupPolicyBackupPolicyNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\DropletActionRestore::class => \Jane\Generated\DigitalOcean\Normalizer\DropletActionRestoreNormalizer::class,
         
@@ -656,15 +656,15 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItem::class => \Jane\Generated\DigitalOcean\Normalizer\FirewallRulesInboundRulesItemNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemsources::class => \Jane\Generated\DigitalOcean\Normalizer\FirewallRulesInboundRulesItemsourcesNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemSources::class => \Jane\Generated\DigitalOcean\Normalizer\FirewallRulesInboundRulesItemSourcesNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItem::class => \Jane\Generated\DigitalOcean\Normalizer\FirewallRulesOutboundRulesItemNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemdestinations::class => \Jane\Generated\DigitalOcean\Normalizer\FirewallRulesOutboundRulesItemdestinationsNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemDestinations::class => \Jane\Generated\DigitalOcean\Normalizer\FirewallRulesOutboundRulesItemDestinationsNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\Firewall::class => \Jane\Generated\DigitalOcean\Normalizer\FirewallNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\FirewallpendingChangesItem::class => \Jane\Generated\DigitalOcean\Normalizer\FirewallpendingChangesItemNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\FirewallPendingChangesItem::class => \Jane\Generated\DigitalOcean\Normalizer\FirewallPendingChangesItemNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\AssociatedResource::class => \Jane\Generated\DigitalOcean\Normalizer\AssociatedResourceNormalizer::class,
         
@@ -822,7 +822,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Generated\DigitalOcean\Model\LoadBalancer::class => \Jane\Generated\DigitalOcean\Normalizer\LoadBalancerNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\LoadBalancerregion::class => \Jane\Generated\DigitalOcean\Normalizer\LoadBalancerregionNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\LoadBalancerRegion::class => \Jane\Generated\DigitalOcean\Normalizer\LoadBalancerRegionNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\SlackDetails::class => \Jane\Generated\DigitalOcean\Normalizer\SlackDetailsNormalizer::class,
         
@@ -874,19 +874,19 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Generated\DigitalOcean\Model\NfsActionResize::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionResizeNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\NfsActionResizeparams::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionResizeparamsNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\NfsActionResizeParams::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionResizeParamsNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\NfsActionSnapshot::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionSnapshotNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotparams::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionSnapshotparamsNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotParams::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionSnapshotParamsNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\NfsActionAttach::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionAttachNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\NfsActionAttachparams::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionAttachparamsNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\NfsActionAttachParams::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionAttachParamsNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\NfsActionDetach::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionDetachNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\NfsActionDetachparams::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionDetachparamsNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\NfsActionDetachParams::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionDetachParamsNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\NfsActionsResponse::class => \Jane\Generated\DigitalOcean\Normalizer\NfsActionsResponseNormalizer::class,
         
@@ -928,7 +928,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Generated\DigitalOcean\Model\Registry::class => \Jane\Generated\DigitalOcean\Normalizer\RegistryNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\Registrysubscription::class => \Jane\Generated\DigitalOcean\Normalizer\RegistrysubscriptionNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\RegistrySubscription::class => \Jane\Generated\DigitalOcean\Normalizer\RegistrySubscriptionNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\MultiregistryCreate::class => \Jane\Generated\DigitalOcean\Normalizer\MultiregistryCreateNormalizer::class,
         
@@ -1012,15 +1012,15 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Generated\DigitalOcean\Model\TagsResources::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\TagsResourcesdroplets::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesdropletsNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\TagsResourcesDroplets::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesDropletsNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\TagsResourcesimgages::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesimgagesNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\TagsResourcesImgages::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesImgagesNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumes::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesvolumesNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumes::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesVolumesNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumeSnapshots::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesvolumeSnapshotsNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumeSnapshots::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesVolumeSnapshotsNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\TagsResourcesdatabases::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesdatabasesNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\TagsResourcesDatabases::class => \Jane\Generated\DigitalOcean\Normalizer\TagsResourcesDatabasesNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\ErrorWithRootCauses::class => \Jane\Generated\DigitalOcean\Normalizer\ErrorWithRootCausesNormalizer::class,
         
@@ -1032,7 +1032,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         
         \Jane\Generated\DigitalOcean\Model\VolumeFull::class => \Jane\Generated\DigitalOcean\Normalizer\VolumeFullNormalizer::class,
         
-        \Jane\Generated\DigitalOcean\Model\VolumeFullregion::class => \Jane\Generated\DigitalOcean\Normalizer\VolumeFullregionNormalizer::class,
+        \Jane\Generated\DigitalOcean\Model\VolumeFullRegion::class => \Jane\Generated\DigitalOcean\Normalizer\VolumeFullRegionNormalizer::class,
         
         \Jane\Generated\DigitalOcean\Model\VolumeBase::class => \Jane\Generated\DigitalOcean\Normalizer\VolumeBaseNormalizer::class,
         
@@ -2050,9 +2050,9 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Generated\DigitalOcean\Model\AppRouteSpec::class => false,
             \Jane\Generated\DigitalOcean\Model\AppServiceSpecTermination::class => false,
             \Jane\Generated\DigitalOcean\Model\AppServiceSpec::class => false,
-            \Jane\Generated\DigitalOcean\Model\AppServiceSpeccors::class => false,
+            \Jane\Generated\DigitalOcean\Model\AppServiceSpecCors::class => false,
             \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpec::class => false,
-            \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpeccors::class => false,
+            \Jane\Generated\DigitalOcean\Model\AppStaticSiteSpecCors::class => false,
             \Jane\Generated\DigitalOcean\Model\AppJobSpecTermination::class => false,
             \Jane\Generated\DigitalOcean\Model\AppJobSpec::class => false,
             \Jane\Generated\DigitalOcean\Model\AppWorkerSpecTermination::class => false,
@@ -2296,9 +2296,9 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Generated\DigitalOcean\Model\SupportedDropletBackupPolicy::class => false,
             \Jane\Generated\DigitalOcean\Model\DropletAction::class => false,
             \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackups::class => false,
-            \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsbackupPolicy::class => false,
+            \Jane\Generated\DigitalOcean\Model\DropletActionEnableBackupsBackupPolicy::class => false,
             \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicy::class => false,
-            \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicybackupPolicy::class => false,
+            \Jane\Generated\DigitalOcean\Model\DropletActionChangeBackupPolicyBackupPolicy::class => false,
             \Jane\Generated\DigitalOcean\Model\DropletActionRestore::class => false,
             \Jane\Generated\DigitalOcean\Model\DropletActionResize::class => false,
             \Jane\Generated\DigitalOcean\Model\DropletActionRebuild::class => false,
@@ -2309,11 +2309,11 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Generated\DigitalOcean\Model\FirewallRuleTarget::class => false,
             \Jane\Generated\DigitalOcean\Model\FirewallRules::class => false,
             \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItem::class => false,
-            \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemsources::class => false,
+            \Jane\Generated\DigitalOcean\Model\FirewallRulesInboundRulesItemSources::class => false,
             \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItem::class => false,
-            \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemdestinations::class => false,
+            \Jane\Generated\DigitalOcean\Model\FirewallRulesOutboundRulesItemDestinations::class => false,
             \Jane\Generated\DigitalOcean\Model\Firewall::class => false,
-            \Jane\Generated\DigitalOcean\Model\FirewallpendingChangesItem::class => false,
+            \Jane\Generated\DigitalOcean\Model\FirewallPendingChangesItem::class => false,
             \Jane\Generated\DigitalOcean\Model\AssociatedResource::class => false,
             \Jane\Generated\DigitalOcean\Model\SelectiveDestroyAssociatedResource::class => false,
             \Jane\Generated\DigitalOcean\Model\DestroyedAssociatedResource::class => false,
@@ -2392,7 +2392,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Generated\DigitalOcean\Model\GlbSettingsCdn::class => false,
             \Jane\Generated\DigitalOcean\Model\LoadBalancerBase::class => false,
             \Jane\Generated\DigitalOcean\Model\LoadBalancer::class => false,
-            \Jane\Generated\DigitalOcean\Model\LoadBalancerregion::class => false,
+            \Jane\Generated\DigitalOcean\Model\LoadBalancerRegion::class => false,
             \Jane\Generated\DigitalOcean\Model\SlackDetails::class => false,
             \Jane\Generated\DigitalOcean\Model\Alerts::class => false,
             \Jane\Generated\DigitalOcean\Model\AlertPolicy::class => false,
@@ -2418,13 +2418,13 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Generated\DigitalOcean\Model\NfsGetResponse::class => false,
             \Jane\Generated\DigitalOcean\Model\NfsAction::class => false,
             \Jane\Generated\DigitalOcean\Model\NfsActionResize::class => false,
-            \Jane\Generated\DigitalOcean\Model\NfsActionResizeparams::class => false,
+            \Jane\Generated\DigitalOcean\Model\NfsActionResizeParams::class => false,
             \Jane\Generated\DigitalOcean\Model\NfsActionSnapshot::class => false,
-            \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotparams::class => false,
+            \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotParams::class => false,
             \Jane\Generated\DigitalOcean\Model\NfsActionAttach::class => false,
-            \Jane\Generated\DigitalOcean\Model\NfsActionAttachparams::class => false,
+            \Jane\Generated\DigitalOcean\Model\NfsActionAttachParams::class => false,
             \Jane\Generated\DigitalOcean\Model\NfsActionDetach::class => false,
-            \Jane\Generated\DigitalOcean\Model\NfsActionDetachparams::class => false,
+            \Jane\Generated\DigitalOcean\Model\NfsActionDetachParams::class => false,
             \Jane\Generated\DigitalOcean\Model\NfsActionsResponse::class => false,
             \Jane\Generated\DigitalOcean\Model\NfsActionsResponseAction::class => false,
             \Jane\Generated\DigitalOcean\Model\NfsSnapshotResponse::class => false,
@@ -2445,7 +2445,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Generated\DigitalOcean\Model\SubscriptionTierBase::class => false,
             \Jane\Generated\DigitalOcean\Model\Subscription::class => false,
             \Jane\Generated\DigitalOcean\Model\Registry::class => false,
-            \Jane\Generated\DigitalOcean\Model\Registrysubscription::class => false,
+            \Jane\Generated\DigitalOcean\Model\RegistrySubscription::class => false,
             \Jane\Generated\DigitalOcean\Model\MultiregistryCreate::class => false,
             \Jane\Generated\DigitalOcean\Model\Multiregistry::class => false,
             \Jane\Generated\DigitalOcean\Model\DockerCredentials::class => false,
@@ -2487,17 +2487,17 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
             \Jane\Generated\DigitalOcean\Model\TagsMetadata::class => false,
             \Jane\Generated\DigitalOcean\Model\Tags::class => false,
             \Jane\Generated\DigitalOcean\Model\TagsResources::class => false,
-            \Jane\Generated\DigitalOcean\Model\TagsResourcesdroplets::class => false,
-            \Jane\Generated\DigitalOcean\Model\TagsResourcesimgages::class => false,
-            \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumes::class => false,
-            \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumeSnapshots::class => false,
-            \Jane\Generated\DigitalOcean\Model\TagsResourcesdatabases::class => false,
+            \Jane\Generated\DigitalOcean\Model\TagsResourcesDroplets::class => false,
+            \Jane\Generated\DigitalOcean\Model\TagsResourcesImgages::class => false,
+            \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumes::class => false,
+            \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumeSnapshots::class => false,
+            \Jane\Generated\DigitalOcean\Model\TagsResourcesDatabases::class => false,
             \Jane\Generated\DigitalOcean\Model\ErrorWithRootCauses::class => false,
             \Jane\Generated\DigitalOcean\Model\TagsResource::class => false,
             \Jane\Generated\DigitalOcean\Model\TagsResourceResourcesItem::class => false,
             \Jane\Generated\DigitalOcean\Model\VolumeBaseRead::class => false,
             \Jane\Generated\DigitalOcean\Model\VolumeFull::class => false,
-            \Jane\Generated\DigitalOcean\Model\VolumeFullregion::class => false,
+            \Jane\Generated\DigitalOcean\Model\VolumeFullRegion::class => false,
             \Jane\Generated\DigitalOcean\Model\VolumeBase::class => false,
             \Jane\Generated\DigitalOcean\Model\VolumeSnapshotId::class => false,
             \Jane\Generated\DigitalOcean\Model\VolumeWriteFileSystemType::class => false,

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/LoadBalancerregionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/LoadBalancerregionNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class LoadBalancerregionNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class LoadBalancerRegionNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class LoadBalancerregionNormalizer implements DenormalizerInterface, NormalizerI
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\LoadBalancerregion::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\LoadBalancerRegion::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\LoadBalancerregion::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\LoadBalancerRegion::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class LoadBalancerregionNormalizer implements DenormalizerInterface, NormalizerI
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\LoadBalancerregion();
+        $object = new \Jane\Generated\DigitalOcean\Model\LoadBalancerRegion();
         if (\array_key_exists('available', $data) && \is_int($data['available'])) {
             $data['available'] = (bool) $data['available'];
         }
@@ -100,6 +100,6 @@ class LoadBalancerregionNormalizer implements DenormalizerInterface, NormalizerI
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\LoadBalancerregion::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\LoadBalancerRegion::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionAttachNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionAttachNormalizer.php
@@ -46,7 +46,7 @@ class NfsActionAttachNormalizer implements DenormalizerInterface, NormalizerInte
             unset($data['region']);
         }
         if (\array_key_exists('params', $data)) {
-            $object->setParams($this->denormalizer->denormalize($data['params'], \Jane\Generated\DigitalOcean\Model\NfsActionAttachparams::class, 'json', $context));
+            $object->setParams($this->denormalizer->denormalize($data['params'], \Jane\Generated\DigitalOcean\Model\NfsActionAttachParams::class, 'json', $context));
             unset($data['params']);
         }
         foreach ($data as $key => $value) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionAttachparamsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionAttachparamsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class NfsActionAttachparamsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class NfsActionAttachParamsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class NfsActionAttachparamsNormalizer implements DenormalizerInterface, Normaliz
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\NfsActionAttachparams::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\NfsActionAttachParams::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\NfsActionAttachparams::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\NfsActionAttachParams::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class NfsActionAttachparamsNormalizer implements DenormalizerInterface, Normaliz
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\NfsActionAttachparams();
+        $object = new \Jane\Generated\DigitalOcean\Model\NfsActionAttachParams();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -61,6 +61,6 @@ class NfsActionAttachparamsNormalizer implements DenormalizerInterface, Normaliz
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\NfsActionAttachparams::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\NfsActionAttachParams::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionDetachNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionDetachNormalizer.php
@@ -46,7 +46,7 @@ class NfsActionDetachNormalizer implements DenormalizerInterface, NormalizerInte
             unset($data['region']);
         }
         if (\array_key_exists('params', $data)) {
-            $object->setParams($this->denormalizer->denormalize($data['params'], \Jane\Generated\DigitalOcean\Model\NfsActionDetachparams::class, 'json', $context));
+            $object->setParams($this->denormalizer->denormalize($data['params'], \Jane\Generated\DigitalOcean\Model\NfsActionDetachParams::class, 'json', $context));
             unset($data['params']);
         }
         foreach ($data as $key => $value) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionDetachparamsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionDetachparamsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class NfsActionDetachparamsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class NfsActionDetachParamsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class NfsActionDetachparamsNormalizer implements DenormalizerInterface, Normaliz
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\NfsActionDetachparams::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\NfsActionDetachParams::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\NfsActionDetachparams::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\NfsActionDetachParams::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class NfsActionDetachparamsNormalizer implements DenormalizerInterface, Normaliz
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\NfsActionDetachparams();
+        $object = new \Jane\Generated\DigitalOcean\Model\NfsActionDetachParams();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -61,6 +61,6 @@ class NfsActionDetachparamsNormalizer implements DenormalizerInterface, Normaliz
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\NfsActionDetachparams::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\NfsActionDetachParams::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionResizeNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionResizeNormalizer.php
@@ -46,7 +46,7 @@ class NfsActionResizeNormalizer implements DenormalizerInterface, NormalizerInte
             unset($data['region']);
         }
         if (\array_key_exists('params', $data)) {
-            $object->setParams($this->denormalizer->denormalize($data['params'], \Jane\Generated\DigitalOcean\Model\NfsActionResizeparams::class, 'json', $context));
+            $object->setParams($this->denormalizer->denormalize($data['params'], \Jane\Generated\DigitalOcean\Model\NfsActionResizeParams::class, 'json', $context));
             unset($data['params']);
         }
         foreach ($data as $key => $value) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionResizeparamsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionResizeparamsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class NfsActionResizeparamsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class NfsActionResizeParamsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class NfsActionResizeparamsNormalizer implements DenormalizerInterface, Normaliz
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\NfsActionResizeparams::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\NfsActionResizeParams::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\NfsActionResizeparams::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\NfsActionResizeParams::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class NfsActionResizeparamsNormalizer implements DenormalizerInterface, Normaliz
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\NfsActionResizeparams();
+        $object = new \Jane\Generated\DigitalOcean\Model\NfsActionResizeParams();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -61,6 +61,6 @@ class NfsActionResizeparamsNormalizer implements DenormalizerInterface, Normaliz
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\NfsActionResizeparams::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\NfsActionResizeParams::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionSnapshotNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionSnapshotNormalizer.php
@@ -46,7 +46,7 @@ class NfsActionSnapshotNormalizer implements DenormalizerInterface, NormalizerIn
             unset($data['region']);
         }
         if (\array_key_exists('params', $data)) {
-            $object->setParams($this->denormalizer->denormalize($data['params'], \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotparams::class, 'json', $context));
+            $object->setParams($this->denormalizer->denormalize($data['params'], \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotParams::class, 'json', $context));
             unset($data['params']);
         }
         foreach ($data as $key => $value) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionSnapshotparamsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/NfsActionSnapshotparamsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class NfsActionSnapshotparamsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class NfsActionSnapshotParamsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class NfsActionSnapshotparamsNormalizer implements DenormalizerInterface, Normal
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotparams::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotParams::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotparams::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotParams::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class NfsActionSnapshotparamsNormalizer implements DenormalizerInterface, Normal
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotparams();
+        $object = new \Jane\Generated\DigitalOcean\Model\NfsActionSnapshotParams();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -61,6 +61,6 @@ class NfsActionSnapshotparamsNormalizer implements DenormalizerInterface, Normal
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\NfsActionSnapshotparams::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\NfsActionSnapshotParams::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/RegistryNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/RegistryNormalizer.php
@@ -58,7 +58,7 @@ class RegistryNormalizer implements DenormalizerInterface, NormalizerInterface, 
             unset($data['storage_usage_bytes_updated_at']);
         }
         if (\array_key_exists('subscription', $data)) {
-            $object->setSubscription($this->denormalizer->denormalize($data['subscription'], \Jane\Generated\DigitalOcean\Model\Registrysubscription::class, 'json', $context));
+            $object->setSubscription($this->denormalizer->denormalize($data['subscription'], \Jane\Generated\DigitalOcean\Model\RegistrySubscription::class, 'json', $context));
             unset($data['subscription']);
         }
         foreach ($data as $key => $value) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/RegistrysubscriptionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/RegistrysubscriptionNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class RegistrysubscriptionNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class RegistrySubscriptionNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class RegistrysubscriptionNormalizer implements DenormalizerInterface, Normalize
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\Registrysubscription::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\RegistrySubscription::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\Registrysubscription::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\RegistrySubscription::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class RegistrysubscriptionNormalizer implements DenormalizerInterface, Normalize
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\Registrysubscription();
+        $object = new \Jane\Generated\DigitalOcean\Model\RegistrySubscription();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -71,6 +71,6 @@ class RegistrysubscriptionNormalizer implements DenormalizerInterface, Normalize
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\Registrysubscription::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\RegistrySubscription::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesNormalizer.php
@@ -46,23 +46,23 @@ class TagsResourcesNormalizer implements DenormalizerInterface, NormalizerInterf
             unset($data['last_tagged_uri']);
         }
         if (\array_key_exists('droplets', $data)) {
-            $object->setDroplets($this->denormalizer->denormalize($data['droplets'], \Jane\Generated\DigitalOcean\Model\TagsResourcesdroplets::class, 'json', $context));
+            $object->setDroplets($this->denormalizer->denormalize($data['droplets'], \Jane\Generated\DigitalOcean\Model\TagsResourcesDroplets::class, 'json', $context));
             unset($data['droplets']);
         }
         if (\array_key_exists('imgages', $data)) {
-            $object->setImgages($this->denormalizer->denormalize($data['imgages'], \Jane\Generated\DigitalOcean\Model\TagsResourcesimgages::class, 'json', $context));
+            $object->setImgages($this->denormalizer->denormalize($data['imgages'], \Jane\Generated\DigitalOcean\Model\TagsResourcesImgages::class, 'json', $context));
             unset($data['imgages']);
         }
         if (\array_key_exists('volumes', $data)) {
-            $object->setVolumes($this->denormalizer->denormalize($data['volumes'], \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumes::class, 'json', $context));
+            $object->setVolumes($this->denormalizer->denormalize($data['volumes'], \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumes::class, 'json', $context));
             unset($data['volumes']);
         }
         if (\array_key_exists('volume_snapshots', $data)) {
-            $object->setVolumeSnapshots($this->denormalizer->denormalize($data['volume_snapshots'], \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumeSnapshots::class, 'json', $context));
+            $object->setVolumeSnapshots($this->denormalizer->denormalize($data['volume_snapshots'], \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumeSnapshots::class, 'json', $context));
             unset($data['volume_snapshots']);
         }
         if (\array_key_exists('databases', $data)) {
-            $object->setDatabases($this->denormalizer->denormalize($data['databases'], \Jane\Generated\DigitalOcean\Model\TagsResourcesdatabases::class, 'json', $context));
+            $object->setDatabases($this->denormalizer->denormalize($data['databases'], \Jane\Generated\DigitalOcean\Model\TagsResourcesDatabases::class, 'json', $context));
             unset($data['databases']);
         }
         foreach ($data as $key => $value) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesdatabasesNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesdatabasesNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class TagsResourcesdatabasesNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class TagsResourcesDatabasesNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class TagsResourcesdatabasesNormalizer implements DenormalizerInterface, Normali
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\TagsResourcesdatabases::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\TagsResourcesDatabases::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\TagsResourcesdatabases::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\TagsResourcesDatabases::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class TagsResourcesdatabasesNormalizer implements DenormalizerInterface, Normali
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\TagsResourcesdatabases();
+        $object = new \Jane\Generated\DigitalOcean\Model\TagsResourcesDatabases();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -70,6 +70,6 @@ class TagsResourcesdatabasesNormalizer implements DenormalizerInterface, Normali
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\TagsResourcesdatabases::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\TagsResourcesDatabases::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesdropletsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesdropletsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class TagsResourcesdropletsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class TagsResourcesDropletsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class TagsResourcesdropletsNormalizer implements DenormalizerInterface, Normaliz
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\TagsResourcesdroplets::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\TagsResourcesDroplets::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\TagsResourcesdroplets::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\TagsResourcesDroplets::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class TagsResourcesdropletsNormalizer implements DenormalizerInterface, Normaliz
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\TagsResourcesdroplets();
+        $object = new \Jane\Generated\DigitalOcean\Model\TagsResourcesDroplets();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -70,6 +70,6 @@ class TagsResourcesdropletsNormalizer implements DenormalizerInterface, Normaliz
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\TagsResourcesdroplets::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\TagsResourcesDroplets::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesimgagesNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesimgagesNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class TagsResourcesimgagesNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class TagsResourcesImgagesNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class TagsResourcesimgagesNormalizer implements DenormalizerInterface, Normalize
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\TagsResourcesimgages::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\TagsResourcesImgages::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\TagsResourcesimgages::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\TagsResourcesImgages::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class TagsResourcesimgagesNormalizer implements DenormalizerInterface, Normalize
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\TagsResourcesimgages();
+        $object = new \Jane\Generated\DigitalOcean\Model\TagsResourcesImgages();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -70,6 +70,6 @@ class TagsResourcesimgagesNormalizer implements DenormalizerInterface, Normalize
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\TagsResourcesimgages::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\TagsResourcesImgages::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesvolumeSnapshotsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesvolumeSnapshotsNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class TagsResourcesvolumeSnapshotsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class TagsResourcesVolumeSnapshotsNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class TagsResourcesvolumeSnapshotsNormalizer implements DenormalizerInterface, N
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumeSnapshots::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumeSnapshots::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumeSnapshots::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumeSnapshots::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class TagsResourcesvolumeSnapshotsNormalizer implements DenormalizerInterface, N
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumeSnapshots();
+        $object = new \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumeSnapshots();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -70,6 +70,6 @@ class TagsResourcesvolumeSnapshotsNormalizer implements DenormalizerInterface, N
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\TagsResourcesvolumeSnapshots::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\TagsResourcesVolumeSnapshots::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesvolumesNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/TagsResourcesvolumesNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class TagsResourcesvolumesNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class TagsResourcesVolumesNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class TagsResourcesvolumesNormalizer implements DenormalizerInterface, Normalize
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumes::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumes::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumes::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumes::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class TagsResourcesvolumesNormalizer implements DenormalizerInterface, Normalize
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\TagsResourcesvolumes();
+        $object = new \Jane\Generated\DigitalOcean\Model\TagsResourcesVolumes();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -70,6 +70,6 @@ class TagsResourcesvolumesNormalizer implements DenormalizerInterface, Normalize
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\TagsResourcesvolumes::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\TagsResourcesVolumes::class => false];
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/V2FirewallsFirewallIdPutBodyNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/V2FirewallsFirewallIdPutBodyNormalizer.php
@@ -52,7 +52,7 @@ class V2FirewallsFirewallIdPutBodyNormalizer implements DenormalizerInterface, N
         if (\array_key_exists('pending_changes', $data)) {
             $values = [];
             foreach ($data['pending_changes'] as $value) {
-                $values[] = $this->denormalizer->denormalize($value, \Jane\Generated\DigitalOcean\Model\FirewallpendingChangesItem::class, 'json', $context);
+                $values[] = $this->denormalizer->denormalize($value, \Jane\Generated\DigitalOcean\Model\FirewallPendingChangesItem::class, 'json', $context);
             }
             $object->setPendingChanges($values);
             unset($data['pending_changes']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/V2FirewallsPostBodyNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/V2FirewallsPostBodyNormalizer.php
@@ -52,7 +52,7 @@ class V2FirewallsPostBodyNormalizer implements DenormalizerInterface, Normalizer
         if (\array_key_exists('pending_changes', $data)) {
             $values = [];
             foreach ($data['pending_changes'] as $value) {
-                $values[] = $this->denormalizer->denormalize($value, \Jane\Generated\DigitalOcean\Model\FirewallpendingChangesItem::class, 'json', $context);
+                $values[] = $this->denormalizer->denormalize($value, \Jane\Generated\DigitalOcean\Model\FirewallPendingChangesItem::class, 'json', $context);
             }
             $object->setPendingChanges($values);
             unset($data['pending_changes']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/VolumeFullNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/VolumeFullNormalizer.php
@@ -80,7 +80,7 @@ class VolumeFullNormalizer implements DenormalizerInterface, NormalizerInterface
             $object->setTags(null);
         }
         if (\array_key_exists('region', $data)) {
-            $object->setRegion($this->denormalizer->denormalize($data['region'], \Jane\Generated\DigitalOcean\Model\VolumeFullregion::class, 'json', $context));
+            $object->setRegion($this->denormalizer->denormalize($data['region'], \Jane\Generated\DigitalOcean\Model\VolumeFullRegion::class, 'json', $context));
             unset($data['region']);
         }
         if (\array_key_exists('filesystem_type', $data)) {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/VolumeFullregionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/VolumeFullregionNormalizer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class VolumeFullregionNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class VolumeFullRegionNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,11 +19,11 @@ class VolumeFullregionNormalizer implements DenormalizerInterface, NormalizerInt
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Generated\DigitalOcean\Model\VolumeFullregion::class;
+        return $type === \Jane\Generated\DigitalOcean\Model\VolumeFullRegion::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\VolumeFullregion::class;
+        return is_object($data) && get_class($data) === \Jane\Generated\DigitalOcean\Model\VolumeFullRegion::class;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
@@ -33,7 +33,7 @@ class VolumeFullregionNormalizer implements DenormalizerInterface, NormalizerInt
         if (isset($data['$recursiveRef'])) {
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
-        $object = new \Jane\Generated\DigitalOcean\Model\VolumeFullregion();
+        $object = new \Jane\Generated\DigitalOcean\Model\VolumeFullRegion();
         if (\array_key_exists('available', $data) && \is_int($data['available'])) {
             $data['available'] = (bool) $data['available'];
         }
@@ -100,6 +100,6 @@ class VolumeFullregionNormalizer implements DenormalizerInterface, NormalizerInt
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Generated\DigitalOcean\Model\VolumeFullregion::class => false];
+        return [\Jane\Generated\DigitalOcean\Model\VolumeFullRegion::class => false];
     }
 }


### PR DESCRIPTION
When generating models from an OpenAPI schema, inline objects defined under allOf properties were generated with lowercase suffixes (e.g. SalesRetrieveInvoicesRequestfilter instead of SalesRetrieveInvoicesRequestFilter).

Cause: In AllOfGuesser::guessClass(), when creating the sub-class for an allOf property, the property $key was concatenated directly to the parent $name (i.e. $name . $key). This skips the standard ucfirst() capitalization step that is correctly applied elsewhere (like in the standard ObjectGuesser).

Fix: Updated the concatenated string to $name . ucfirst($key) to ensure generated classes follow proper PascalCase naming conventions.