### PR TITLE
Enums as classes

### DIFF
--- a/docs/json_schema/component.md
+++ b/docs/json_schema/component.md
@@ -154,6 +154,9 @@ Other options are available to customize the generated code:
 - `validation`: Will enable validation following JSON Schema validation specification. By default it is disabled. You
   can read more about it in the dedicated [Validation guide](../guides/validation.md).
 - `include-null-value`: Will enable a way to manage null values. By default it is enabled.
+- `enums-as-objects`: When enabled, schemas with `type: string` or `type: integer` that have an `enum` keyword will
+ be generated as native PHP backed enums instead of plain scalar types. The generated enum cases use PascalCase naming.
+ Properties referencing these schemas will be typed with the enum class. By default it is disabled.
 
 ## Using a generated Model
 

--- a/docs/openapi/component.md
+++ b/docs/openapi/component.md
@@ -159,6 +159,9 @@ Other options are available to customize the generated code:
 - `validation`: Will enable validation following JSON Schema validation specification. By default it is disabled. You
  can read more about it on the dedicated guide: [Validation guide](../guides/validation.md).
 - `include-null-value`: Will enable a way to manage null values. By default it is enabled.
+- `enums-as-objects`: When enabled, schemas with `type: string` or `type: integer` that have an `enum` keyword will
+ be generated as native PHP backed enums instead of plain scalar types. The generated enum cases use PascalCase naming.
+ Properties referencing these schemas will be typed with the enum class. By default it is disabled.
 - `whitelisted-paths`: This option allows you to generate only needed endpoints and related models. Be carefull,
  that option will filter models used by whitelisted endpoints and generate model & normalizer only for them. Here is
  some examples about how to use it:

--- a/src/Bundle/JsonSchemaBundle/Tests/Resources/config/reference.php
+++ b/src/Bundle/JsonSchemaBundle/Tests/Resources/config/reference.php
@@ -33,11 +33,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     type?: string|null,
  *     ignore_errors?: bool,
  * }>
- * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|Param|null>|Param|null>
+ * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|null>|null>
  * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>
  * @psalm-type CallType = array<string, ArgumentsType>|array{0:string, 1?:ArgumentsType, 2?:bool}|array{method:string, arguments?:ArgumentsType, returns_clone?:bool}
  * @psalm-type TagsType = list<string|array<string, array<string, mixed>>> // arrays inside the list must have only one element, with the tag name as the key
