### PR TITLE
fix: Fix missing InvalidArgumentException import in generated BaseEndpoint

### DIFF
--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/BaseEndpoint.php
@@ -82,7 +82,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
     private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string

--- a/src/Component/OpenApiCommon/Generator/Runtime/data/Client/BaseEndpoint.php
+++ b/src/Component/OpenApiCommon/Generator/Runtime/data/Client/BaseEndpoint.php
@@ -111,7 +111,7 @@ abstract class BaseEndpoint implements Endpoint
             is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
             is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
             is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
-            default => throw new InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
         };
     }
 


### PR DESCRIPTION
The BaseEndpoint template used `InvalidArgumentException` without a use statement, causing a fatal error at runtime when an unsupported query parameter type was passed. 
Fixed by using the fully-qualified `\InvalidArgumentException` instead, and regenerated all test fixtures to reflect the change.

Closes #956