### PR TITLE
Use node 24 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: install node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - name: install prism
         run: yarn global add @stoplight/prism-cli
       - name: run OpenApi3 prism server
@@ -113,7 +113,7 @@ jobs:
       - name: install node
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - name: install prism
         run: yarn global add @stoplight/prism-cli
       - name: run OpenApi3 prism server


### PR DESCRIPTION
```
error @stoplight/prism-http@5.15.10: The engine "node" is incompatible with this module. Expected version ">=24.14.0". Got "22.22.3"
```

See https://github.com/stoplightio/prism/pull/2752/changes