- * @psalm-type CallbackType = string|array{0:string|ReferenceConfigurator,1:string}|\Closure|ReferenceConfigurator
+ * @psalm-type CallbackType = string|array{0:string|ReferenceConfigurator,1:string}|\Closure|ReferenceConfigurator|ExpressionConfigurator
  * @psalm-type DeprecationType = array{package: string, version: string, message?: string}
  * @psalm-type DefaultsType = array{
  *     public?: bool,
@@ -126,44 +126,44 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type ExtensionType = array<string, mixed>
  * @psalm-type FrameworkConfig = array{
- *     secret?: scalar|Param|null,
+ *     secret?: scalar|null|Param,
  *     http_method_override?: bool|Param, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
  *     allowed_http_method_override?: list<string|Param>|null,
- *     trust_x_sendfile_type_header?: scalar|Param|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
- *     ide?: scalar|Param|null, // Default: "%env(default::SYMFONY_IDE)%"
+ *     trust_x_sendfile_type_header?: scalar|null|Param, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
+ *     ide?: scalar|null|Param, // Default: "%env(default::SYMFONY_IDE)%"
  *     test?: bool|Param,
- *     default_locale?: scalar|Param|null, // Default: "en"
+ *     default_locale?: scalar|null|Param, // Default: "en"
  *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
  *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
- *     enabled_locales?: list<scalar|Param|null>,
- *     trusted_hosts?: list<scalar|Param|null>,
+ *     enabled_locales?: list<scalar|null|Param>,
+ *     trusted_hosts?: list<scalar|null|Param>,
  *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
- *     trusted_headers?: list<scalar|Param|null>,
- *     error_controller?: scalar|Param|null, // Default: "error_controller"
+ *     trusted_headers?: list<scalar|null|Param>,
+ *     error_controller?: scalar|null|Param, // Default: "error_controller"
  *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
  *     csrf_protection?: bool|array{
- *         enabled?: scalar|Param|null, // Default: null
- *         stateless_token_ids?: list<scalar|Param|null>,
- *         check_header?: scalar|Param|null, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
- *         cookie_name?: scalar|Param|null, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
+ *         enabled?: scalar|null|Param, // Default: null
+ *         stateless_token_ids?: list<scalar|null|Param>,
+ *         check_header?: scalar|null|Param, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
+ *         cookie_name?: scalar|null|Param, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
  *     },
  *     form?: bool|array{ // Form configuration
  *         enabled?: bool|Param, // Default: false
- *         csrf_protection?: bool|array{
- *             enabled?: scalar|Param|null, // Default: null
- *             token_id?: scalar|Param|null, // Default: null
- *             field_name?: scalar|Param|null, // Default: "_token"
- *             field_attr?: array<string, scalar|Param|null>,
+ *         csrf_protection?: array{
+ *             enabled?: scalar|null|Param, // Default: null
+ *             token_id?: scalar|null|Param, // Default: null
+ *             field_name?: scalar|null|Param, // Default: "_token"
+ *             field_attr?: array<string, scalar|null|Param>,
  *         },
  *     },
  *     http_cache?: bool|array{ // HTTP cache configuration
  *         enabled?: bool|Param, // Default: false
  *         debug?: bool|Param, // Default: "%kernel.debug%"
  *         trace_level?: "none"|"short"|"full"|Param,
- *         trace_header?: scalar|Param|null,
+ *         trace_header?: scalar|null|Param,
  *         default_ttl?: int|Param,
- *         private_headers?: list<scalar|Param|null>,
- *         skip_response_headers?: list<scalar|Param|null>,
+ *         private_headers?: list<scalar|null|Param>,
+ *         skip_response_headers?: list<scalar|null|Param>,
  *         allow_reload?: bool|Param,
  *         allow_revalidate?: bool|Param,
  *         stale_while_revalidate?: int|Param,
@@ -178,16 +178,16 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     fragments?: bool|array{ // Fragments configuration
  *         enabled?: bool|Param, // Default: false
- *         hinclude_default_template?: scalar|Param|null, // Default: null
- *         path?: scalar|Param|null, // Default: "/_fragment"
+ *         hinclude_default_template?: scalar|null|Param, // Default: null
+ *         path?: scalar|null|Param, // Default: "/_fragment"
  *     },
  *     profiler?: bool|array{ // Profiler configuration
  *         enabled?: bool|Param, // Default: false
  *         collect?: bool|Param, // Default: true
- *         collect_parameter?: scalar|Param|null, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
+ *         collect_parameter?: scalar|null|Param, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
  *         only_exceptions?: bool|Param, // Default: false
  *         only_main_requests?: bool|Param, // Default: false
- *         dsn?: scalar|Param|null, // Default: "file:%kernel.cache_dir%/profiler"
+ *         dsn?: scalar|null|Param, // Default: "file:%kernel.cache_dir%/profiler"
  *         collect_serializer_data?: true|Param, // Default: true
  *     },
  *     workflows?: bool|array{
@@ -199,164 +199,164 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
  *             marking_store?: array{
  *                 type?: "method"|Param,
- *                 property?: scalar|Param|null,
- *                 service?: scalar|Param|null,
+ *                 property?: scalar|null|Param,
+ *                 service?: scalar|null|Param,
  *             },
- *             supports?: list<scalar|Param|null>,
- *             definition_validators?: list<scalar|Param|null>,
- *             support_strategy?: scalar|Param|null,
- *             initial_marking?: list<scalar|Param|null>,
+ *             supports?: list<scalar|null|Param>,
+ *             definition_validators?: list<scalar|null|Param>,
+ *             support_strategy?: scalar|null|Param,
+ *             initial_marking?: list<scalar|null|Param>,
  *             events_to_dispatch?: list<string|Param>|null,
  *             places?: list<array{ // Default: []
- *                 name?: scalar|Param|null,
- *                 metadata?: array<string, mixed>,
+ *                 name: scalar|null|Param,
+ *                 metadata?: list<mixed>,
  *             }>,
- *             transitions?: list<array{ // Default: []
- *                 name?: string|Param,
+ *             transitions: list<array{ // Default: []
+ *                 name: string|Param,
  *                 guard?: string|Param, // An expression to block the transition.
  *                 from?: list<array{ // Default: []
- *                     place?: string|Param,
+ *                     place: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
  *                 to?: list<array{ // Default: []
- *                     place?: string|Param,
+ *                     place: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
  *                 weight?: int|Param, // Default: 1
- *                 metadata?: array<string, mixed>,
+ *                 metadata?: list<mixed>,
  *             }>,
- *             metadata?: array<string, mixed>,
+ *             metadata?: list<mixed>,
  *         }>,
  *     },
  *     router?: bool|array{ // Router configuration
  *         enabled?: bool|Param, // Default: false
- *         resource?: scalar|Param|null,
- *         type?: scalar|Param|null,
- *         default_uri?: scalar|Param|null, // The default URI used to generate URLs in a non-HTTP context. // Default: null
- *         http_port?: scalar|Param|null, // Default: 80
- *         https_port?: scalar|Param|null, // Default: 443
- *         strict_requirements?: scalar|Param|null, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
+ *         resource: scalar|null|Param,
+ *         type?: scalar|null|Param,
+ *         default_uri?: scalar|null|Param, // The default URI used to generate URLs in a non-HTTP context. // Default: null
+ *         http_port?: scalar|null|Param, // Default: 80
+ *         https_port?: scalar|null|Param, // Default: 443
+ *         strict_requirements?: scalar|null|Param, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
  *         utf8?: bool|Param, // Default: true
  *     },
  *     session?: bool|array{ // Session configuration
  *         enabled?: bool|Param, // Default: false
- *         storage_factory_id?: scalar|Param|null, // Default: "session.storage.factory.native"
- *         handler_id?: scalar|Param|null, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
- *         name?: scalar|Param|null,
- *         cookie_lifetime?: scalar|Param|null,
- *         cookie_path?: scalar|Param|null,
- *         cookie_domain?: scalar|Param|null,
+ *         storage_factory_id?: scalar|null|Param, // Default: "session.storage.factory.native"
+ *         handler_id?: scalar|null|Param, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
+ *         name?: scalar|null|Param,
+ *         cookie_lifetime?: scalar|null|Param,
+ *         cookie_path?: scalar|null|Param,
+ *         cookie_domain?: scalar|null|Param,
  *         cookie_secure?: true|false|"auto"|Param, // Default: "auto"
  *         cookie_httponly?: bool|Param, // Default: true
  *         cookie_samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
  *         use_cookies?: bool|Param,
- *         gc_divisor?: scalar|Param|null,
- *         gc_probability?: scalar|Param|null,
- *         gc_maxlifetime?: scalar|Param|null,
- *         save_path?: scalar|Param|null, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
+ *         gc_divisor?: scalar|null|Param,
+ *         gc_probability?: scalar|null|Param,
+ *         gc_maxlifetime?: scalar|null|Param,
+ *         save_path?: scalar|null|Param, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
  *         metadata_update_threshold?: int|Param, // Seconds to wait between 2 session metadata updates. // Default: 0
  *     },
  *     request?: bool|array{ // Request configuration
  *         enabled?: bool|Param, // Default: false
- *         formats?: array<string, string|list<scalar|Param|null>>,
+ *         formats?: array<string, string|list<scalar|null|Param>>,
  *     },
  *     assets?: bool|array{ // Assets configuration
  *         enabled?: bool|Param, // Default: false
  *         strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *         version_strategy?: scalar|Param|null, // Default: null
- *         version?: scalar|Param|null, // Default: null
- *         version_format?: scalar|Param|null, // Default: "%%s?%%s"
- *         json_manifest_path?: scalar|Param|null, // Default: null
- *         base_path?: scalar|Param|null, // Default: ""
- *         base_urls?: list<scalar|Param|null>,
+ *         version_strategy?: scalar|null|Param, // Default: null
+ *         version?: scalar|null|Param, // Default: null
+ *         version_format?: scalar|null|Param, // Default: "%%s?%%s"
+ *         json_manifest_path?: scalar|null|Param, // Default: null
+ *         base_path?: scalar|null|Param, // Default: ""
+ *         base_urls?: list<scalar|null|Param>,
  *         packages?: array<string, array{ // Default: []
  *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *             version_strategy?: scalar|Param|null, // Default: null
- *             version?: scalar|Param|null,
- *             version_format?: scalar|Param|null, // Default: null
- *             json_manifest_path?: scalar|Param|null, // Default: null
- *             base_path?: scalar|Param|null, // Default: ""
- *             base_urls?: list<scalar|Param|null>,
+ *             version_strategy?: scalar|null|Param, // Default: null
+ *             version?: scalar|null|Param,
+ *             version_format?: scalar|null|Param, // Default: null
+ *             json_manifest_path?: scalar|null|Param, // Default: null
+ *             base_path?: scalar|null|Param, // Default: ""
+ *             base_urls?: list<scalar|null|Param>,
  *         }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
  *         enabled?: bool|Param, // Default: false
- *         paths?: array<string, scalar|Param|null>,
- *         excluded_patterns?: list<scalar|Param|null>,
+ *         paths?: array<string, scalar|null|Param>,
+ *         excluded_patterns?: list<scalar|null|Param>,
  *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
  *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
- *         public_prefix?: scalar|Param|null, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
+ *         public_prefix?: scalar|null|Param, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
  *         missing_import_mode?: "strict"|"warn"|"ignore"|Param, // Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. "import './non-existent.js'". "strict" means an exception is thrown, "warn" means a warning is logged, "ignore" means the import is left as-is. // Default: "warn"
- *         extensions?: array<string, scalar|Param|null>,
- *         importmap_path?: scalar|Param|null, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
- *         importmap_polyfill?: scalar|Param|null, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
- *         importmap_script_attributes?: array<string, scalar|Param|null>,
- *         vendor_dir?: scalar|Param|null, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
+ *         extensions?: array<string, scalar|null|Param>,
+ *         importmap_path?: scalar|null|Param, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
+ *         importmap_polyfill?: scalar|null|Param, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
+ *         importmap_script_attributes?: array<string, scalar|null|Param>,
+ *         vendor_dir?: scalar|null|Param, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
  *         precompress?: bool|array{ // Precompress assets with Brotli, Zstandard and gzip.
  *             enabled?: bool|Param, // Default: false
- *             formats?: list<scalar|Param|null>,
- *             extensions?: list<scalar|Param|null>,
+ *             formats?: list<scalar|null|Param>,
+ *             extensions?: list<scalar|null|Param>,
  *         },
  *     },
  *     translator?: bool|array{ // Translator configuration
  *         enabled?: bool|Param, // Default: false
- *         fallbacks?: list<scalar|Param|null>,
+ *         fallbacks?: list<scalar|null|Param>,
  *         logging?: bool|Param, // Default: false
- *         formatter?: scalar|Param|null, // Default: "translator.formatter.default"
- *         cache_dir?: scalar|Param|null, // Default: "%kernel.cache_dir%/translations"
- *         default_path?: scalar|Param|null, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
- *         paths?: list<scalar|Param|null>,
+ *         formatter?: scalar|null|Param, // Default: "translator.formatter.default"
+ *         cache_dir?: scalar|null|Param, // Default: "%kernel.cache_dir%/translations"
+ *         default_path?: scalar|null|Param, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
+ *         paths?: list<scalar|null|Param>,
  *         pseudo_localization?: bool|array{
  *             enabled?: bool|Param, // Default: false
  *             accents?: bool|Param, // Default: true
  *             expansion_factor?: float|Param, // Default: 1.0
  *             brackets?: bool|Param, // Default: true
  *             parse_html?: bool|Param, // Default: false
- *             localizable_html_attributes?: list<scalar|Param|null>,
+ *             localizable_html_attributes?: list<scalar|null|Param>,
  *         },
  *         providers?: array<string, array{ // Default: []
- *             dsn?: scalar|Param|null,
- *             domains?: list<scalar|Param|null>,
- *             locales?: list<scalar|Param|null>,
+ *             dsn?: scalar|null|Param,
+ *             domains?: list<scalar|null|Param>,
+ *             locales?: list<scalar|null|Param>,
  *         }>,
  *         globals?: array<string, string|array{ // Default: []
  *             value?: mixed,
  *             message?: string|Param,
- *             parameters?: array<string, scalar|Param|null>,
+ *             parameters?: array<string, scalar|null|Param>,
  *             domain?: string|Param,
  *         }>,
  *     },
  *     validation?: bool|array{ // Validation configuration
  *         enabled?: bool|Param, // Default: true
  *         enable_attributes?: bool|Param, // Default: true
- *         static_method?: list<scalar|Param|null>,
- *         translation_domain?: scalar|Param|null, // Default: "validators"
+ *         static_method?: list<scalar|null|Param>,
+ *         translation_domain?: scalar|null|Param, // Default: "validators"
  *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|Param, // Default: "html5"
  *         mapping?: array{
- *             paths?: list<scalar|Param|null>,
+ *             paths?: list<scalar|null|Param>,
  *         },
  *         not_compromised_password?: bool|array{
  *             enabled?: bool|Param, // When disabled, compromised passwords will be accepted as valid. // Default: true
- *             endpoint?: scalar|Param|null, // API endpoint for the NotCompromisedPassword Validator. // Default: null
+ *             endpoint?: scalar|null|Param, // API endpoint for the NotCompromisedPassword Validator. // Default: null
  *         },
  *         disable_translation?: bool|Param, // Default: false
  *         auto_mapping?: array<string, array{ // Default: []
- *             services?: list<scalar|Param|null>,
+ *             services?: list<scalar|null|Param>,
  *         }>,
  *     },
  *     serializer?: bool|array{ // Serializer configuration
  *         enabled?: bool|Param, // Default: true
  *         enable_attributes?: bool|Param, // Default: true
- *         name_converter?: scalar|Param|null,
- *         circular_reference_handler?: scalar|Param|null,
- *         max_depth_handler?: scalar|Param|null,
+ *         name_converter?: scalar|null|Param,
+ *         circular_reference_handler?: scalar|null|Param,
+ *         max_depth_handler?: scalar|null|Param,
  *         mapping?: array{
- *             paths?: list<scalar|Param|null>,
+ *             paths?: list<scalar|null|Param>,
  *         },
- *         default_context?: array<string, mixed>,
+ *         default_context?: list<mixed>,
  *         named_serializers?: array<string, array{ // Default: []
- *             name_converter?: scalar|Param|null,
- *             default_context?: array<string, mixed>,
+ *             name_converter?: scalar|null|Param,
+ *             default_context?: list<mixed>,
  *             include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
  *             include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
  *         }>,
@@ -371,31 +371,31 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     type_info?: bool|array{ // Type info configuration
  *         enabled?: bool|Param, // Default: true
- *         aliases?: array<string, scalar|Param|null>,
+ *         aliases?: array<string, scalar|null|Param>,
  *     },
  *     property_info?: bool|array{ // Property info configuration
  *         enabled?: bool|Param, // Default: true
  *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor. // Default: true
  *     },
  *     cache?: array{ // Cache configuration
- *         prefix_seed?: scalar|Param|null, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
- *         app?: scalar|Param|null, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
- *         system?: scalar|Param|null, // System related cache pools configuration. // Default: "cache.adapter.system"
- *         directory?: scalar|Param|null, // Default: "%kernel.share_dir%/pools/app"
- *         default_psr6_provider?: scalar|Param|null,
- *         default_redis_provider?: scalar|Param|null, // Default: "redis://localhost"
- *         default_valkey_provider?: scalar|Param|null, // Default: "valkey://localhost"
- *         default_memcached_provider?: scalar|Param|null, // Default: "memcached://localhost"
- *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
- *         default_pdo_provider?: scalar|Param|null, // Default: null
+ *         prefix_seed?: scalar|null|Param, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
+ *         app?: scalar|null|Param, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
+ *         system?: scalar|null|Param, // System related cache pools configuration. // Default: "cache.adapter.system"
+ *         directory?: scalar|null|Param, // Default: "%kernel.share_dir%/pools/app"
+ *         default_psr6_provider?: scalar|null|Param,
+ *         default_redis_provider?: scalar|null|Param, // Default: "redis://localhost"
+ *         default_valkey_provider?: scalar|null|Param, // Default: "valkey://localhost"
+ *         default_memcached_provider?: scalar|null|Param, // Default: "memcached://localhost"
+ *         default_doctrine_dbal_provider?: scalar|null|Param, // Default: "database_connection"
+ *         default_pdo_provider?: scalar|null|Param, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: list<scalar|Param|null>,
- *             tags?: scalar|Param|null, // Default: null
+ *             adapters?: list<scalar|null|Param>,
+ *             tags?: scalar|null|Param, // Default: null
  *             public?: bool|Param, // Default: false
- *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
- *             provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
- *             early_expiration_message_bus?: scalar|Param|null,
- *             clearer?: scalar|Param|null,
+ *             default_lifetime?: scalar|null|Param, // Default lifetime of the pool.
+ *             provider?: scalar|null|Param, // Overwrite the setting from the default provider for this adapter.
+ *             early_expiration_message_bus?: scalar|null|Param,
+ *             clearer?: scalar|null|Param,
  *         }>,
  *     },
  *     php_errors?: array{ // PHP errors handling configuration
@@ -403,51 +403,51 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         throw?: bool|Param, // Throw PHP errors as \ErrorException instances. // Default: true
  *     },
  *     exceptions?: array<string, array{ // Default: []
- *         log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
- *         status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
- *         log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
+ *         log_level?: scalar|null|Param, // The level of log message. Null to let Symfony decide. // Default: null
+ *         status_code?: scalar|null|Param, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
+ *         log_channel?: scalar|null|Param, // The channel of log message. Null to let Symfony decide. // Default: null
  *     }>,
  *     web_link?: bool|array{ // Web links configuration
  *         enabled?: bool|Param, // Default: false
  *     },
  *     lock?: bool|string|array{ // Lock configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: array<string, string|list<scalar|Param|null>>,
+ *         resources?: array<string, string|list<scalar|null|Param>>,
  *     },
  *     semaphore?: bool|string|array{ // Semaphore configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: array<string, scalar|Param|null>,
+ *         resources?: array<string, scalar|null|Param>,
  *     },
  *     messenger?: bool|array{ // Messenger configuration
  *         enabled?: bool|Param, // Default: false
- *         routing?: array<string, string|array{ // Default: []
- *             senders?: list<scalar|Param|null>,
+ *         routing?: array<string, array{ // Default: []
+ *             senders?: list<scalar|null|Param>,
  *         }>,
  *         serializer?: array{
- *             default_serializer?: scalar|Param|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
+ *             default_serializer?: scalar|null|Param, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
  *             symfony_serializer?: array{
- *                 format?: scalar|Param|null, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
+ *                 format?: scalar|null|Param, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
  *                 context?: array<string, mixed>,
  *             },
  *         },
  *         transports?: array<string, string|array{ // Default: []
- *             dsn?: scalar|Param|null,
- *             serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
- *             options?: array<string, mixed>,
- *             failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *             dsn?: scalar|null|Param,
+ *             serializer?: scalar|null|Param, // Service id of a custom serializer to use. // Default: null
+ *             options?: list<mixed>,
+ *             failure_transport?: scalar|null|Param, // Transport name to send failed messages to (after all retries have failed). // Default: null
  *             retry_strategy?: string|array{
- *                 service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
+ *                 service?: scalar|null|Param, // Service id to override the retry strategy entirely. // Default: null
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
  *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
  *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
  *                 jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
  *             },
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use when processing messages. // Default: null
  *         }>,
- *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *         stop_worker_on_signals?: list<scalar|Param|null>,
- *         default_bus?: scalar|Param|null, // Default: null
+ *         failure_transport?: scalar|null|Param, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *         stop_worker_on_signals?: list<scalar|null|Param>,
+ *         default_bus?: scalar|null|Param, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
  *             default_middleware?: bool|string|array{
  *                 enabled?: bool|Param, // Default: true
@@ -455,7 +455,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 allow_no_senders?: bool|Param, // Default: true
  *             },
  *             middleware?: list<string|array{ // Default: []
- *                 id?: scalar|Param|null,
+ *                 id: scalar|null|Param,
  *                 arguments?: list<mixed>,
  *             }>,
  *         }>,
@@ -471,29 +471,29 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             headers?: array<string, mixed>,
  *             vars?: array<string, mixed>,
  *             max_redirects?: int|Param, // The maximum number of redirects to follow.
- *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|Param|null>,
- *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             http_version?: scalar|null|Param, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|null|Param>,
+ *             proxy?: scalar|null|Param, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|null|Param, // A comma separated list of hosts that do not require a proxy to be reached.
  *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
  *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             bindto?: scalar|null|Param, // A network interface name, IP address, a host name or a UNIX socket to bind to.
  *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
  *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|Param|null, // A certificate authority file.
- *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|Param|null, // A private key file.
- *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
+ *             cafile?: scalar|null|Param, // A certificate authority file.
+ *             capath?: scalar|null|Param, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|null|Param, // A PEM formatted certificate file.
+ *             local_pk?: scalar|null|Param, // A private key file.
+ *             passphrase?: scalar|null|Param, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|null|Param, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|null|Param, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
  *                 enabled?: bool|Param, // Default: false
  *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
@@ -502,7 +502,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
- *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 retry_strategy?: scalar|null|Param, // service id to override the retry strategy. // Default: null
  *                 http_codes?: array<string, array{ // Default: []
  *                     code?: int|Param,
  *                     methods?: list<string|Param>,
@@ -514,39 +514,39 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
  *             },
  *         },
- *         mock_response_factory?: scalar|Param|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
+ *         mock_response_factory?: scalar|null|Param, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
  *         scoped_clients?: array<string, string|array{ // Default: []
- *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
- *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
- *             auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
- *             auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
- *             auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
- *             query?: array<string, scalar|Param|null>,
+ *             scope?: scalar|null|Param, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
+ *             base_uri?: scalar|null|Param, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
+ *             auth_basic?: scalar|null|Param, // An HTTP Basic authentication "username:password".
+ *             auth_bearer?: scalar|null|Param, // A token enabling HTTP Bearer authorization.
+ *             auth_ntlm?: scalar|null|Param, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
+ *             query?: array<string, scalar|null|Param>,
  *             headers?: array<string, mixed>,
  *             max_redirects?: int|Param, // The maximum number of redirects to follow.
- *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|Param|null>,
- *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             http_version?: scalar|null|Param, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|null|Param>,
+ *             proxy?: scalar|null|Param, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|null|Param, // A comma separated list of hosts that do not require a proxy to be reached.
  *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
  *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             bindto?: scalar|null|Param, // A network interface name, IP address, a host name or a UNIX socket to bind to.
  *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
  *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|Param|null, // A certificate authority file.
- *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|Param|null, // A private key file.
- *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
+ *             cafile?: scalar|null|Param, // A certificate authority file.
+ *             capath?: scalar|null|Param, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|null|Param, // A PEM formatted certificate file.
+ *             local_pk?: scalar|null|Param, // A private key file.
+ *             passphrase?: scalar|null|Param, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|null|Param, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|null|Param, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
  *                 enabled?: bool|Param, // Default: false
  *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
@@ -555,7 +555,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
- *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 retry_strategy?: scalar|null|Param, // service id to override the retry strategy. // Default: null
  *                 http_codes?: array<string, array{ // Default: []
  *                     code?: int|Param,
  *                     methods?: list<string|Param>,
@@ -570,69 +570,69 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     mailer?: bool|array{ // Mailer configuration
  *         enabled?: bool|Param, // Default: false
- *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         dsn?: scalar|Param|null, // Default: null
- *         transports?: array<string, scalar|Param|null>,
+ *         message_bus?: scalar|null|Param, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         dsn?: scalar|null|Param, // Default: null
+ *         transports?: array<string, scalar|null|Param>,
  *         envelope?: array{ // Mailer Envelope configuration
- *             sender?: scalar|Param|null,
- *             recipients?: list<scalar|Param|null>,
- *             allowed_recipients?: list<scalar|Param|null>,
+ *             sender?: scalar|null|Param,
+ *             recipients?: list<scalar|null|Param>,
+ *             allowed_recipients?: list<scalar|null|Param>,
  *         },
  *         headers?: array<string, string|array{ // Default: []
  *             value?: mixed,
  *         }>,
  *         dkim_signer?: bool|array{ // DKIM signer configuration
  *             enabled?: bool|Param, // Default: false
- *             key?: scalar|Param|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
- *             domain?: scalar|Param|null, // Default: ""
- *             select?: scalar|Param|null, // Default: ""
- *             passphrase?: scalar|Param|null, // The private key passphrase // Default: ""
+ *             key?: scalar|null|Param, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
+ *             domain?: scalar|null|Param, // Default: ""
+ *             select?: scalar|null|Param, // Default: ""
+ *             passphrase?: scalar|null|Param, // The private key passphrase // Default: ""
  *             options?: array<string, mixed>,
  *         },
  *         smime_signer?: bool|array{ // S/MIME signer configuration
  *             enabled?: bool|Param, // Default: false
- *             key?: scalar|Param|null, // Path to key (in PEM format) // Default: ""
- *             certificate?: scalar|Param|null, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
- *             passphrase?: scalar|Param|null, // The private key passphrase // Default: null
- *             extra_certificates?: scalar|Param|null, // Default: null
+ *             key?: scalar|null|Param, // Path to key (in PEM format) // Default: ""
+ *             certificate?: scalar|null|Param, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
+ *             passphrase?: scalar|null|Param, // The private key passphrase // Default: null
+ *             extra_certificates?: scalar|null|Param, // Default: null
  *             sign_options?: int|Param, // Default: null
  *         },
  *         smime_encrypter?: bool|array{ // S/MIME encrypter configuration
  *             enabled?: bool|Param, // Default: false
- *             repository?: scalar|Param|null, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
+ *             repository?: scalar|null|Param, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
  *             cipher?: int|Param, // A set of algorithms used to encrypt the message // Default: null
  *         },
  *     },
  *     secrets?: bool|array{
  *         enabled?: bool|Param, // Default: true
- *         vault_directory?: scalar|Param|null, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
- *         local_dotenv_file?: scalar|Param|null, // Default: "%kernel.project_dir%/.env.%kernel.environment%.local"
- *         decryption_env_var?: scalar|Param|null, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
+ *         vault_directory?: scalar|null|Param, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
+ *         local_dotenv_file?: scalar|null|Param, // Default: "%kernel.project_dir%/.env.%kernel.runtime_environment%.local"
+ *         decryption_env_var?: scalar|null|Param, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
  *     },
  *     notifier?: bool|array{ // Notifier configuration
  *         enabled?: bool|Param, // Default: false
- *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         chatter_transports?: array<string, scalar|Param|null>,
- *         texter_transports?: array<string, scalar|Param|null>,
+ *         message_bus?: scalar|null|Param, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         chatter_transports?: array<string, scalar|null|Param>,
+ *         texter_transports?: array<string, scalar|null|Param>,
  *         notification_on_failed_messages?: bool|Param, // Default: false
- *         channel_policy?: array<string, string|list<scalar|Param|null>>,
+ *         channel_policy?: array<string, string|list<scalar|null|Param>>,
  *         admin_recipients?: list<array{ // Default: []
- *             email?: scalar|Param|null,
- *             phone?: scalar|Param|null, // Default: ""
+ *             email?: scalar|null|Param,
+ *             phone?: scalar|null|Param, // Default: ""
  *         }>,
  *     },
  *     rate_limiter?: bool|array{ // Rate limiter configuration
  *         enabled?: bool|Param, // Default: false
  *         limiters?: array<string, array{ // Default: []
- *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
- *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
- *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
- *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
- *             limiters?: list<scalar|Param|null>,
+ *             lock_factory?: scalar|null|Param, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
+ *             cache_pool?: scalar|null|Param, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
+ *             storage_service?: scalar|null|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
+ *             policy: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
+ *             limiters?: list<scalar|null|Param>,
  *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
- *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *             interval?: scalar|null|Param, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
- *                 interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                 interval?: scalar|null|Param, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
  *             },
  *         }>,
@@ -641,9 +641,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: true
  *         default_uuid_version?: 7|6|4|1|Param, // Default: 7
  *         name_based_uuid_version?: 5|3|Param, // Default: 5
- *         name_based_uuid_namespace?: scalar|Param|null,
+ *         name_based_uuid_namespace?: scalar|null|Param,
  *         time_based_uuid_version?: 7|6|1|Param, // Default: 7
- *         time_based_uuid_node?: scalar|Param|null,
+ *         time_based_uuid_node?: scalar|null|Param,
  *     },
  *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
  *         enabled?: bool|Param, // Default: false
@@ -670,10 +670,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     webhook?: bool|array{ // Webhook configuration
  *         enabled?: bool|Param, // Default: false
- *         message_bus?: scalar|Param|null, // The message bus to use. // Default: "messenger.default_bus"
+ *         message_bus?: scalar|null|Param, // The message bus to use. // Default: "messenger.default_bus"
  *         routing?: array<string, array{ // Default: []
- *             service?: scalar|Param|null,
- *             secret?: scalar|Param|null, // Default: ""
+ *             service: scalar|null|Param,
+ *             secret?: scalar|null|Param, // Default: ""
  *         }>,
  *     },
  *     remote-event?: bool|array{ // RemoteEvent configuration
@@ -711,10 +711,7 @@ final class App
      */
     public static function config(array $config): array
     {
-        /** @var ConfigType $config */
-        $config = AppReference::config($config);
-
-        return $config;
+        return AppReference::config($config);
     }
 }
 

--- a/src/Bundle/OpenApiBundle/Tests/Resources/config/reference.php
+++ b/src/Bundle/OpenApiBundle/Tests/Resources/config/reference.php
@@ -33,11 +33,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     type?: string|null,
  *     ignore_errors?: bool,
  * }>
- * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|Param|null>|Param|null>
+ * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|null>|null>
  * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>
  * @psalm-type CallType = array<string, ArgumentsType>|array{0:string, 1?:ArgumentsType, 2?:bool}|array{method:string, arguments?:ArgumentsType, returns_clone?:bool}
  * @psalm-type TagsType = list<string|array<string, array<string, mixed>>> // arrays inside the list must have only one element, with the tag name as the key
- * @psalm-type CallbackType = string|array{0:string|ReferenceConfigurator,1:string}|\Closure|ReferenceConfigurator
+ * @psalm-type CallbackType = string|array{0:string|ReferenceConfigurator,1:string}|\Closure|ReferenceConfigurator|ExpressionConfigurator
  * @psalm-type DeprecationType = array{package: string, version: string, message?: string}
  * @psalm-type DefaultsType = array{
  *     public?: bool,
@@ -126,44 +126,44 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type ExtensionType = array<string, mixed>
  * @psalm-type FrameworkConfig = array{
- *     secret?: scalar|Param|null,
+ *     secret?: scalar|null|Param,
  *     http_method_override?: bool|Param, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
  *     allowed_http_method_override?: list<string|Param>|null,
- *     trust_x_sendfile_type_header?: scalar|Param|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
- *     ide?: scalar|Param|null, // Default: "%env(default::SYMFONY_IDE)%"
+ *     trust_x_sendfile_type_header?: scalar|null|Param, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
+ *     ide?: scalar|null|Param, // Default: "%env(default::SYMFONY_IDE)%"
  *     test?: bool|Param,
- *     default_locale?: scalar|Param|null, // Default: "en"
+ *     default_locale?: scalar|null|Param, // Default: "en"
  *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
  *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
- *     enabled_locales?: list<scalar|Param|null>,
- *     trusted_hosts?: list<scalar|Param|null>,
+ *     enabled_locales?: list<scalar|null|Param>,
+ *     trusted_hosts?: list<scalar|null|Param>,
  *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
- *     trusted_headers?: list<scalar|Param|null>,
- *     error_controller?: scalar|Param|null, // Default: "error_controller"
+ *     trusted_headers?: list<scalar|null|Param>,
+ *     error_controller?: scalar|null|Param, // Default: "error_controller"
  *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
  *     csrf_protection?: bool|array{
- *         enabled?: scalar|Param|null, // Default: null
- *         stateless_token_ids?: list<scalar|Param|null>,
- *         check_header?: scalar|Param|null, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
- *         cookie_name?: scalar|Param|null, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
+ *         enabled?: scalar|null|Param, // Default: null
+ *         stateless_token_ids?: list<scalar|null|Param>,
+ *         check_header?: scalar|null|Param, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
+ *         cookie_name?: scalar|null|Param, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
  *     },
  *     form?: bool|array{ // Form configuration
  *         enabled?: bool|Param, // Default: false
- *         csrf_protection?: bool|array{
- *             enabled?: scalar|Param|null, // Default: null
- *             token_id?: scalar|Param|null, // Default: null
- *             field_name?: scalar|Param|null, // Default: "_token"
- *             field_attr?: array<string, scalar|Param|null>,
+ *         csrf_protection?: array{
+ *             enabled?: scalar|null|Param, // Default: null
+ *             token_id?: scalar|null|Param, // Default: null
+ *             field_name?: scalar|null|Param, // Default: "_token"
+ *             field_attr?: array<string, scalar|null|Param>,
  *         },
  *     },
  *     http_cache?: bool|array{ // HTTP cache configuration
  *         enabled?: bool|Param, // Default: false
  *         debug?: bool|Param, // Default: "%kernel.debug%"
  *         trace_level?: "none"|"short"|"full"|Param,
- *         trace_header?: scalar|Param|null,
+ *         trace_header?: scalar|null|Param,
  *         default_ttl?: int|Param,
- *         private_headers?: list<scalar|Param|null>,
- *         skip_response_headers?: list<scalar|Param|null>,
+ *         private_headers?: list<scalar|null|Param>,
+ *         skip_response_headers?: list<scalar|null|Param>,
  *         allow_reload?: bool|Param,
  *         allow_revalidate?: bool|Param,
  *         stale_while_revalidate?: int|Param,
@@ -178,16 +178,16 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     fragments?: bool|array{ // Fragments configuration
  *         enabled?: bool|Param, // Default: false
- *         hinclude_default_template?: scalar|Param|null, // Default: null
- *         path?: scalar|Param|null, // Default: "/_fragment"
+ *         hinclude_default_template?: scalar|null|Param, // Default: null
+ *         path?: scalar|null|Param, // Default: "/_fragment"
  *     },
  *     profiler?: bool|array{ // Profiler configuration
  *         enabled?: bool|Param, // Default: false
  *         collect?: bool|Param, // Default: true
- *         collect_parameter?: scalar|Param|null, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
+ *         collect_parameter?: scalar|null|Param, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
  *         only_exceptions?: bool|Param, // Default: false
  *         only_main_requests?: bool|Param, // Default: false
- *         dsn?: scalar|Param|null, // Default: "file:%kernel.cache_dir%/profiler"
+ *         dsn?: scalar|null|Param, // Default: "file:%kernel.cache_dir%/profiler"
  *         collect_serializer_data?: true|Param, // Default: true
  *     },
  *     workflows?: bool|array{
@@ -199,164 +199,164 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
  *             marking_store?: array{
  *                 type?: "method"|Param,
- *                 property?: scalar|Param|null,
- *                 service?: scalar|Param|null,
+ *                 property?: scalar|null|Param,
+ *                 service?: scalar|null|Param,
  *             },
- *             supports?: list<scalar|Param|null>,
- *             definition_validators?: list<scalar|Param|null>,
- *             support_strategy?: scalar|Param|null,
- *             initial_marking?: list<scalar|Param|null>,
+ *             supports?: list<scalar|null|Param>,
+ *             definition_validators?: list<scalar|null|Param>,
+ *             support_strategy?: scalar|null|Param,
+ *             initial_marking?: list<scalar|null|Param>,
  *             events_to_dispatch?: list<string|Param>|null,
  *             places?: list<array{ // Default: []
- *                 name?: scalar|Param|null,
- *                 metadata?: array<string, mixed>,
+ *                 name: scalar|null|Param,
+ *                 metadata?: list<mixed>,
  *             }>,
- *             transitions?: list<array{ // Default: []
- *                 name?: string|Param,
+ *             transitions: list<array{ // Default: []
+ *                 name: string|Param,
  *                 guard?: string|Param, // An expression to block the transition.
  *                 from?: list<array{ // Default: []
- *                     place?: string|Param,
+ *                     place: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
  *                 to?: list<array{ // Default: []
- *                     place?: string|Param,
+ *                     place: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
  *                 weight?: int|Param, // Default: 1
- *                 metadata?: array<string, mixed>,
+ *                 metadata?: list<mixed>,
  *             }>,
- *             metadata?: array<string, mixed>,
+ *             metadata?: list<mixed>,
  *         }>,
  *     },
  *     router?: bool|array{ // Router configuration
  *         enabled?: bool|Param, // Default: false
- *         resource?: scalar|Param|null,
- *         type?: scalar|Param|null,
- *         default_uri?: scalar|Param|null, // The default URI used to generate URLs in a non-HTTP context. // Default: null
- *         http_port?: scalar|Param|null, // Default: 80
- *         https_port?: scalar|Param|null, // Default: 443
- *         strict_requirements?: scalar|Param|null, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
+ *         resource: scalar|null|Param,
+ *         type?: scalar|null|Param,
+ *         default_uri?: scalar|null|Param, // The default URI used to generate URLs in a non-HTTP context. // Default: null
+ *         http_port?: scalar|null|Param, // Default: 80
+ *         https_port?: scalar|null|Param, // Default: 443
+ *         strict_requirements?: scalar|null|Param, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
  *         utf8?: bool|Param, // Default: true
  *     },
  *     session?: bool|array{ // Session configuration
  *         enabled?: bool|Param, // Default: false
- *         storage_factory_id?: scalar|Param|null, // Default: "session.storage.factory.native"
- *         handler_id?: scalar|Param|null, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
- *         name?: scalar|Param|null,
- *         cookie_lifetime?: scalar|Param|null,
- *         cookie_path?: scalar|Param|null,
- *         cookie_domain?: scalar|Param|null,
+ *         storage_factory_id?: scalar|null|Param, // Default: "session.storage.factory.native"
+ *         handler_id?: scalar|null|Param, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
+ *         name?: scalar|null|Param,
+ *         cookie_lifetime?: scalar|null|Param,
+ *         cookie_path?: scalar|null|Param,
+ *         cookie_domain?: scalar|null|Param,
  *         cookie_secure?: true|false|"auto"|Param, // Default: "auto"
  *         cookie_httponly?: bool|Param, // Default: true
  *         cookie_samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
  *         use_cookies?: bool|Param,
- *         gc_divisor?: scalar|Param|null,
- *         gc_probability?: scalar|Param|null,
- *         gc_maxlifetime?: scalar|Param|null,
- *         save_path?: scalar|Param|null, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
+ *         gc_divisor?: scalar|null|Param,
+ *         gc_probability?: scalar|null|Param,
+ *         gc_maxlifetime?: scalar|null|Param,
+ *         save_path?: scalar|null|Param, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
  *         metadata_update_threshold?: int|Param, // Seconds to wait between 2 session metadata updates. // Default: 0
  *     },
  *     request?: bool|array{ // Request configuration
  *         enabled?: bool|Param, // Default: false
- *         formats?: array<string, string|list<scalar|Param|null>>,
+ *         formats?: array<string, string|list<scalar|null|Param>>,
  *     },
  *     assets?: bool|array{ // Assets configuration
  *         enabled?: bool|Param, // Default: false
  *         strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *         version_strategy?: scalar|Param|null, // Default: null
- *         version?: scalar|Param|null, // Default: null
- *         version_format?: scalar|Param|null, // Default: "%%s?%%s"
- *         json_manifest_path?: scalar|Param|null, // Default: null
- *         base_path?: scalar|Param|null, // Default: ""
- *         base_urls?: list<scalar|Param|null>,
+ *         version_strategy?: scalar|null|Param, // Default: null
+ *         version?: scalar|null|Param, // Default: null
+ *         version_format?: scalar|null|Param, // Default: "%%s?%%s"
+ *         json_manifest_path?: scalar|null|Param, // Default: null
+ *         base_path?: scalar|null|Param, // Default: ""
+ *         base_urls?: list<scalar|null|Param>,
  *         packages?: array<string, array{ // Default: []
  *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *             version_strategy?: scalar|Param|null, // Default: null
- *             version?: scalar|Param|null,
- *             version_format?: scalar|Param|null, // Default: null
- *             json_manifest_path?: scalar|Param|null, // Default: null
- *             base_path?: scalar|Param|null, // Default: ""
- *             base_urls?: list<scalar|Param|null>,
+ *             version_strategy?: scalar|null|Param, // Default: null
+ *             version?: scalar|null|Param,
+ *             version_format?: scalar|null|Param, // Default: null
+ *             json_manifest_path?: scalar|null|Param, // Default: null
+ *             base_path?: scalar|null|Param, // Default: ""
+ *             base_urls?: list<scalar|null|Param>,
  *         }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
  *         enabled?: bool|Param, // Default: false
- *         paths?: array<string, scalar|Param|null>,
- *         excluded_patterns?: list<scalar|Param|null>,
+ *         paths?: array<string, scalar|null|Param>,
+ *         excluded_patterns?: list<scalar|null|Param>,
  *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
  *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
- *         public_prefix?: scalar|Param|null, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
+ *         public_prefix?: scalar|null|Param, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
  *         missing_import_mode?: "strict"|"warn"|"ignore"|Param, // Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. "import './non-existent.js'". "strict" means an exception is thrown, "warn" means a warning is logged, "ignore" means the import is left as-is. // Default: "warn"
- *         extensions?: array<string, scalar|Param|null>,
- *         importmap_path?: scalar|Param|null, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
- *         importmap_polyfill?: scalar|Param|null, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
- *         importmap_script_attributes?: array<string, scalar|Param|null>,
- *         vendor_dir?: scalar|Param|null, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
+ *         extensions?: array<string, scalar|null|Param>,
+ *         importmap_path?: scalar|null|Param, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
+ *         importmap_polyfill?: scalar|null|Param, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
+ *         importmap_script_attributes?: array<string, scalar|null|Param>,
+ *         vendor_dir?: scalar|null|Param, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
  *         precompress?: bool|array{ // Precompress assets with Brotli, Zstandard and gzip.
  *             enabled?: bool|Param, // Default: false
- *             formats?: list<scalar|Param|null>,
- *             extensions?: list<scalar|Param|null>,
+ *             formats?: list<scalar|null|Param>,
+ *             extensions?: list<scalar|null|Param>,
  *         },
  *     },
  *     translator?: bool|array{ // Translator configuration
  *         enabled?: bool|Param, // Default: false
- *         fallbacks?: list<scalar|Param|null>,
+ *         fallbacks?: list<scalar|null|Param>,
  *         logging?: bool|Param, // Default: false
- *         formatter?: scalar|Param|null, // Default: "translator.formatter.default"
- *         cache_dir?: scalar|Param|null, // Default: "%kernel.cache_dir%/translations"
- *         default_path?: scalar|Param|null, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
- *         paths?: list<scalar|Param|null>,
+ *         formatter?: scalar|null|Param, // Default: "translator.formatter.default"
+ *         cache_dir?: scalar|null|Param, // Default: "%kernel.cache_dir%/translations"
+ *         default_path?: scalar|null|Param, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
+ *         paths?: list<scalar|null|Param>,
  *         pseudo_localization?: bool|array{
  *             enabled?: bool|Param, // Default: false
  *             accents?: bool|Param, // Default: true
  *             expansion_factor?: float|Param, // Default: 1.0
  *             brackets?: bool|Param, // Default: true
  *             parse_html?: bool|Param, // Default: false
- *             localizable_html_attributes?: list<scalar|Param|null>,
+ *             localizable_html_attributes?: list<scalar|null|Param>,
  *         },
  *         providers?: array<string, array{ // Default: []
- *             dsn?: scalar|Param|null,
- *             domains?: list<scalar|Param|null>,
- *             locales?: list<scalar|Param|null>,
+ *             dsn?: scalar|null|Param,
+ *             domains?: list<scalar|null|Param>,
+ *             locales?: list<scalar|null|Param>,
  *         }>,
  *         globals?: array<string, string|array{ // Default: []
  *             value?: mixed,
  *             message?: string|Param,
- *             parameters?: array<string, scalar|Param|null>,
+ *             parameters?: array<string, scalar|null|Param>,
  *             domain?: string|Param,
  *         }>,
  *     },
  *     validation?: bool|array{ // Validation configuration
  *         enabled?: bool|Param, // Default: true
  *         enable_attributes?: bool|Param, // Default: true
- *         static_method?: list<scalar|Param|null>,
- *         translation_domain?: scalar|Param|null, // Default: "validators"
+ *         static_method?: list<scalar|null|Param>,
+ *         translation_domain?: scalar|null|Param, // Default: "validators"
  *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|Param, // Default: "html5"
  *         mapping?: array{
- *             paths?: list<scalar|Param|null>,
+ *             paths?: list<scalar|null|Param>,
  *         },
  *         not_compromised_password?: bool|array{
  *             enabled?: bool|Param, // When disabled, compromised passwords will be accepted as valid. // Default: true
- *             endpoint?: scalar|Param|null, // API endpoint for the NotCompromisedPassword Validator. // Default: null
+ *             endpoint?: scalar|null|Param, // API endpoint for the NotCompromisedPassword Validator. // Default: null
  *         },
  *         disable_translation?: bool|Param, // Default: false
  *         auto_mapping?: array<string, array{ // Default: []
- *             services?: list<scalar|Param|null>,
+ *             services?: list<scalar|null|Param>,
  *         }>,
  *     },
  *     serializer?: bool|array{ // Serializer configuration
  *         enabled?: bool|Param, // Default: true
  *         enable_attributes?: bool|Param, // Default: true
- *         name_converter?: scalar|Param|null,
- *         circular_reference_handler?: scalar|Param|null,
- *         max_depth_handler?: scalar|Param|null,
+ *         name_converter?: scalar|null|Param,
+ *         circular_reference_handler?: scalar|null|Param,
+ *         max_depth_handler?: scalar|null|Param,
  *         mapping?: array{
- *             paths?: list<scalar|Param|null>,
+ *             paths?: list<scalar|null|Param>,
  *         },
- *         default_context?: array<string, mixed>,
+ *         default_context?: list<mixed>,
  *         named_serializers?: array<string, array{ // Default: []
- *             name_converter?: scalar|Param|null,
- *             default_context?: array<string, mixed>,
+ *             name_converter?: scalar|null|Param,
+ *             default_context?: list<mixed>,
  *             include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
  *             include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
  *         }>,
@@ -371,31 +371,31 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     type_info?: bool|array{ // Type info configuration
  *         enabled?: bool|Param, // Default: true
- *         aliases?: array<string, scalar|Param|null>,
+ *         aliases?: array<string, scalar|null|Param>,
  *     },
  *     property_info?: bool|array{ // Property info configuration
  *         enabled?: bool|Param, // Default: true
  *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor. // Default: true
  *     },
  *     cache?: array{ // Cache configuration
- *         prefix_seed?: scalar|Param|null, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
- *         app?: scalar|Param|null, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
- *         system?: scalar|Param|null, // System related cache pools configuration. // Default: "cache.adapter.system"
- *         directory?: scalar|Param|null, // Default: "%kernel.share_dir%/pools/app"
- *         default_psr6_provider?: scalar|Param|null,
- *         default_redis_provider?: scalar|Param|null, // Default: "redis://localhost"
- *         default_valkey_provider?: scalar|Param|null, // Default: "valkey://localhost"
- *         default_memcached_provider?: scalar|Param|null, // Default: "memcached://localhost"
- *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
- *         default_pdo_provider?: scalar|Param|null, // Default: null
+ *         prefix_seed?: scalar|null|Param, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
+ *         app?: scalar|null|Param, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
+ *         system?: scalar|null|Param, // System related cache pools configuration. // Default: "cache.adapter.system"
+ *         directory?: scalar|null|Param, // Default: "%kernel.share_dir%/pools/app"
+ *         default_psr6_provider?: scalar|null|Param,
+ *         default_redis_provider?: scalar|null|Param, // Default: "redis://localhost"
+ *         default_valkey_provider?: scalar|null|Param, // Default: "valkey://localhost"
+ *         default_memcached_provider?: scalar|null|Param, // Default: "memcached://localhost"
+ *         default_doctrine_dbal_provider?: scalar|null|Param, // Default: "database_connection"
+ *         default_pdo_provider?: scalar|null|Param, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: list<scalar|Param|null>,
- *             tags?: scalar|Param|null, // Default: null
+ *             adapters?: list<scalar|null|Param>,
+ *             tags?: scalar|null|Param, // Default: null
  *             public?: bool|Param, // Default: false
- *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
- *             provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
- *             early_expiration_message_bus?: scalar|Param|null,
- *             clearer?: scalar|Param|null,
+ *             default_lifetime?: scalar|null|Param, // Default lifetime of the pool.
+ *             provider?: scalar|null|Param, // Overwrite the setting from the default provider for this adapter.
+ *             early_expiration_message_bus?: scalar|null|Param,
+ *             clearer?: scalar|null|Param,
  *         }>,
  *     },
  *     php_errors?: array{ // PHP errors handling configuration
@@ -403,51 +403,51 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         throw?: bool|Param, // Throw PHP errors as \ErrorException instances. // Default: true
  *     },
  *     exceptions?: array<string, array{ // Default: []
- *         log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
- *         status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
- *         log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
+ *         log_level?: scalar|null|Param, // The level of log message. Null to let Symfony decide. // Default: null
+ *         status_code?: scalar|null|Param, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
+ *         log_channel?: scalar|null|Param, // The channel of log message. Null to let Symfony decide. // Default: null
  *     }>,
  *     web_link?: bool|array{ // Web links configuration
  *         enabled?: bool|Param, // Default: false
  *     },
  *     lock?: bool|string|array{ // Lock configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: array<string, string|list<scalar|Param|null>>,
+ *         resources?: array<string, string|list<scalar|null|Param>>,
  *     },
  *     semaphore?: bool|string|array{ // Semaphore configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: array<string, scalar|Param|null>,
+ *         resources?: array<string, scalar|null|Param>,
  *     },
  *     messenger?: bool|array{ // Messenger configuration
  *         enabled?: bool|Param, // Default: false
- *         routing?: array<string, string|array{ // Default: []
- *             senders?: list<scalar|Param|null>,
+ *         routing?: array<string, array{ // Default: []
+ *             senders?: list<scalar|null|Param>,
  *         }>,
  *         serializer?: array{
- *             default_serializer?: scalar|Param|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
+ *             default_serializer?: scalar|null|Param, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
  *             symfony_serializer?: array{
- *                 format?: scalar|Param|null, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
+ *                 format?: scalar|null|Param, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
  *                 context?: array<string, mixed>,
  *             },
  *         },
  *         transports?: array<string, string|array{ // Default: []
- *             dsn?: scalar|Param|null,
- *             serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
- *             options?: array<string, mixed>,
- *             failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *             dsn?: scalar|null|Param,
+ *             serializer?: scalar|null|Param, // Service id of a custom serializer to use. // Default: null
+ *             options?: list<mixed>,
+ *             failure_transport?: scalar|null|Param, // Transport name to send failed messages to (after all retries have failed). // Default: null
  *             retry_strategy?: string|array{
- *                 service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
+ *                 service?: scalar|null|Param, // Service id to override the retry strategy entirely. // Default: null
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
  *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
  *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
  *                 jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
  *             },
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use when processing messages. // Default: null
  *         }>,
- *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *         stop_worker_on_signals?: list<scalar|Param|null>,
- *         default_bus?: scalar|Param|null, // Default: null
+ *         failure_transport?: scalar|null|Param, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *         stop_worker_on_signals?: list<scalar|null|Param>,
+ *         default_bus?: scalar|null|Param, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
  *             default_middleware?: bool|string|array{
  *                 enabled?: bool|Param, // Default: true
@@ -455,7 +455,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 allow_no_senders?: bool|Param, // Default: true
  *             },
  *             middleware?: list<string|array{ // Default: []
- *                 id?: scalar|Param|null,
+ *                 id: scalar|null|Param,
  *                 arguments?: list<mixed>,
  *             }>,
  *         }>,
@@ -471,29 +471,29 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             headers?: array<string, mixed>,
  *             vars?: array<string, mixed>,
  *             max_redirects?: int|Param, // The maximum number of redirects to follow.
- *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|Param|null>,
- *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             http_version?: scalar|null|Param, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|null|Param>,
+ *             proxy?: scalar|null|Param, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|null|Param, // A comma separated list of hosts that do not require a proxy to be reached.
  *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
  *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             bindto?: scalar|null|Param, // A network interface name, IP address, a host name or a UNIX socket to bind to.
  *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
  *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|Param|null, // A certificate authority file.
- *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|Param|null, // A private key file.
- *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
+ *             cafile?: scalar|null|Param, // A certificate authority file.
+ *             capath?: scalar|null|Param, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|null|Param, // A PEM formatted certificate file.
+ *             local_pk?: scalar|null|Param, // A private key file.
+ *             passphrase?: scalar|null|Param, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|null|Param, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|null|Param, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
  *                 enabled?: bool|Param, // Default: false
  *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
@@ -502,7 +502,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
- *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 retry_strategy?: scalar|null|Param, // service id to override the retry strategy. // Default: null
  *                 http_codes?: array<string, array{ // Default: []
  *                     code?: int|Param,
  *                     methods?: list<string|Param>,
@@ -514,39 +514,39 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
  *             },
  *         },
- *         mock_response_factory?: scalar|Param|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
+ *         mock_response_factory?: scalar|null|Param, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
  *         scoped_clients?: array<string, string|array{ // Default: []
- *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
- *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
- *             auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
- *             auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
- *             auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
- *             query?: array<string, scalar|Param|null>,
+ *             scope?: scalar|null|Param, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
+ *             base_uri?: scalar|null|Param, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
+ *             auth_basic?: scalar|null|Param, // An HTTP Basic authentication "username:password".
+ *             auth_bearer?: scalar|null|Param, // A token enabling HTTP Bearer authorization.
+ *             auth_ntlm?: scalar|null|Param, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
+ *             query?: array<string, scalar|null|Param>,
  *             headers?: array<string, mixed>,
  *             max_redirects?: int|Param, // The maximum number of redirects to follow.
- *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|Param|null>,
- *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             http_version?: scalar|null|Param, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|null|Param>,
+ *             proxy?: scalar|null|Param, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|null|Param, // A comma separated list of hosts that do not require a proxy to be reached.
  *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
  *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             bindto?: scalar|null|Param, // A network interface name, IP address, a host name or a UNIX socket to bind to.
  *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
  *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|Param|null, // A certificate authority file.
- *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
- *             local_pk?: scalar|Param|null, // A private key file.
- *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
+ *             cafile?: scalar|null|Param, // A certificate authority file.
+ *             capath?: scalar|null|Param, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|null|Param, // A PEM formatted certificate file.
+ *             local_pk?: scalar|null|Param, // A private key file.
+ *             passphrase?: scalar|null|Param, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|null|Param, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|null|Param, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|null|Param, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
  *                 enabled?: bool|Param, // Default: false
  *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
@@ -555,7 +555,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             },
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
- *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 retry_strategy?: scalar|null|Param, // service id to override the retry strategy. // Default: null
  *                 http_codes?: array<string, array{ // Default: []
  *                     code?: int|Param,
  *                     methods?: list<string|Param>,
@@ -570,69 +570,69 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     mailer?: bool|array{ // Mailer configuration
  *         enabled?: bool|Param, // Default: false
- *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         dsn?: scalar|Param|null, // Default: null
- *         transports?: array<string, scalar|Param|null>,
+ *         message_bus?: scalar|null|Param, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         dsn?: scalar|null|Param, // Default: null
+ *         transports?: array<string, scalar|null|Param>,
  *         envelope?: array{ // Mailer Envelope configuration
- *             sender?: scalar|Param|null,
- *             recipients?: list<scalar|Param|null>,
- *             allowed_recipients?: list<scalar|Param|null>,
+ *             sender?: scalar|null|Param,
+ *             recipients?: list<scalar|null|Param>,
+ *             allowed_recipients?: list<scalar|null|Param>,
  *         },
  *         headers?: array<string, string|array{ // Default: []
  *             value?: mixed,
  *         }>,
  *         dkim_signer?: bool|array{ // DKIM signer configuration
  *             enabled?: bool|Param, // Default: false
- *             key?: scalar|Param|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
- *             domain?: scalar|Param|null, // Default: ""
- *             select?: scalar|Param|null, // Default: ""
- *             passphrase?: scalar|Param|null, // The private key passphrase // Default: ""
+ *             key?: scalar|null|Param, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
+ *             domain?: scalar|null|Param, // Default: ""
+ *             select?: scalar|null|Param, // Default: ""
+ *             passphrase?: scalar|null|Param, // The private key passphrase // Default: ""
  *             options?: array<string, mixed>,
  *         },
  *         smime_signer?: bool|array{ // S/MIME signer configuration
  *             enabled?: bool|Param, // Default: false
- *             key?: scalar|Param|null, // Path to key (in PEM format) // Default: ""
- *             certificate?: scalar|Param|null, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
- *             passphrase?: scalar|Param|null, // The private key passphrase // Default: null
- *             extra_certificates?: scalar|Param|null, // Default: null
+ *             key?: scalar|null|Param, // Path to key (in PEM format) // Default: ""
+ *             certificate?: scalar|null|Param, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
+ *             passphrase?: scalar|null|Param, // The private key passphrase // Default: null
+ *             extra_certificates?: scalar|null|Param, // Default: null
  *             sign_options?: int|Param, // Default: null
  *         },
  *         smime_encrypter?: bool|array{ // S/MIME encrypter configuration
  *             enabled?: bool|Param, // Default: false
- *             repository?: scalar|Param|null, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
+ *             repository?: scalar|null|Param, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
  *             cipher?: int|Param, // A set of algorithms used to encrypt the message // Default: null
  *         },
  *     },
  *     secrets?: bool|array{
  *         enabled?: bool|Param, // Default: true
- *         vault_directory?: scalar|Param|null, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
- *         local_dotenv_file?: scalar|Param|null, // Default: "%kernel.project_dir%/.env.%kernel.environment%.local"
- *         decryption_env_var?: scalar|Param|null, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
+ *         vault_directory?: scalar|null|Param, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
+ *         local_dotenv_file?: scalar|null|Param, // Default: "%kernel.project_dir%/.env.%kernel.runtime_environment%.local"
+ *         decryption_env_var?: scalar|null|Param, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
  *     },
  *     notifier?: bool|array{ // Notifier configuration
  *         enabled?: bool|Param, // Default: false
- *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         chatter_transports?: array<string, scalar|Param|null>,
- *         texter_transports?: array<string, scalar|Param|null>,
+ *         message_bus?: scalar|null|Param, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         chatter_transports?: array<string, scalar|null|Param>,
+ *         texter_transports?: array<string, scalar|null|Param>,
  *         notification_on_failed_messages?: bool|Param, // Default: false
- *         channel_policy?: array<string, string|list<scalar|Param|null>>,
+ *         channel_policy?: array<string, string|list<scalar|null|Param>>,
  *         admin_recipients?: list<array{ // Default: []
- *             email?: scalar|Param|null,
- *             phone?: scalar|Param|null, // Default: ""
+ *             email?: scalar|null|Param,
+ *             phone?: scalar|null|Param, // Default: ""
  *         }>,
  *     },
  *     rate_limiter?: bool|array{ // Rate limiter configuration
  *         enabled?: bool|Param, // Default: false
  *         limiters?: array<string, array{ // Default: []
- *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
- *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
- *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
- *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
- *             limiters?: list<scalar|Param|null>,
+ *             lock_factory?: scalar|null|Param, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
+ *             cache_pool?: scalar|null|Param, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
+ *             storage_service?: scalar|null|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
+ *             policy: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
+ *             limiters?: list<scalar|null|Param>,
  *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
- *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *             interval?: scalar|null|Param, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
- *                 interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                 interval?: scalar|null|Param, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
  *             },
  *         }>,
@@ -641,9 +641,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: true
  *         default_uuid_version?: 7|6|4|1|Param, // Default: 7
  *         name_based_uuid_version?: 5|3|Param, // Default: 5
- *         name_based_uuid_namespace?: scalar|Param|null,
+ *         name_based_uuid_namespace?: scalar|null|Param,
  *         time_based_uuid_version?: 7|6|1|Param, // Default: 7
- *         time_based_uuid_node?: scalar|Param|null,
+ *         time_based_uuid_node?: scalar|null|Param,
  *     },
  *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
  *         enabled?: bool|Param, // Default: false
@@ -670,10 +670,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     webhook?: bool|array{ // Webhook configuration
  *         enabled?: bool|Param, // Default: false
- *         message_bus?: scalar|Param|null, // The message bus to use. // Default: "messenger.default_bus"
+ *         message_bus?: scalar|null|Param, // The message bus to use. // Default: "messenger.default_bus"
  *         routing?: array<string, array{ // Default: []
- *             service?: scalar|Param|null,
- *             secret?: scalar|Param|null, // Default: ""
+ *             service: scalar|null|Param,
+ *             secret?: scalar|null|Param, // Default: ""
  *         }>,
  *     },
  *     remote-event?: bool|array{ // RemoteEvent configuration
@@ -711,10 +711,7 @@ final class App
      */
     public static function config(array $config): array
     {
-        /** @var ConfigType $config */
-        $config = AppReference::config($config);
-
-        return $config;
+        return AppReference::config($config);
     }
 }
 

--- a/src/Component/JsonSchema/Generator/EnumGenerator.php
+++ b/src/Component/JsonSchema/Generator/EnumGenerator.php
@@ -15,9 +15,8 @@ class EnumGenerator implements GeneratorInterface
 {
     public const FILE_TYPE_ENUM = 'enum';
 
-    public function __construct(
-        protected Naming $naming,
-    ) {
+    public function __construct(private readonly Naming $naming)
+    {
     }
 
     public function generate(Schema $schema, string $className, Context $context): void

--- a/src/Component/JsonSchema/Generator/EnumGenerator.php
+++ b/src/Component/JsonSchema/Generator/EnumGenerator.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Generator;
+
+use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
+use Jane\Component\JsonSchema\Registry\Schema;
+use PhpParser\Comment\Doc;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt;
+
+class EnumGenerator implements GeneratorInterface
+{
+    public const FILE_TYPE_ENUM = 'enum';
+
+    public function __construct(
+        protected Naming $naming,
+    ) {
+    }
+
+    public function generate(Schema $schema, string $className, Context $context): void
+    {
+        $namespace = $schema->getNamespace() . '\\Model';
+
+        foreach ($schema->getClasses() as $class) {
+            if (!$class instanceof EnumGuess) {
+                continue;
+            }
+
+            $enumNode = $this->createEnum($class);
+
+            $namespaceStmt = new Stmt\Namespace_(new Name($namespace), [$enumNode]);
+            $schema->addFile(new File($schema->getDirectory() . '/Model/' . $class->getName() . '.php', $namespaceStmt, self::FILE_TYPE_ENUM));
+        }
+    }
+
+    protected function createEnum(EnumGuess $enumGuess): Stmt\Enum_
+    {
+        $cases = [];
+        foreach ($enumGuess->getValues() as $value) {
+            $caseName = $this->buildCaseName($value, $enumGuess->getBackingType());
+            $caseExpr = 'string' === $enumGuess->getBackingType()
+                ? new Scalar\String_((string) $value)
+                : new Scalar\Int_((int) $value);
+
+            $cases[] = new Stmt\EnumCase($caseName, $caseExpr);
+        }
+
+        $attributes = [];
+        if ($enumGuess->isDeprecated()) {
+            $attributes['comments'] = [new Doc(<<<EOD
+/**
+ * @deprecated
+ */
+EOD
+            )];
+        }
+
+        return new Stmt\Enum_(
+            $this->naming->getClassName($enumGuess->getName()),
+            [
+                'scalarType' => new Identifier($enumGuess->getBackingType()),
+                'stmts' => $cases,
+            ],
+            $attributes
+        );
+    }
+
+    protected function buildCaseName(string|int $value, string $backingType): string
+    {
+        if ('int' === $backingType) {
+            $name = 'Value' . $value;
+        } else {
+            $name = (string) $value;
+        }
+
+        // Replace non-alphanumeric characters with spaces for word boundary detection
+        $name = preg_replace('/[^a-zA-Z0-9]/', ' ', $name);
+
+        // Convert to PascalCase
+        $name = str_replace(' ', '', ucwords(strtolower(trim($name))));
+
+        // Ensure it starts with a letter
+        if ('' === $name || is_numeric(substr($name, 0, 1))) {
+            $name = 'Value' . $name;
+        }
+
+        return $name;
+    }
+}

--- a/src/Component/JsonSchema/Generator/ModelGenerator.php
+++ b/src/Component/JsonSchema/Generator/ModelGenerator.php
@@ -7,6 +7,7 @@ use Jane\Component\JsonSchema\Generator\Model\ClassGenerator;
 use Jane\Component\JsonSchema\Generator\Model\GetterSetterGenerator;
 use Jane\Component\JsonSchema\Generator\Model\PropertyGenerator;
 use Jane\Component\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
 use Jane\Component\JsonSchema\Guesser\Guess\Property;
 use Jane\Component\JsonSchema\Registry\Schema;
 use PhpParser\Node\Name;
@@ -51,6 +52,10 @@ class ModelGenerator implements GeneratorInterface
         $namespace = $schema->getNamespace() . '\\Model';
 
         foreach ($schema->getClasses() as $class) {
+            if ($class instanceof EnumGuess) {
+                continue;
+            }
+
             $properties = [];
             $methods = [];
 

--- a/src/Component/JsonSchema/Generator/ModelGenerator.php
+++ b/src/Component/JsonSchema/Generator/ModelGenerator.php
@@ -7,7 +7,7 @@ use Jane\Component\JsonSchema\Generator\Model\ClassGenerator;
 use Jane\Component\JsonSchema\Generator\Model\GetterSetterGenerator;
 use Jane\Component\JsonSchema\Generator\Model\PropertyGenerator;
 use Jane\Component\JsonSchema\Guesser\Guess\ClassGuess;
-use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
+use Jane\Component\JsonSchema\Guesser\Guess\NonObjectGuessInterface;
 use Jane\Component\JsonSchema\Guesser\Guess\Property;
 use Jane\Component\JsonSchema\Registry\Schema;
 use PhpParser\Node\Name;
@@ -52,14 +52,13 @@ class ModelGenerator implements GeneratorInterface
         $namespace = $schema->getNamespace() . '\\Model';
 
         foreach ($schema->getClasses() as $class) {
-            if ($class instanceof EnumGuess) {
+            if ($class instanceof NonObjectGuessInterface) {
                 continue;
             }
 
             $properties = [];
             $methods = [];
 
-            /** @var Property $property */
             foreach ($class->getLocalProperties() as $property) {
                 $properties[] = $this->createProperty($property, $namespace, null, $context->isStrict());
                 $methods = array_merge($methods, $this->doCreateClassMethods($class, $property, $namespace, $context->isStrict()));

--- a/src/Component/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/NormalizerGenerator.php
@@ -4,7 +4,7 @@ namespace Jane\Component\JsonSchema\Generator;
 
 use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\JsonSchema\Generator\Normalizer\DenormalizerGenerator;
-use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
+use Jane\Component\JsonSchema\Guesser\Guess\NonObjectGuessInterface;
 use Jane\Component\JsonSchema\Generator\Normalizer\JaneObjectNormalizerGenerator;
 use Jane\Component\JsonSchema\Generator\Normalizer\NormalizerGenerator as NormalizerGeneratorTrait;
 use Jane\Component\JsonSchema\Registry\Schema;
@@ -63,7 +63,7 @@ class NormalizerGenerator implements GeneratorInterface
         $normalizers = [];
 
         foreach ($schema->getClasses() as $class) {
-            if ($class instanceof EnumGuess) {
+            if ($class instanceof NonObjectGuessInterface) {
                 continue;
             }
 

--- a/src/Component/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/NormalizerGenerator.php
@@ -4,6 +4,7 @@ namespace Jane\Component\JsonSchema\Generator;
 
 use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\JsonSchema\Generator\Normalizer\DenormalizerGenerator;
+use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
 use Jane\Component\JsonSchema\Generator\Normalizer\JaneObjectNormalizerGenerator;
 use Jane\Component\JsonSchema\Generator\Normalizer\NormalizerGenerator as NormalizerGeneratorTrait;
 use Jane\Component\JsonSchema\Registry\Schema;
@@ -62,6 +63,10 @@ class NormalizerGenerator implements GeneratorInterface
         $normalizers = [];
 
         foreach ($schema->getClasses() as $class) {
+            if ($class instanceof EnumGuess) {
+                continue;
+            }
+
             $modelFqdn = $schema->getNamespace() . '\\Model\\' . $class->getName();
 
             $methods = [];

--- a/src/Component/JsonSchema/Generator/ValidatorGenerator.php
+++ b/src/Component/JsonSchema/Generator/ValidatorGenerator.php
@@ -3,6 +3,7 @@
 namespace Jane\Component\JsonSchema\Generator;
 
 use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
 use Jane\Component\JsonSchema\Guesser\Validator\ValidatorGuess;
 use Jane\Component\JsonSchema\Registry\Schema;
 use PhpParser\Modifiers;
@@ -30,6 +31,10 @@ class ValidatorGenerator implements GeneratorInterface
         $namespace = $schema->getNamespace() . '\\Validator';
 
         foreach ($schema->getClasses() as $class) {
+            if ($class instanceof EnumGuess) {
+                continue;
+            }
+
             if ($class->hasValidatorGuesses()) {
                 $className = $this->naming->getConstraintName($class->getName());
                 $collectionItemsConstraints = [];

--- a/src/Component/JsonSchema/Generator/ValidatorGenerator.php
+++ b/src/Component/JsonSchema/Generator/ValidatorGenerator.php
@@ -3,7 +3,7 @@
 namespace Jane\Component\JsonSchema\Generator;
 
 use Jane\Component\JsonSchema\Generator\Context\Context;
-use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
+use Jane\Component\JsonSchema\Guesser\Guess\NonObjectGuessInterface;
 use Jane\Component\JsonSchema\Guesser\Validator\ValidatorGuess;
 use Jane\Component\JsonSchema\Registry\Schema;
 use PhpParser\Modifiers;
@@ -31,7 +31,7 @@ class ValidatorGenerator implements GeneratorInterface
         $namespace = $schema->getNamespace() . '\\Validator';
 
         foreach ($schema->getClasses() as $class) {
-            if ($class instanceof EnumGuess) {
+            if ($class instanceof NonObjectGuessInterface) {
                 continue;
             }
 

--- a/src/Component/JsonSchema/Guesser/Guess/EnumGuess.php
+++ b/src/Component/JsonSchema/Guesser/Guess/EnumGuess.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Guesser\Guess;
+
+class EnumGuess extends ClassGuess
+{
+    /**
+     * @param object        $object    Object link to the generation
+     * @param string        $reference Reference of the schema
+     * @param string        $name      Name of the enum
+     * @param string        $backingType PHP backing type ('string' or 'int')
+     * @param array<string|int> $values    Enum values
+     */
+    public function __construct(
+        object $object,
+        string $reference,
+        string $name,
+        private readonly string $backingType,
+        private readonly array $values,
+        bool $deprecated = false,
+    ) {
+        parent::__construct($object, $reference, $name, [], $deprecated);
+    }
+
+    public function getBackingType(): string
+    {
+        return $this->backingType;
+    }
+
+    /**
+     * @return array<string|int>
+     */
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+}

--- a/src/Component/JsonSchema/Guesser/Guess/EnumGuess.php
+++ b/src/Component/JsonSchema/Guesser/Guess/EnumGuess.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\JsonSchema\Guesser\Guess;
 
-class EnumGuess extends ClassGuess
+class EnumGuess extends ClassGuess implements NonObjectGuessInterface
 {
     /**
      * @param object        $object    Object link to the generation

--- a/src/Component/JsonSchema/Guesser/Guess/EnumType.php
+++ b/src/Component/JsonSchema/Guesser/Guess/EnumType.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Guesser\Guess;
+
+use Jane\Component\JsonSchema\Generator\Context\Context;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar;
+
+class EnumType extends Type
+{
+    public function __construct(
+        object $object,
+        private readonly string $className,
+        private readonly string $namespace,
+        private readonly string $backingType,
+    ) {
+        parent::__construct($object, $backingType);
+    }
+
+    protected function createDenormalizationValueStatement(Context $context, Expr $input, bool $normalizerFromObject = true): Expr
+    {
+        return new Expr\StaticCall(
+            new FullyQualified($this->getFqdn(false)),
+            'from',
+            [new Arg($input)]
+        );
+    }
+
+    protected function createNormalizationValueStatement(Context $context, Expr $input, bool $normalizerFromObject = true): Expr
+    {
+        return new Expr\PropertyFetch($input, 'value');
+    }
+
+    public function createConditionStatement(Expr $input): Expr
+    {
+        return new Expr\FuncCall(
+            new Name($this->conditionMapping[$this->name]),
+            [new Arg($input)]
+        );
+    }
+
+    public function createNormalizationConditionStatement(Expr $input): Expr
+    {
+        return new Expr\Instanceof_(
+            $input,
+            new FullyQualified($this->getFqdn(false))
+        );
+    }
+
+    public function getTypeHint(string $namespace): Name
+    {
+        if ('\\' . $namespace . '\\' . $this->className === $this->getFqdn()) {
+            return new Name($this->className);
+        }
+
+        return new Name($this->getFqdn());
+    }
+
+    public function getDocTypeHint(string $namespace): Name
+    {
+        return $this->getTypeHint($namespace);
+    }
+
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    private function getFqdn(bool $withRoot = true): string
+    {
+        if ($withRoot) {
+            return '\\' . $this->namespace . '\\Model\\' . $this->className;
+        }
+
+        return $this->namespace . '\\Model\\' . $this->className;
+    }
+}

--- a/src/Component/JsonSchema/Guesser/Guess/NonObjectGuessInterface.php
+++ b/src/Component/JsonSchema/Guesser/Guess/NonObjectGuessInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Guesser\Guess;
+
+/**
+ * Marker interface for guesses that represent types without properties (e.g. enums).
+ *
+ * Classes implementing this interface will be skipped during property guessing,
+ * model generation, normalizer generation, and validator generation.
+ */
+interface NonObjectGuessInterface
+{
+}

--- a/src/Component/JsonSchema/Guesser/JsonSchema/EnumGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/EnumGuesser.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Guesser\JsonSchema;
+
+use Jane\Component\JsonSchema\Generator\Naming;
+use Jane\Component\JsonSchema\Guesser\ClassGuesserInterface;
+use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
+use Jane\Component\JsonSchema\Guesser\Guess\EnumType;
+use Jane\Component\JsonSchema\Guesser\Guess\Type;
+use Jane\Component\JsonSchema\Guesser\GuesserInterface;
+use Jane\Component\JsonSchema\Guesser\TypeGuesserInterface;
+use Jane\Component\JsonSchema\JsonSchema\Model\JsonSchema;
+use Jane\Component\JsonSchema\Registry\Registry;
+
+class EnumGuesser implements GuesserInterface, ClassGuesserInterface, TypeGuesserInterface
+{
+    private static array $jsonTypeToPhp = [
+        'string' => 'string',
+        'integer' => 'int',
+    ];
+
+    public function __construct(protected Naming $naming = new Naming())
+    {
+    }
+
+    public function supportObject($object): bool
+    {
+        $class = $this->getSchemaClass();
+        if (!$object instanceof $class) {
+            return false;
+        }
+
+        if (!\in_array($object->getType(), ['string', 'integer'], true)) {
+            return false;
+        }
+
+        if (null === $object->getEnum() || [] === $object->getEnum()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param JsonSchema $object
+     */
+    public function guessClass($object, string $name, string $reference, Registry $registry): void
+    {
+        if ($registry->hasClass($reference)) {
+            return;
+        }
+
+        $values = $object->getEnum();
+
+        $enumGuess = new EnumGuess(
+            $object,
+            $reference,
+            $this->naming->getClassName($name),
+            $this->getBackingType($object),
+            $values,
+            method_exists($object, 'getDeprecated') && ($object->getDeprecated() ?? false)
+        );
+
+        $schema = $registry->getSchema($reference);
+        if (null !== $schema) {
+            $schema->addClass($reference, $enumGuess);
+        }
+    }
+
+    /**
+     * @param JsonSchema $object
+     */
+    public function guessType($object, string $name, string $reference, Registry $registry): Type
+    {
+        $backingType = $this->getBackingType($object);
+
+        if ($registry->hasClass($reference) && null !== ($schema = $registry->getSchema($reference))) {
+            return new EnumType(
+                $object,
+                $registry->getClass($reference)->getName(),
+                $schema->getNamespace(),
+                $backingType,
+            );
+        }
+
+        return new Type($object, $backingType);
+    }
+
+    protected function getSchemaClass(): string
+    {
+        return JsonSchema::class;
+    }
+
+    private function getBackingType(JsonSchema $object): string
+    {
+        return match ($object->getType()) {
+            'integer' => 'int',
+            default => 'string',
+        };
+    }
+}

--- a/src/Component/JsonSchema/Guesser/JsonSchema/EnumGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/EnumGuesser.php
@@ -67,7 +67,7 @@ class EnumGuesser implements GuesserInterface, ClassGuesserInterface, TypeGuesse
      */
     public function guessType($object, string $name, string $reference, Registry $registry): Type
     {
-        $backingType = $this->getBackingType($object);
+        $backingType = $this->getBackingType($object->getType());
 
         if ($registry->hasClass($reference) && null !== ($schema = $registry->getSchema($reference))) {
             return new EnumType(

--- a/src/Component/JsonSchema/Guesser/JsonSchema/EnumGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/EnumGuesser.php
@@ -14,12 +14,7 @@ use Jane\Component\JsonSchema\Registry\Registry;
 
 class EnumGuesser implements GuesserInterface, ClassGuesserInterface, TypeGuesserInterface
 {
-    private static array $jsonTypeToPhp = [
-        'string' => 'string',
-        'integer' => 'int',
-    ];
-
-    public function __construct(protected Naming $naming = new Naming())
+    public function __construct(private readonly Naming $naming = new Naming())
     {
     }
 
@@ -56,7 +51,7 @@ class EnumGuesser implements GuesserInterface, ClassGuesserInterface, TypeGuesse
             $object,
             $reference,
             $this->naming->getClassName($name),
-            $this->getBackingType($object),
+            $this->getBackingType($object->getType()),
             $values,
             method_exists($object, 'getDeprecated') && ($object->getDeprecated() ?? false)
         );
@@ -91,9 +86,9 @@ class EnumGuesser implements GuesserInterface, ClassGuesserInterface, TypeGuesse
         return JsonSchema::class;
     }
 
-    private function getBackingType(JsonSchema $object): string
+    private function getBackingType(string $type): string
     {
-        return match ($object->getType()) {
+        return match ($type) {
             'integer' => 'int',
             default => 'string',
         };

--- a/src/Component/JsonSchema/Guesser/JsonSchema/JsonSchemaGuesserFactory.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/JsonSchemaGuesserFactory.php
@@ -15,10 +15,15 @@ class JsonSchemaGuesserFactory
         $chainGuesser = ChainGuesserFactory::create($denormalizer);
         $naming = new Naming();
         $merger = new JsonSchemaMerger();
-        $dateFormat = isset($options['full-date-format']) ? $options['full-date-format'] : 'Y-m-d';
-        $outputDateTimeFormat = isset($options['date-format']) ? $options['date-format'] : \DateTimeInterface::RFC3339;
-        $inputDateTimeFormat = isset($options['date-input-format']) ? $options['date-input-format'] : null;
-        $datePreferInterface = isset($options['date-prefer-interface']) ? $options['date-prefer-interface'] : null;
+        $dateFormat = $options['full-date-format'] ?? 'Y-m-d';
+        $outputDateTimeFormat = $options['date-format'] ?? \DateTimeInterface::RFC3339;
+        $inputDateTimeFormat = $options['date-input-format'] ?? null;
+        $datePreferInterface = $options['date-prefer-interface'] ?? null;
+        $enumObjects = $options['enums-as-objects'] ?? false;
+
+        if ($enumObjects) {
+            $chainGuesser->addGuesser(new EnumGuesser($naming));
+        }
 
         $chainGuesser->addGuesser(new DateGuesser($dateFormat, $datePreferInterface));
         $chainGuesser->addGuesser(new DateTimeGuesser($outputDateTimeFormat, $inputDateTimeFormat, $datePreferInterface));

--- a/src/Component/JsonSchema/Jane.php
+++ b/src/Component/JsonSchema/Jane.php
@@ -4,6 +4,7 @@ namespace Jane\Component\JsonSchema;
 
 use Jane\Component\JsonSchema\Generator\ChainGenerator;
 use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\JsonSchema\Generator\EnumGenerator;
 use Jane\Component\JsonSchema\Generator\ModelGenerator;
 use Jane\Component\JsonSchema\Generator\Naming;
 use Jane\Component\JsonSchema\Generator\NormalizerGenerator;
@@ -11,6 +12,7 @@ use Jane\Component\JsonSchema\Generator\RuntimeGenerator;
 use Jane\Component\JsonSchema\Generator\ValidatorGenerator;
 use Jane\Component\JsonSchema\Guesser\ChainGuesser;
 use Jane\Component\JsonSchema\Guesser\JsonSchema\JsonSchemaGuesserFactory;
+use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
 use Jane\Component\JsonSchema\Guesser\Validator\ChainValidatorFactory;
 use Jane\Component\JsonSchema\JsonSchema\Normalizer\JaneObjectNormalizer;
 use Jane\Component\JsonSchema\Registry\Registry;
@@ -53,6 +55,10 @@ class Jane extends ChainGenerator
 
         foreach ($registry->getSchemas() as $schema) {
             foreach ($schema->getClasses() as $class) {
+                if ($class instanceof EnumGuess) {
+                    continue;
+                }
+
                 $properties = $this->chainGuesser->guessProperties($class->getObject(), $schema->getRootName(), $class->getReference(), $registry);
 
                 $names = [];
@@ -94,6 +100,9 @@ class Jane extends ChainGenerator
         $self->addGenerator(new RuntimeGenerator($naming, $parser));
         if ($options['validation'] ?? false) {
             $self->addGenerator(new ValidatorGenerator($naming));
+        }
+        if ($options['enums-as-objects'] ?? false) {
+            $self->addGenerator(new EnumGenerator($naming));
         }
 
         return $self;

--- a/src/Component/JsonSchema/Jane.php
+++ b/src/Component/JsonSchema/Jane.php
@@ -12,7 +12,7 @@ use Jane\Component\JsonSchema\Generator\RuntimeGenerator;
 use Jane\Component\JsonSchema\Generator\ValidatorGenerator;
 use Jane\Component\JsonSchema\Guesser\ChainGuesser;
 use Jane\Component\JsonSchema\Guesser\JsonSchema\JsonSchemaGuesserFactory;
-use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
+use Jane\Component\JsonSchema\Guesser\Guess\NonObjectGuessInterface;
 use Jane\Component\JsonSchema\Guesser\Validator\ChainValidatorFactory;
 use Jane\Component\JsonSchema\JsonSchema\Normalizer\JaneObjectNormalizer;
 use Jane\Component\JsonSchema\Registry\Registry;
@@ -55,7 +55,7 @@ class Jane extends ChainGenerator
 
         foreach ($registry->getSchemas() as $schema) {
             foreach ($schema->getClasses() as $class) {
-                if ($class instanceof EnumGuess) {
+                if ($class instanceof NonObjectGuessInterface) {
                     continue;
                 }
 

--- a/src/Component/OpenApi2/Guesser/OpenApiSchema/GuesserFactory.php
+++ b/src/Component/OpenApi2/Guesser/OpenApiSchema/GuesserFactory.php
@@ -13,6 +13,7 @@ use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\DateTimeGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\ItemsGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\MultipleGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\ReferenceGuesser;
+use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\EnumGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\SimpleTypeGuesser;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
@@ -25,8 +26,14 @@ class GuesserFactory
         $outputDateTimeFormat = $options['date-format'] ?? \DateTimeInterface::RFC3339;
         $inputDateTimeFormat = $options['date-input-format'] ?? null;
         $datePreferInterface = $options['date-prefer-interface'] ?? null;
+        $enumObjects = $options['enums-as-objects'] ?? false;
 
         $chainGuesser = new ChainGuesser();
+
+        if ($enumObjects) {
+            $chainGuesser->addGuesser(new EnumGuesser(Schema::class, $naming));
+        }
+
         $chainGuesser->addGuesser(new SecurityGuesser());
         $chainGuesser->addGuesser(new DateGuesser(Schema::class, $dateFormat, $datePreferInterface));
         $chainGuesser->addGuesser(new DateTimeGuesser(Schema::class, $outputDateTimeFormat, $inputDateTimeFormat, $datePreferInterface));

--- a/src/Component/OpenApi2/JaneOpenApi.php
+++ b/src/Component/OpenApi2/JaneOpenApi.php
@@ -2,6 +2,7 @@
 
 namespace Jane\Component\OpenApi2;
 
+use Jane\Component\JsonSchema\Generator\EnumGenerator;
 use Jane\Component\JsonSchema\Generator\Naming;
 use Jane\Component\JsonSchema\Generator\ValidatorGenerator;
 use Jane\Component\OpenApi2\Generator\EndpointGenerator;
@@ -45,6 +46,9 @@ class JaneOpenApi extends CommonJaneOpenApi
         yield new RuntimeGenerator($naming, $parser);
         if ($options['validation'] ?? false) {
             yield new ValidatorGenerator($naming);
+        }
+        if ($options['enums-as-objects'] ?? false) {
+            yield new EnumGenerator($naming);
         }
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/.jane-openapi
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.json',
+    'namespace' => 'Jane\Component\OpenApi2\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'enums-as-objects' => true,
+];

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Client.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi2\Tests\Expected\Model\Item[] : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getItems(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Endpoint\GetItems(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://localhost/');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Endpoint/GetItems.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Endpoint/GetItems.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Endpoint;
+
+class GetItems extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/items';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi2\Tests\Expected\Model\Item[]
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (200 === $status) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Expected\Model\Item[]', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Model/Item.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Model/Item.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Model;
+
+class Item
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var int
+     */
+    protected $id;
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var ItemStatus
+     */
+    protected $status;
+    /**
+     * @var Priority
+     */
+    protected $priority;
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+    /**
+     * @param int $id
+     *
+     * @return self
+     */
+    public function setId(int $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return ItemStatus
+     */
+    public function getStatus(): ItemStatus
+    {
+        return $this->status;
+    }
+    /**
+     * @param ItemStatus $status
+     *
+     * @return self
+     */
+    public function setStatus(ItemStatus $status): self
+    {
+        $this->initialized['status'] = true;
+        $this->status = $status;
+        return $this;
+    }
+    /**
+     * @return Priority
+     */
+    public function getPriority(): Priority
+    {
+        return $this->priority;
+    }
+    /**
+     * @param Priority $priority
+     *
+     * @return self
+     */
+    public function setPriority(Priority $priority): self
+    {
+        $this->initialized['priority'] = true;
+        $this->priority = $priority;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Model/ItemStatus.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Model/ItemStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Model;
+
+enum ItemStatus : string
+{
+    case Pending = 'pending';
+    case InProgress = 'in_progress';
+    case Completed = 'completed';
+    case Cancelled = 'cancelled';
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Model/Priority.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Model/Priority.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Model;
+
+enum Priority : int
+{
+    case Value1 = 1;
+    case Value2 = 2;
+    case Value3 = 3;
+    case Value4 = 4;
+    case Value5 = 5;
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Normalizer/ItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Normalizer/ItemNormalizer.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi2\Tests\Expected\Model\Item::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Expected\Model\Item::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi2\Tests\Expected\Model\Item();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+        }
+        if (\array_key_exists('status', $data)) {
+            $object->setStatus(\Jane\Component\OpenApi2\Tests\Expected\Model\ItemStatus::from($data['status']));
+        }
+        if (\array_key_exists('priority', $data)) {
+            $object->setPriority(\Jane\Component\OpenApi2\Tests\Expected\Model\Priority::from($data['priority']));
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('id') && null !== $data->getId()) {
+            $dataArray['id'] = $data->getId();
+        }
+        if ($data->isInitialized('name') && null !== $data->getName()) {
+            $dataArray['name'] = $data->getName();
+        }
+        if ($data->isInitialized('status') && null !== $data->getStatus()) {
+            $dataArray['status'] = $data->getStatus()->value;
+        }
+        if ($data->isInitialized('priority') && null !== $data->getPriority()) {
+            $dataArray['priority'] = $data->getPriority()->value;
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi2\Tests\Expected\Model\Item::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi2\Tests\Expected\Model\Item::class => \Jane\Component\OpenApi2\Tests\Expected\Normalizer\ItemNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            
+            \Jane\Component\OpenApi2\Tests\Expected\Model\Item::class => false,
+            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+        ];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(static function ($value) {
+            return $value ?? '';
+        }, $optionsResolved);
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            $allowReservedKey = in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/swagger.json
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/swagger.json
@@ -1,0 +1,63 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Enum Test API",
+        "version": "1.0.0"
+    },
+    "host": "localhost",
+    "basePath": "/",
+    "schemes": ["https"],
+    "paths": {
+        "/items": {
+            "get": {
+                "operationId": "getItems",
+                "summary": "Get items",
+                "produces": ["application/json"],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Item"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Item": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/ItemStatus"
+                },
+                "priority": {
+                    "$ref": "#/definitions/Priority"
+                }
+            }
+        },
+        "ItemStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "cancelled"
+            ]
+        },
+        "Priority": {
+            "type": "integer",
+            "enum": [1, 2, 3, 4, 5]
+        }
+    }
+}

--- a/src/Component/OpenApi3/Guesser/OpenApiSchema/GuesserFactory.php
+++ b/src/Component/OpenApi3/Guesser/OpenApiSchema/GuesserFactory.php
@@ -14,6 +14,7 @@ use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\DateTimeGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\ItemsGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\MultipleGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\ReferenceGuesser;
+use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\EnumGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\SimpleTypeGuesser;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
@@ -27,8 +28,14 @@ class GuesserFactory
         $inputDateTimeFormat = $options['date-input-format'] ?? null;
         $datePreferInterface = $options['date-prefer-interface'] ?? null;
         $customStringFormatMapping = $options['custom-string-format-mapping'] ?? [];
+        $enumObjects = $options['enums-as-objects'] ?? false;
 
         $chainGuesser = new ChainGuesser();
+
+        if ($enumObjects) {
+            $chainGuesser->addGuesser(new EnumGuesser(Schema::class, $naming));
+        }
+
         $chainGuesser->addGuesser(new SecurityGuesser());
         $chainGuesser->addGuesser(new CustomStringFormatGuesser(Schema::class, $customStringFormatMapping));
         $chainGuesser->addGuesser(new DateGuesser(Schema::class, $dateFormat, $datePreferInterface));

--- a/src/Component/OpenApi3/JaneOpenApi.php
+++ b/src/Component/OpenApi3/JaneOpenApi.php
@@ -2,6 +2,7 @@
 
 namespace Jane\Component\OpenApi3;
 
+use Jane\Component\JsonSchema\Generator\EnumGenerator;
 use Jane\Component\JsonSchema\Generator\Naming;
 use Jane\Component\JsonSchema\Generator\ValidatorGenerator;
 use Jane\Component\OpenApi3\Generator\EndpointGenerator;
@@ -44,6 +45,9 @@ class JaneOpenApi extends CommonJaneOpenApi
         yield new RuntimeGenerator($naming, $parser);
         if ($options['validation'] ?? false) {
             yield new ValidatorGenerator($naming);
+        }
+        if ($options['enums-as-objects'] ?? false) {
+            yield new EnumGenerator($naming);
         }
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.yaml',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'enums-as-objects' => true,
+];

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Client.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Expected\Model\Item[] : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getItems(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetItems(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Endpoint/GetItems.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Endpoint/GetItems.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetItems extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/items';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\Item[]
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Expected\Model\Item[]', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Model/Item.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Model/Item.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class Item extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var int
+     */
+    protected $id;
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @var ItemStatus
+     */
+    protected $status;
+    /**
+     * @var Priority
+     */
+    protected $priority;
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+    /**
+     * @param int $id
+     *
+     * @return self
+     */
+    public function setId(int $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+    /**
+     * @return ItemStatus
+     */
+    public function getStatus(): ItemStatus
+    {
+        return $this->status;
+    }
+    /**
+     * @param ItemStatus $status
+     *
+     * @return self
+     */
+    public function setStatus(ItemStatus $status): self
+    {
+        $this->initialized['status'] = true;
+        $this->status = $status;
+        return $this;
+    }
+    /**
+     * @return Priority
+     */
+    public function getPriority(): Priority
+    {
+        return $this->priority;
+    }
+    /**
+     * @param Priority $priority
+     *
+     * @return self
+     */
+    public function setPriority(Priority $priority): self
+    {
+        $this->initialized['priority'] = true;
+        $this->priority = $priority;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Model/ItemStatus.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Model/ItemStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+enum ItemStatus : string
+{
+    case Pending = 'pending';
+    case InProgress = 'in_progress';
+    case Completed = 'completed';
+    case Cancelled = 'cancelled';
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Model/Priority.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Model/Priority.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+enum Priority : int
+{
+    case Value1 = 1;
+    case Value2 = 2;
+    case Value3 = 3;
+    case Value4 = 4;
+    case Value5 = 5;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Normalizer/ItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Normalizer/ItemNormalizer.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\Item::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\Item::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Item();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+            unset($data['id']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+            unset($data['name']);
+        }
+        if (\array_key_exists('status', $data)) {
+            $object->setStatus(\Jane\Component\OpenApi3\Tests\Expected\Model\ItemStatus::from($data['status']));
+            unset($data['status']);
+        }
+        if (\array_key_exists('priority', $data)) {
+            $object->setPriority(\Jane\Component\OpenApi3\Tests\Expected\Model\Priority::from($data['priority']));
+            unset($data['priority']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('id') && null !== $data->getId()) {
+            $dataArray['id'] = $data->getId();
+        }
+        if ($data->isInitialized('name') && null !== $data->getName()) {
+            $dataArray['name'] = $data->getName();
+        }
+        if ($data->isInitialized('status') && null !== $data->getStatus()) {
+            $dataArray['status'] = $data->getStatus()->value;
+        }
+        if ($data->isInitialized('priority') && null !== $data->getPriority()) {
+            $dataArray['priority'] = $data->getPriority()->value;
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\Item::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi3\Tests\Expected\Model\Item::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ItemNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            
+            \Jane\Component\OpenApi3\Tests\Expected\Model\Item::class => false,
+            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+        ];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(static function ($value) {
+            return $value ?? '';
+        }, $optionsResolved);
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            $allowReservedKey = in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/swagger.yaml
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/swagger.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.3
+info:
+  title: Enum Test API
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      operationId: getItems
+      summary: Get items
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Item'
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        status:
+          $ref: '#/components/schemas/ItemStatus'
+        priority:
+          $ref: '#/components/schemas/Priority'
+    ItemStatus:
+      type: string
+      enum:
+        - pending
+        - in_progress
+        - completed
+        - cancelled
+    Priority:
+      type: integer
+      enum:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5

--- a/src/Component/OpenApi31/Guesser/OpenApiSchema/GuesserFactory.php
+++ b/src/Component/OpenApi31/Guesser/OpenApiSchema/GuesserFactory.php
@@ -14,6 +14,7 @@ use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\DateTimeGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\ItemsGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\MultipleGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\ReferenceGuesser;
+use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\EnumGuesser;
 use Jane\Component\OpenApiCommon\Guesser\OpenApiSchema\SimpleTypeGuesser;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
@@ -27,8 +28,14 @@ class GuesserFactory
         $inputDateTimeFormat = $options['date-input-format'] ?? null;
         $datePreferInterface = $options['date-prefer-interface'] ?? null;
         $customStringFormatMapping = $options['custom-string-format-mapping'] ?? [];
+        $enumObjects = $options['enums-as-objects'] ?? false;
 
         $chainGuesser = new ChainGuesser();
+
+        if ($enumObjects) {
+            $chainGuesser->addGuesser(new EnumGuesser(JsonSchema::class, $naming));
+        }
+
         $chainGuesser->addGuesser(new SecurityGuesser());
         $chainGuesser->addGuesser(new CustomStringFormatGuesser(JsonSchema::class, $customStringFormatMapping));
         $chainGuesser->addGuesser(new DateGuesser(JsonSchema::class, $dateFormat, $datePreferInterface));

--- a/src/Component/OpenApi31/JaneOpenApi.php
+++ b/src/Component/OpenApi31/JaneOpenApi.php
@@ -2,6 +2,7 @@
 
 namespace Jane\Component\OpenApi31;
 
+use Jane\Component\JsonSchema\Generator\EnumGenerator;
 use Jane\Component\JsonSchema\Generator\Naming;
 use Jane\Component\JsonSchema\Generator\ValidatorGenerator;
 use Jane\Component\JsonSchema\JsonSchema\Normalizer\JsonSchemaNormalizer;
@@ -56,6 +57,9 @@ class JaneOpenApi extends CommonJaneOpenApi
         yield new RuntimeGenerator($naming, $parser);
         if ($options['validation'] ?? false) {
             yield new ValidatorGenerator($naming);
+        }
+        if ($options['enums-as-objects'] ?? false) {
+            yield new EnumGenerator($naming);
         }
     }
 

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/.jane-openapi
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/.jane-openapi
@@ -5,4 +5,5 @@ return [
     'namespace' => 'Jane\Component\OpenApi31\Tests\Expected',
     'directory' => __DIR__ . '/generated',
     'validation' => true,
+    'enums-as-objects' => true,
 ];

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Model/Planet.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Model/Planet.php
@@ -25,7 +25,7 @@ class Planet
      */
     protected $description;
     /**
-     * @var string
+     * @var PlanetType
      */
     protected $type;
     /**
@@ -137,18 +137,18 @@ class Planet
         return $this;
     }
     /**
-     * @return string
+     * @return PlanetType
      */
-    public function getType(): string
+    public function getType(): PlanetType
     {
         return $this->type;
     }
     /**
-     * @param string $type
+     * @param PlanetType $type
      *
      * @return self
      */
-    public function setType(string $type): self
+    public function setType(PlanetType $type): self
     {
         $this->initialized['type'] = true;
         $this->type = $type;

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Model/PlanetType.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Model/PlanetType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model;
+
+enum PlanetType : string
+{
+    case Terrestrial = 'terrestrial';
+    case GasGiant = 'gas_giant';
+    case IceGiant = 'ice_giant';
+    case Dwarf = 'dwarf';
+    case SuperEarth = 'super_earth';
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Model/Satellite.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Model/Satellite.php
@@ -31,7 +31,7 @@ class Satellite
      */
     protected $diameter;
     /**
-     * @var string
+     * @var SatelliteType
      */
     protected $type;
     /**
@@ -115,18 +115,18 @@ class Satellite
         return $this;
     }
     /**
-     * @return string
+     * @return SatelliteType
      */
-    public function getType(): string
+    public function getType(): SatelliteType
     {
         return $this->type;
     }
     /**
-     * @param string $type
+     * @param SatelliteType $type
      *
      * @return self
      */
-    public function setType(string $type): self
+    public function setType(SatelliteType $type): self
     {
         $this->initialized['type'] = true;
         $this->type = $type;

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Model/SatelliteType.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Model/SatelliteType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model;
+
+enum SatelliteType : string
+{
+    case Moon = 'moon';
+    case Asteroid = 'asteroid';
+    case Comet = 'comet';
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetNormalizer.php
@@ -62,7 +62,7 @@ class PlanetNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $object->setDescription(null);
         }
         if (\array_key_exists('type', $data)) {
-            $object->setType($data['type']);
+            $object->setType(\Jane\Component\OpenApi31\Tests\Expected\Model\PlanetType::from($data['type']));
         }
         if (\array_key_exists('habitabilityIndex', $data)) {
             $object->setHabitabilityIndex($data['habitabilityIndex']);
@@ -134,7 +134,7 @@ class PlanetNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $dataArray['description'] = $value;
         }
         if ($data->isInitialized('type') && null !== $data->getType()) {
-            $dataArray['type'] = $data->getType();
+            $dataArray['type'] = $data->getType()->value;
         }
         if ($data->isInitialized('habitabilityIndex') && null !== $data->getHabitabilityIndex()) {
             $dataArray['habitabilityIndex'] = $data->getHabitabilityIndex();

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/SatelliteNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/SatelliteNormalizer.php
@@ -65,7 +65,7 @@ class SatelliteNormalizer implements DenormalizerInterface, NormalizerInterface,
             $object->setDiameter($data['diameter']);
         }
         if (\array_key_exists('type', $data)) {
-            $object->setType($data['type']);
+            $object->setType(\Jane\Component\OpenApi31\Tests\Expected\Model\SatelliteType::from($data['type']));
         }
         if (\array_key_exists('orbit', $data)) {
             $object->setOrbit($this->denormalizer->denormalize($data['orbit'], \Jane\Component\OpenApi31\Tests\Expected\Model\SatelliteOrbit::class, 'json', $context));
@@ -89,7 +89,7 @@ class SatelliteNormalizer implements DenormalizerInterface, NormalizerInterface,
             $dataArray['diameter'] = $data->getDiameter();
         }
         if ($data->isInitialized('type') && null !== $data->getType()) {
-            $dataArray['type'] = $data->getType();
+            $dataArray['type'] = $data->getType()->value;
         }
         if ($data->isInitialized('orbit') && null !== $data->getOrbit()) {
             $dataArray['orbit'] = $this->normalizer->normalize($data->getOrbit(), 'json', $context);

--- a/src/Component/OpenApiCommon/Console/Loader/ConfigLoader.php
+++ b/src/Component/OpenApiCommon/Console/Loader/ConfigLoader.php
@@ -28,6 +28,7 @@ class ConfigLoader extends BaseConfigLoader implements ConfigLoaderInterface
             'endpoint-generator' => null,
             'custom-query-resolver' => [],
             'throw-unexpected-status-code' => false,
+            'enums-as-objects' => false,
         ]);
     }
 }

--- a/src/Component/OpenApiCommon/Console/Loader/SchemaLoader.php
+++ b/src/Component/OpenApiCommon/Console/Loader/SchemaLoader.php
@@ -38,6 +38,7 @@ class SchemaLoader extends BaseSchemaLoader implements SchemaLoaderInterface
             'throw-unexpected-status-code',
             'custom-string-format-mapping',
             'include-null-value',
+            'enums-as-objects',
         ];
     }
 

--- a/src/Component/OpenApiCommon/Guesser/OpenApiSchema/EnumGuesser.php
+++ b/src/Component/OpenApiCommon/Guesser/OpenApiSchema/EnumGuesser.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jane\Component\OpenApiCommon\Guesser\OpenApiSchema;
+
+use Jane\Component\JsonSchema\Generator\Naming;
+use Jane\Component\JsonSchema\Guesser\JsonSchema\EnumGuesser as BaseEnumGuesser;
+
+class EnumGuesser extends BaseEnumGuesser
+{
+    private string $schemaClass;
+
+    public function __construct(string $schemaClass, ?Naming $naming = null)
+    {
+        $this->schemaClass = $schemaClass;
+        parent::__construct($naming ?? new Naming());
+    }
+
+    protected function getSchemaClass(): string
+    {
+        return $this->schemaClass;
+    }
+}

--- a/src/Component/OpenApiCommon/JaneOpenApi.php
+++ b/src/Component/OpenApiCommon/JaneOpenApi.php
@@ -6,7 +6,7 @@ use Jane\Component\JsonSchema\Generator\ChainGenerator;
 use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\JsonSchema\Generator\Naming;
 use Jane\Component\JsonSchema\Guesser\ChainGuesser;
-use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
+use Jane\Component\JsonSchema\Guesser\Guess\NonObjectGuessInterface;
 use Jane\Component\JsonSchema\Guesser\Validator\ChainValidatorFactory;
 use Jane\Component\JsonSchema\Registry\Registry;
 use Jane\Component\OpenApiCommon\Contracts\WhitelistFetchInterface;
@@ -72,7 +72,7 @@ abstract class JaneOpenApi extends ChainGenerator
 
         foreach ($schemas as $schema) {
             foreach ($schema->getClasses() as $class) {
-                if ($class instanceof EnumGuess) {
+                if ($class instanceof NonObjectGuessInterface) {
                     continue;
                 }
 

--- a/src/Component/OpenApiCommon/JaneOpenApi.php
+++ b/src/Component/OpenApiCommon/JaneOpenApi.php
@@ -6,6 +6,7 @@ use Jane\Component\JsonSchema\Generator\ChainGenerator;
 use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\JsonSchema\Generator\Naming;
 use Jane\Component\JsonSchema\Guesser\ChainGuesser;
+use Jane\Component\JsonSchema\Guesser\Guess\EnumGuess;
 use Jane\Component\JsonSchema\Guesser\Validator\ChainValidatorFactory;
 use Jane\Component\JsonSchema\Registry\Registry;
 use Jane\Component\OpenApiCommon\Contracts\WhitelistFetchInterface;
@@ -71,6 +72,10 @@ abstract class JaneOpenApi extends ChainGenerator
 
         foreach ($schemas as $schema) {
             foreach ($schema->getClasses() as $class) {
+                if ($class instanceof EnumGuess) {
+                    continue;
+                }
+
                 $properties = $this->chainGuesser->guessProperties($class->getObject(), $schema->getRootName(), $class->getReference(), $registry);
 
                 $names = [];


### PR DESCRIPTION
Added new option to generate enum classes for schemas with enums in them. 

I kinda don't like those conditions in generators and JaneOpenApi but I've didn't come up with anything better without major rewrite, and since we can have either classes / enums / interfaces in PHP I don't think this is the worst. I've at least tried to cover it behind marker interface in case we would want to generate interfaces (I don't think we will though 😄 ). I've also updated existing spec for OA 3.1 in tests instead of creating new one so I hope thats fine by you. 