### PR TITLE
GH#776 - Allow number query parameters to accept int or float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [JsonSchema] [GH#933](https://github.com/janephp/janephp/pull/933) Fix denormalizers using `$data` before type checking it
+- [OpenApi] [GH#934](https://github.com/janephp/janephp/pull/934) Allow number query parameters to accept int or float
 
 ### Fixed
 - [OpenApi3] [GH#917](https://github.com/janephp/janephp/pull/917) Multipart/form-data requests failing with non-scalar properties (objects, arrays) by serializing them to JSON

--- a/src/Component/OpenApi2/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi2/Generator/Parameter/NonBodyParameterGenerator.php
@@ -8,6 +8,7 @@ use Jane\Component\OpenApi2\JsonSchema\Model\HeaderParameterSubSchema;
 use Jane\Component\OpenApi2\JsonSchema\Model\PathParameterSubSchema;
 use Jane\Component\OpenApi2\JsonSchema\Model\QueryParameterSubSchema;
 use Jane\Component\OpenApiCommon\Generator\Parameter\ParameterGenerator;
+use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
 use Jane\Component\OpenApiCommon\Generator\Traits\OptionResolverNormalizationTrait;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
@@ -17,6 +18,7 @@ use Psr\Http\Message\StreamInterface;
 
 class NonBodyParameterGenerator extends ParameterGenerator
 {
+    use OpenApiNumberTypeResolverTrait;
     use OptionResolverNormalizationTrait;
 
     /**
@@ -31,7 +33,7 @@ class NonBodyParameterGenerator extends ParameterGenerator
             $methodParameter->default = $this->getDefaultAsExpr($parameter);
         }
 
-        $types = $this->convertParameterType($parameter->getType());
+        $types = $this->convertParameterType($parameter);
 
         if (\count($types) === 1) {
             $methodParameter->type = new Node\Name($types[0]);
@@ -66,7 +68,7 @@ class NonBodyParameterGenerator extends ParameterGenerator
             if ($parameter->getType()) {
                 $types = [];
 
-                foreach ($this->convertParameterType($parameter->getType()) as $typeString) {
+                foreach ($this->convertParameterType($parameter) as $typeString) {
                     if (\in_array($typeString, $genericResolverKeys)) {
                         $matchGenericResolver = $typeString;
                     }
@@ -109,7 +111,7 @@ class NonBodyParameterGenerator extends ParameterGenerator
      */
     public function generateMethodDocParameter($parameter, Context $context, string $reference): string
     {
-        $type = implode('|', $this->convertParameterType($parameter->getType()));
+        $type = implode('|', $this->convertParameterType($parameter));
         $description = array_map(rtrim(...), explode("\n", $parameter->getDescription() ?: ''));
 
         $param = [rtrim(\sprintf(' * @param %s $%s %s', $type, $this->getInflector()->camelize($parameter->getName()), array_shift($description)))];
@@ -122,7 +124,7 @@ class NonBodyParameterGenerator extends ParameterGenerator
 
     public function generateOptionDocParameter(PathParameterSubSchema|HeaderParameterSubSchema|FormDataParameterSubSchema|QueryParameterSubSchema $parameter): string
     {
-        $type = implode('|', $this->convertParameterType($parameter->getType()));
+        $type = implode('|', $this->convertParameterType($parameter));
         $description = array_map(rtrim(...), explode("\n", $parameter->getDescription() ?: ''));
 
         $var = [rtrim(\sprintf(' *     @var %s $%s %s', $type, $parameter->getName(), array_shift($description)))];
@@ -148,11 +150,19 @@ class NonBodyParameterGenerator extends ParameterGenerator
         return $expr;
     }
 
-    private function convertParameterType(string $type): array
+    private function convertParameterType(PathParameterSubSchema|HeaderParameterSubSchema|FormDataParameterSubSchema|QueryParameterSubSchema $parameter): array
     {
+        $type = $parameter->getType();
         $convertArray = [
             'string' => ['string'],
-            'number' => ['float'],
+            'number' => [$this->isNumberFloat(
+                $parameter->getFormat(),
+                $parameter->getDefault(),
+                $parameter->getMinimum(),
+                $parameter->getMaximum(),
+                $parameter->getMultipleOf(),
+                $parameter->getEnum()
+            ) ? 'float' : 'int'],
             'boolean' => ['bool'],
             'integer' => ['int'],
             'array' => ['array'],

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Client.php
@@ -40,7 +40,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
      * @param array $queryParameters {
      *     @var string $testString
      *     @var int $testInteger
-     *     @var float $testFloat
+     *     @var int $testFloat
      *     @var array $testArray
      *     @var string $testRequired
      *     @var string $testDefault
@@ -57,7 +57,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
      * @param array $headerParameters {
      *     @var string $testString
      *     @var int $testInteger
-     *     @var float $testFloat
+     *     @var int $testFloat
      *     @var array $testArray
      *     @var string $testRequired
      *     @var string $testDefault
@@ -74,7 +74,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
      * @param array $formParameters {
      *     @var string $testString
      *     @var int $testInteger
-     *     @var float $testFloat
+     *     @var int $testFloat
      *     @var array $testArray
      *     @var string $testRequired
      *     @var string $testDefault
@@ -112,12 +112,12 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
     /**
      * @param string $testString
      * @param int $testInteger
-     * @param float $testFloat
+     * @param int $testFloat
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
      * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
      */
-    public function testPathParameters(string $testString, int $testInteger, float $testFloat, string $fetch = self::FETCH_OBJECT)
+    public function testPathParameters(string $testString, int $testInteger, int $testFloat, string $fetch = self::FETCH_OBJECT)
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Endpoint\TestPathParameters($testString, $testInteger, $testFloat), $fetch);
     }

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestFormParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestFormParameters.php
@@ -8,7 +8,7 @@ class TestFormParameters extends \Jane\Component\OpenApi2\Tests\Expected\Runtime
      * @param array $formParameters {
      *     @var string $testString
      *     @var int $testInteger
-     *     @var float $testFloat
+     *     @var int $testFloat
      *     @var array $testArray
      *     @var string $testRequired
      *     @var string $testDefault
@@ -39,7 +39,7 @@ class TestFormParameters extends \Jane\Component\OpenApi2\Tests\Expected\Runtime
         $optionsResolver->setDefaults(['testDefault' => 'test']);
         $optionsResolver->addAllowedTypes('testString', ['string']);
         $optionsResolver->addAllowedTypes('testInteger', ['int']);
-        $optionsResolver->addAllowedTypes('testFloat', ['float']);
+        $optionsResolver->addAllowedTypes('testFloat', ['int']);
         $optionsResolver->addAllowedTypes('testArray', ['array']);
         $optionsResolver->addAllowedTypes('testRequired', ['string']);
         $optionsResolver->addAllowedTypes('testDefault', ['string']);

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
@@ -8,7 +8,7 @@ class TestHeaderParameters extends \Jane\Component\OpenApi2\Tests\Expected\Runti
      * @param array $headerParameters {
      *     @var string $testString
      *     @var int $testInteger
-     *     @var float $testFloat
+     *     @var int $testFloat
      *     @var array $testArray
      *     @var string $testRequired
      *     @var string $testDefault
@@ -39,7 +39,7 @@ class TestHeaderParameters extends \Jane\Component\OpenApi2\Tests\Expected\Runti
         $optionsResolver->setDefaults(['testDefault' => 'test']);
         $optionsResolver->addAllowedTypes('testString', ['string']);
         $optionsResolver->addAllowedTypes('testInteger', ['int']);
-        $optionsResolver->addAllowedTypes('testFloat', ['float']);
+        $optionsResolver->addAllowedTypes('testFloat', ['int']);
         $optionsResolver->addAllowedTypes('testArray', ['array']);
         $optionsResolver->addAllowedTypes('testRequired', ['string']);
         $optionsResolver->addAllowedTypes('testDefault', ['string']);

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestPathParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestPathParameters.php
@@ -10,9 +10,9 @@ class TestPathParameters extends \Jane\Component\OpenApi2\Tests\Expected\Runtime
     /**
      * @param string $testString
      * @param int $testInteger
-     * @param float $testFloat
+     * @param int $testFloat
      */
-    public function __construct(string $testString, int $testInteger, float $testFloat)
+    public function __construct(string $testString, int $testInteger, int $testFloat)
     {
         $this->testString = $testString;
         $this->testInteger = $testInteger;

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
@@ -8,7 +8,7 @@ class TestQueryParameters extends \Jane\Component\OpenApi2\Tests\Expected\Runtim
      * @param array $queryParameters {
      *     @var string $testString
      *     @var int $testInteger
-     *     @var float $testFloat
+     *     @var int $testFloat
      *     @var array $testArray
      *     @var string $testRequired
      *     @var string $testDefault
@@ -39,7 +39,7 @@ class TestQueryParameters extends \Jane\Component\OpenApi2\Tests\Expected\Runtim
         $optionsResolver->setDefaults(['testDefault' => 'test']);
         $optionsResolver->addAllowedTypes('testString', ['string']);
         $optionsResolver->addAllowedTypes('testInteger', ['int']);
-        $optionsResolver->addAllowedTypes('testFloat', ['float']);
+        $optionsResolver->addAllowedTypes('testFloat', ['int']);
         $optionsResolver->addAllowedTypes('testArray', ['array']);
         $optionsResolver->addAllowedTypes('testRequired', ['string']);
         $optionsResolver->addAllowedTypes('testDefault', ['string']);

--- a/src/Component/OpenApi3/Generator/Endpoint/GetGetExtraHeadersTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetGetExtraHeadersTrait.php
@@ -2,9 +2,9 @@
 
 namespace Jane\Component\OpenApi3\Generator\Endpoint;
 
+use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\OpenApi3\Guesser\GuessClass;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
-use Jane\Component\JsonSchema\Generator\Context\Context;
 use PhpParser\Modifiers;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;

--- a/src/Component/OpenApi3/Generator/Endpoint/GetResponseContentTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetResponseContentTrait.php
@@ -2,8 +2,8 @@
 
 namespace Jane\Component\OpenApi3\Generator\Endpoint;
 
-use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi3\Guesser\GuessClass;
 use Jane\Component\OpenApi3\JsonSchema\Model\Response;
 use Jane\Component\OpenApi3\JsonSchema\Normalizer\ResponseNormalizer;

--- a/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
@@ -8,6 +8,7 @@ use Jane\Component\OpenApi3\Guesser\GuessClass;
 use Jane\Component\OpenApi3\JsonSchema\Model\Parameter;
 use Jane\Component\OpenApi3\JsonSchema\Model\Schema;
 use Jane\Component\OpenApiCommon\Generator\Parameter\ParameterGenerator;
+use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
 use Jane\Component\OpenApiCommon\Generator\Traits\OptionResolverNormalizationTrait;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
@@ -19,6 +20,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class NonBodyParameterGenerator extends ParameterGenerator
 {
+    use OpenApiNumberTypeResolverTrait;
     use OptionResolverNormalizationTrait;
 
     private GuessClass $guessClass;
@@ -199,7 +201,14 @@ class NonBodyParameterGenerator extends ParameterGenerator
 
         $convertArray = [
             'string' => ['string'],
-            'number' => ['float'],
+            'number' => [$this->isNumberFloat(
+                $schema->getFormat(),
+                $schema->getDefault(),
+                $schema->getMinimum(),
+                $schema->getMaximum(),
+                $schema->getMultipleOf(),
+                $schema->getEnum()
+            ) ? 'float' : 'int'],
             'boolean' => ['bool'],
             'integer' => ['int'],
             'array' => ['array'],

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php
@@ -40,7 +40,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * @param array{
      *    "testString"?: string,
      *    "testInteger"?: int,
-     *    "testFloat"?: float,
+     *    "testFloat"?: int,
      *    "testArray"?: array,
      *    "testRequired": string,
      *    "testDefault"?: string,
@@ -57,7 +57,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * @param array{
      *    "testString"?: string,
      *    "testInteger"?: int,
-     *    "testFloat"?: float,
+     *    "testFloat"?: int,
      *    "testArray"?: array,
      *    "testRequired": string,
      *    "testDefault"?: string,
@@ -103,12 +103,12 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     /**
      * @param string $testString
      * @param int $testInteger
-     * @param float $testFloat
+     * @param int $testFloat
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
      * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
      */
-    public function testPathParameters(string $testString, int $testInteger, float $testFloat, string $fetch = self::FETCH_OBJECT)
+    public function testPathParameters(string $testString, int $testInteger, int $testFloat, string $fetch = self::FETCH_OBJECT)
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\TestPathParameters($testString, $testInteger, $testFloat), $fetch);
     }

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestHeaderParameters.php
@@ -8,7 +8,7 @@ class TestHeaderParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runti
      * @param array{
      *    "testString"?: string,
      *    "testInteger"?: int,
-     *    "testFloat"?: float,
+     *    "testFloat"?: int,
      *    "testArray"?: array,
      *    "testRequired": string,
      *    "testDefault"?: string,
@@ -39,7 +39,7 @@ class TestHeaderParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runti
         $optionsResolver->setDefaults(['testDefault' => 'test']);
         $optionsResolver->addAllowedTypes('testString', ['string']);
         $optionsResolver->addAllowedTypes('testInteger', ['int']);
-        $optionsResolver->addAllowedTypes('testFloat', ['float']);
+        $optionsResolver->addAllowedTypes('testFloat', ['int']);
         $optionsResolver->addAllowedTypes('testArray', ['array']);
         $optionsResolver->addAllowedTypes('testRequired', ['string']);
         $optionsResolver->addAllowedTypes('testDefault', ['string']);

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestPathParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestPathParameters.php
@@ -10,9 +10,9 @@ class TestPathParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runtime
     /**
      * @param string $testString
      * @param int $testInteger
-     * @param float $testFloat
+     * @param int $testFloat
      */
-    public function __construct(string $testString, int $testInteger, float $testFloat)
+    public function __construct(string $testString, int $testInteger, int $testFloat)
     {
         $this->testString = $testString;
         $this->testInteger = $testInteger;

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestQueryParameters.php
@@ -8,7 +8,7 @@ class TestQueryParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runtim
      * @param array{
      *    "testString"?: string,
      *    "testInteger"?: int,
-     *    "testFloat"?: float,
+     *    "testFloat"?: int,
      *    "testArray"?: array,
      *    "testRequired": string,
      *    "testDefault"?: string,
@@ -39,7 +39,7 @@ class TestQueryParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runtim
         $optionsResolver->setDefaults(['testDefault' => 'test']);
         $optionsResolver->addAllowedTypes('testString', ['string']);
         $optionsResolver->addAllowedTypes('testInteger', ['int']);
-        $optionsResolver->addAllowedTypes('testFloat', ['float']);
+        $optionsResolver->addAllowedTypes('testFloat', ['int']);
         $optionsResolver->addAllowedTypes('testArray', ['array']);
         $optionsResolver->addAllowedTypes('testRequired', ['string']);
         $optionsResolver->addAllowedTypes('testDefault', ['string']);

--- a/src/Component/OpenApi31/Generator/Endpoint/GetGetExtraHeadersTrait.php
+++ b/src/Component/OpenApi31/Generator/Endpoint/GetGetExtraHeadersTrait.php
@@ -2,9 +2,9 @@
 
 namespace Jane\Component\OpenApi31\Generator\Endpoint;
 
+use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\OpenApi31\Guesser\GuessClass;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
-use Jane\Component\JsonSchema\Generator\Context\Context;
 use PhpParser\Modifiers;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;

--- a/src/Component/OpenApi31/Generator/Endpoint/GetResponseContentTrait.php
+++ b/src/Component/OpenApi31/Generator/Endpoint/GetResponseContentTrait.php
@@ -2,8 +2,8 @@
 
 namespace Jane\Component\OpenApi31\Generator\Endpoint;
 
-use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi31\Guesser\GuessClass;
 use Jane\Component\OpenApi31\JsonSchema\Model\Response;
 use Jane\Component\OpenApi31\JsonSchema\Normalizer\ResponseNormalizer;

--- a/src/Component/OpenApi31/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi31/Generator/Parameter/NonBodyParameterGenerator.php
@@ -8,6 +8,7 @@ use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi31\Guesser\GuessClass;
 use Jane\Component\OpenApi31\JsonSchema\Model\Parameter;
 use Jane\Component\OpenApiCommon\Generator\Parameter\ParameterGenerator;
+use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
 use Jane\Component\OpenApiCommon\Generator\Traits\OptionResolverNormalizationTrait;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
@@ -19,6 +20,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class NonBodyParameterGenerator extends ParameterGenerator
 {
+    use OpenApiNumberTypeResolverTrait;
     use OptionResolverNormalizationTrait;
 
     private GuessClass $guessClass;
@@ -202,7 +204,14 @@ class NonBodyParameterGenerator extends ParameterGenerator
 
         $convertArray = [
             'string' => ['string'],
-            'number' => ['float'],
+            'number' => [$this->isNumberFloat(
+                $schema->getFormat(),
+                $schema->getDefault(),
+                $schema->getMinimum(),
+                $schema->getMaximum(),
+                $schema->getMultipleOf(),
+                $schema->getEnum()
+            ) ? 'float' : 'int'],
             'boolean' => ['bool'],
             'integer' => ['int'],
             'array' => ['array'],

--- a/src/Component/OpenApiCommon/Generator/Traits/OpenApiNumberTypeResolverTrait.php
+++ b/src/Component/OpenApiCommon/Generator/Traits/OpenApiNumberTypeResolverTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Jane\Component\OpenApiCommon\Generator\Traits;
+
+trait OpenApiNumberTypeResolverTrait
+{
+    private function isNumberFloat(?string $format, mixed $default, ?float $minimum, ?float $maximum, ?float $multipleOf, ?array $enum): bool
+    {
+        if (\in_array($format, ['float', 'double'], true)) {
+            return true;
+        }
+
+        if ($this->isFloatLikeNumeric($default)) {
+            return true;
+        }
+
+        if ($this->isFloatLikeNumeric($minimum)) {
+            return true;
+        }
+
+        if ($this->isFloatLikeNumeric($maximum)) {
+            return true;
+        }
+
+        if ($this->isFloatLikeNumeric($multipleOf)) {
+            return true;
+        }
+
+        foreach ($enum ?? [] as $enumValue) {
+            if ($this->isFloatLikeNumeric($enumValue)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isFloatLikeNumeric(mixed $value): bool
+    {
+        if (!is_numeric($value)) {
+            return false;
+        }
+
+        return (float) $value != (int) $value;
+    }
+}


### PR DESCRIPTION
Fixes #776 