### PR TITLE
Sanitize PHPDoc to prevent instantiation RCE via */ breakout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- [OpenApi] [GHSA-xwcw-j52r-34x4](https://github.com/janephp/janephp/security/advisories/GHSA-xwcw-j52r-34x4) [GHSA-x9xr-53qx-9qcf](https://github.com/janephp/janephp/security/advisories/GHSA-x9xr-53qx-9qcf) [GHSA-q8v2-3j4h-xg2p](https://github.com/janephp/janephp/security/advisories/GHSA-q8v2-3j4h-xg2p) Sanitize `*/` in generated PHPDoc comments to prevent instantiation RCE via PHPDoc breakout
 
 ## [7.11.2] - 2026-04-16
 ### Added

--- a/src/Component/JsonSchema/Generator/Model/GetterSetterGenerator.php
+++ b/src/Component/JsonSchema/Generator/Model/GetterSetterGenerator.php
@@ -104,7 +104,7 @@ trait GetterSetterGenerator
     {
         $description = ['/**'];
         if ($property->getDescription()) {
-            foreach (array_map(rtrim(...), explode("\n", $property->getDescription())) as $line) {
+            foreach (array_map(fn (string $line): string => str_replace('*/', '*\\/', rtrim($line)), explode("\n", $property->getDescription())) as $line) {
                 $description[] = ' * ' . $line;
             }
             $description[] = ' *';
@@ -127,7 +127,7 @@ trait GetterSetterGenerator
     {
         $description = ['/**'];
         if ($property->getDescription()) {
-            $description[] = ' * ' . $property->getDescription();
+            $description[] = ' * ' . str_replace('*/', '*\\/', $property->getDescription());
             $description[] = ' *';
         }
 

--- a/src/Component/JsonSchema/Generator/Model/PropertyGenerator.php
+++ b/src/Component/JsonSchema/Generator/Model/PropertyGenerator.php
@@ -51,7 +51,7 @@ trait PropertyGenerator
 
         $description = ['/**'];
         if ($property->getDescription()) {
-            foreach (array_map(rtrim(...), explode("\n", $property->getDescription())) as $line) {
+            foreach (array_map(fn (string $line): string => str_replace('*/', '*\\/', rtrim($line)), explode("\n", $property->getDescription())) as $line) {
                 $description[] = ' * ' . $line;
             }
             $description[] = ' *';

--- a/src/Component/OpenApi2/Generator/Endpoint/GetConstructorTrait.php
+++ b/src/Component/OpenApi2/Generator/Endpoint/GetConstructorTrait.php
@@ -106,7 +106,7 @@ trait GetConstructorTrait
         $methodParamsDoc = ['/**'];
         if ($operation->getOperation()->getDescription()) {
             foreach (explode("\n", $operation->getOperation()->getDescription()) as $line) {
-                $methodParamsDoc[] = rtrim(' * ' . $line);
+                $methodParamsDoc[] = rtrim(' * ' . str_replace('*/', '*\\/', $line));
             }
         }
         $methodParamsDoc[] = implode("\n", $methodDocumentations);

--- a/src/Component/OpenApi2/Generator/Parameter/BodyParameterGenerator.php
+++ b/src/Component/OpenApi2/Generator/Parameter/BodyParameterGenerator.php
@@ -58,7 +58,7 @@ class BodyParameterGenerator extends ParameterGenerator
             [$class] = $guessedType;
         }
 
-        return rtrim(\sprintf(' * @param %s $%s %s', implode('|', $class), $this->getInflector()->camelize($parameter->getName()), $parameter->getDescription() ?: ''));
+        return rtrim(\sprintf(' * @param %s $%s %s', implode('|', $class), str_replace('*/', '*\\/', $this->getInflector()->camelize($parameter->getName())), str_replace('*/', '*\\/', $parameter->getDescription() ?: '')));
     }
 
     /**

--- a/src/Component/OpenApi2/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi2/Generator/Parameter/NonBodyParameterGenerator.php
@@ -114,7 +114,8 @@ class NonBodyParameterGenerator extends ParameterGenerator
         $type = implode('|', $this->convertParameterType($parameter));
         $description = array_map(rtrim(...), explode("\n", $parameter->getDescription() ?: ''));
 
-        $param = [rtrim(\sprintf(' * @param %s $%s %s', $type, $this->getInflector()->camelize($parameter->getName()), array_shift($description)))];
+        $description = array_map(fn (string $line): string => str_replace('*/', '*\\/', $line), $description);
+        $param = [rtrim(\sprintf(' * @param %s $%s %s', $type, str_replace('*/', '*\\/', $this->getInflector()->camelize($parameter->getName())), array_shift($description)))];
         foreach ($description as $line) {
             $param[] = \sprintf(' * %s', $line);
         }
@@ -127,9 +128,9 @@ class NonBodyParameterGenerator extends ParameterGenerator
         $type = implode('|', $this->convertParameterType($parameter));
         $description = array_map(rtrim(...), explode("\n", $parameter->getDescription() ?: ''));
 
-        $var = [rtrim(\sprintf(' *     @var %s $%s %s', $type, $parameter->getName(), array_shift($description)))];
+        $var = [rtrim(\sprintf(' *     @var %s $%s %s', $type, str_replace('*/', '*\\/', $parameter->getName()), str_replace('*/', '*\\/', array_shift($description))))];
         foreach ($description as $line) {
-            $var[] = \sprintf(' *     %s', $line);
+            $var[] = \sprintf(' *     %s', str_replace('*/', '*\\/', $line));
         }
 
         return implode("\n", $var);

--- a/src/Component/OpenApi3/Generator/Endpoint/GetConstructorTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetConstructorTrait.php
@@ -112,7 +112,7 @@ trait GetConstructorTrait
         $methodParamsDoc = ['/**'];
         if ($operation->getOperation()->getDescription()) {
             foreach (explode("\n", $operation->getOperation()->getDescription()) as $line) {
-                $methodParamsDoc[] = rtrim(' * ' . $line);
+                $methodParamsDoc[] = rtrim(' * ' . str_replace('*/', '*\\/', $line));
             }
         }
         $methodParamsDoc[] = implode("\n", $methodDocumentations);

--- a/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
@@ -145,7 +145,7 @@ class NonBodyParameterGenerator extends ParameterGenerator
             $type = implode('|', $this->convertParameterType($parameter->getSchema()));
         }
 
-        return rtrim(\sprintf(' * @param %s $%s %s', $type, $this->getInflector()->camelize($parameter->getName()), $parameter->getDescription() ?: ''));
+        return rtrim(\sprintf(' * @param %s $%s %s', $type, str_replace('*/', '*\\/', $this->getInflector()->camelize($parameter->getName())), str_replace('*/', '*\\/', $parameter->getDescription() ?: '')));
     }
 
     public function generateOptionDocParameter(Parameter $parameter): string
@@ -156,12 +156,12 @@ class NonBodyParameterGenerator extends ParameterGenerator
             $type = implode('|', $this->convertParameterType($parameter->getSchema()));
         }
 
-        $description = implode("\n", array_map(rtrim(...), explode("\n", $parameter->getDescription() ?: '')));
+        $description = implode("\n", array_map(fn (string $line): string => str_replace('*/', '*\\/', rtrim($line)), explode("\n", $parameter->getDescription() ?: '')));
 
         return rtrim(
             \sprintf(
                 ' *    "%s"%s: %s%s',
-                $parameter->getName(),
+                str_replace('*/', '*\\/', $parameter->getName()),
                 $parameter->getRequired() ? '' : '?',
                 $type,
                 $description !== '' ? ', //' . $description : ','

--- a/src/Component/OpenApi3/Tests/IssuePhpDocInjectionRegressionTest.php
+++ b/src/Component/OpenApi3/Tests/IssuePhpDocInjectionRegressionTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Jane\Component\OpenApiCommon\Console\Command\GenerateCommand;
+use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
+use Jane\Component\OpenApiCommon\Console\Loader\OpenApiMatcher;
+use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class IssuePhpDocInjectionRegressionTest extends TestCase
+{
+    public function testPhpDocInjectionSanitizedInParameterNameAndDescription(): void
+    {
+        $fixtureDirectory = sys_get_temp_dir() . '/jane-openapi3-phpdoc-injection-' . bin2hex(random_bytes(8));
+        $generatedDirectory = $fixtureDirectory . '/generated';
+        mkdir($generatedDirectory, 0777, true);
+
+        $openApiFile = $fixtureDirectory . '/openapi.json';
+        file_put_contents($openApiFile, json_encode([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test',
+                'version' => '1.0.0',
+            ],
+            'servers' => [
+                ['url' => 'https://api.example.com/v1'],
+            ],
+            'paths' => [
+                '/items' => [
+                    'get' => [
+                        'operationId' => 'getItems',
+                        'description' => 'Retrieve items */ public function __construct(){system("id");} /*',
+                        'parameters' => [
+                            [
+                                'name' => '*/ public function __construct(){system("id");} /*',
+                                'in' => 'query',
+                                'required' => true,
+                                'schema' => ['type' => 'string'],
+                                'description' => 'Description containing */ to close docblock',
+                            ],
+                        ],
+                        'responses' => [
+                            '200' => [
+                                'description' => 'OK',
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['type' => 'string'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $configFile = $fixtureDirectory . '/.jane-openapi';
+        file_put_contents($configFile, \sprintf(
+            "<?php\n\nreturn [\n    'openapi-file' => %s,\n    'namespace' => 'Jane\\\\Component\\\\OpenApi3\\\\Tests\\\\PhpDocInjectionExpected',\n    'directory' => %s,\n];\n",
+            var_export($openApiFile, true),
+            var_export($generatedDirectory, true)
+        ));
+
+        try {
+            $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+            $input = new ArrayInput(['--config-file' => $configFile], $command->getDefinition());
+            $command->execute($input, new NullOutput());
+
+            $generatedFiles = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($generatedDirectory, \RecursiveDirectoryIterator::SKIP_DOTS));
+
+            $phpFiles = [];
+            foreach ($generatedFiles as $file) {
+                if ($file->getExtension() === 'php') {
+                    $phpFiles[] = $file->getRealPath();
+                }
+            }
+
+            $this->assertGreaterThan(0, \count($phpFiles), 'No PHP files generated');
+
+            // Endpoint and Client files are the ones that contain user-controlled PHPDoc text
+            $relevantFiles = array_filter($phpFiles, fn (string $path): bool => str_contains($path, '/Endpoint/') || str_contains($path, '/Client.php')
+            );
+
+            $this->assertGreaterThan(0, \count($relevantFiles), 'No relevant endpoint/client files found');
+
+            foreach ($phpFiles as $phpFile) {
+                $content = file_get_contents($phpFile);
+
+                $isRelevant = \in_array($phpFile, $relevantFiles, true);
+
+                if ($isRelevant) {
+                    // Raw */ from injected strings must be sanitized
+                    $this->assertStringNotContainsString(
+                        'Retrieve items */',
+                        $content,
+                        \sprintf('File %s contains raw */ in operation description (unsanitized)', $phpFile)
+                    );
+
+                    $this->assertStringNotContainsString(
+                        '"*/ public function __construct',
+                        $content,
+                        \sprintf('File %s contains raw */ in parameter name (unsanitized)', $phpFile)
+                    );
+                }
+
+                // Lint check — every PHP file must be valid
+                $output = null;
+                $returnCode = null;
+                exec('php -l ' . escapeshellarg($phpFile) . ' 2>&1', $output, $returnCode);
+                $this->assertEquals(0, $returnCode, \sprintf(
+                    'File %s has syntax errors: %s',
+                    $phpFile,
+                    implode("\n", $output)
+                ));
+            }
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $entries = scandir($path);
+        if (false === $entries) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+
+            $entryPath = $path . '/' . $entry;
+            if (is_dir($entryPath)) {
+                $this->removeDirectory($entryPath);
+                continue;
+            }
+
+            unlink($entryPath);
+        }
+
+        rmdir($path);
+    }
+}

--- a/src/Component/OpenApi31/Generator/Endpoint/GetConstructorTrait.php
+++ b/src/Component/OpenApi31/Generator/Endpoint/GetConstructorTrait.php
@@ -117,7 +117,7 @@ trait GetConstructorTrait
         $methodParamsDoc = ['/**'];
         if ($operation->getOperation()->getDescription()) {
             foreach (explode("\n", $operation->getOperation()->getDescription()) as $line) {
-                $methodParamsDoc[] = rtrim(' * ' . $line);
+                $methodParamsDoc[] = rtrim(' * ' . str_replace('*/', '*\\/', $line));
             }
         }
         $methodParamsDoc[] = implode("\n", $methodDocumentations);

--- a/src/Component/OpenApi31/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi31/Generator/Parameter/NonBodyParameterGenerator.php
@@ -145,7 +145,7 @@ class NonBodyParameterGenerator extends ParameterGenerator
             $type = implode('|', $this->convertParameterType($schema));
         }
 
-        return rtrim(\sprintf(' * @param %s $%s %s', $type, $this->getInflector()->camelize($parameter->getName()), $parameter->getDescription() ?: ''));
+        return rtrim(\sprintf(' * @param %s $%s %s', $type, str_replace('*/', '*\\/', $this->getInflector()->camelize($parameter->getName())), str_replace('*/', '*\\/', $parameter->getDescription() ?: '')));
     }
 
     public function generateOptionDocParameter(Parameter $parameter): string
@@ -157,12 +157,12 @@ class NonBodyParameterGenerator extends ParameterGenerator
             $type = implode('|', $this->convertParameterType($schema));
         }
 
-        $description = implode("\n", array_map(rtrim(...), explode("\n", $parameter->getDescription() ?: '')));
+        $description = implode("\n", array_map(fn (string $line): string => str_replace('*/', '*\\/', rtrim($line)), explode("\n", $parameter->getDescription() ?: '')));
 
         return rtrim(
             \sprintf(
                 ' *    "%s"%s: %s%s',
-                $parameter->getName(),
+                str_replace('*/', '*\\/', $parameter->getName()),
                 $parameter->getRequired() ? '' : '?',
                 $type,
                 $description !== '' ? ', //' . $description : ','


### PR DESCRIPTION
## Summary

Fixes 3 security advisories for PHPDoc injection leading to Remote Code Execution (CWE-94, CWE-95, CWE-116). All three share the same root cause and fix.

**Severity:** Critical — CVSS 4.0 9.3

**Affected package:** `jane-php/open-api-3` (and sibling generators)

---

### The vulnerability

Jane generates PHP code through nikic/php-parser (an AST), so string literals are safely escaped. But PHPDoc comment text is emitted RAW.

The generated Client/Endpoint method docblocks embed OpenAPI parameter names, descriptions, and operation descriptions verbatim inside `/** ... */` blocks. A `*/` placed in any of these fields prematurely closes the docblock. Everything after the `*/` lands in class-body position, and because parameter names are raw string keys (not identifier-mangled), the injected PHP survives.

Injecting `*/ public function __construct(){ <code> } /*` in a parameter name or description adds an attacker-controlled `__construct()` to the generated Client class, which runs on instantiation — Remote Code Execution.

### What was fixed

`str_replace('*/', '*\\/', $text)` is now applied at every point where user-controlled text enters a generated PHPDoc comment. The replacement `*\/` cannot close the docblock. This is consistent with the existing sanitization already applied to content-type strings in the same codebase.

The fix covers all user-controlled fields that flow into generated PHPDoc:

- Header parameter names (https://github.com/janephp/janephp/security/advisories/GHSA-x9xr-53qx-9qcf)
- Query parameter names (https://github.com/janephp/janephp/security/advisories/GHSA-q8v2-3j4h-xg2p)
- Parameter descriptions (https://github.com/janephp/janephp/security/advisories/GHSA-xwcw-j52r-34x4)
- Operation descriptions (https://github.com/janephp/janephp/security/advisories/GHSA-xwcw-j52r-34x4)
- Property descriptions in model getter/setter/docblock (additional gap)
- Path parameter names — these went through Doctrine's `camelize()` which does not strip `*` or `/` characters (additional gap)
