### PR TITLE
fix(json-schema): match property class by reference segment, not substring

### DIFF
--- a/src/Component/JsonSchema/Registry/Schema.php
+++ b/src/Component/JsonSchema/Registry/Schema.php
@@ -93,9 +93,10 @@ class Schema implements SchemaInterface
     public function findPropertyClass(string $sourceObject, string $propertyObject): ?array
     {
         $referencePart = \sprintf('%s/properties/%s', $sourceObject, $propertyObject);
+        $referencePartPattern = '#(^|/)' . preg_quote($referencePart, '#') . '($|/)#';
 
         foreach ($this->classes as $class) {
-            if (str_contains($class->getReference(), $referencePart)) {
+            if (preg_match($referencePartPattern, $class->getReference()) === 1) {
                 return [$class, $class->getReference()];
             }
         }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/.jane-openapi
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\Component\OpenApi31\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'validation' => true,
+];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Client.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Expected\Model\Order : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getOrder(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetOrder(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Endpoint/GetOrder.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Endpoint/GetOrder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Endpoint;
+
+class GetOrder extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/order';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Expected\Model\Order
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Expected\Model\Order', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Model/Order.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Model/Order.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model;
+
+class Order
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var OrderProductData
+     */
+    protected $productData;
+    /**
+     * @var OrderProduct
+     */
+    protected $product;
+    /**
+     * @return OrderProductData
+     */
+    public function getProductData(): OrderProductData
+    {
+        return $this->productData;
+    }
+    /**
+     * @param OrderProductData $productData
+     *
+     * @return self
+     */
+    public function setProductData(OrderProductData $productData): self
+    {
+        $this->initialized['productData'] = true;
+        $this->productData = $productData;
+        return $this;
+    }
+    /**
+     * @return OrderProduct
+     */
+    public function getProduct(): OrderProduct
+    {
+        return $this->product;
+    }
+    /**
+     * @param OrderProduct $product
+     *
+     * @return self
+     */
+    public function setProduct(OrderProduct $product): self
+    {
+        $this->initialized['product'] = true;
+        $this->product = $product;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Model/OrderProduct.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Model/OrderProduct.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model;
+
+class OrderProduct
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var int
+     */
+    protected $id;
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+    /**
+     * @param int $id
+     *
+     * @return self
+     */
+    public function setId(int $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Model/OrderProductData.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Model/OrderProductData.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model;
+
+class OrderProductData
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $title;
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+    /**
+     * @param string $title
+     *
+     * @return self
+     */
+    public function setTitle(string $title): self
+    {
+        $this->initialized['title'] = true;
+        $this->title = $title;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi31\Tests\Expected\Model\Order::class => \Jane\Component\OpenApi31\Tests\Expected\Normalizer\OrderNormalizer::class,
+        
+        \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProductData::class => \Jane\Component\OpenApi31\Tests\Expected\Normalizer\OrderProductDataNormalizer::class,
+        
+        \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProduct::class => \Jane\Component\OpenApi31\Tests\Expected\Normalizer\OrderProductNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            
+            \Jane\Component\OpenApi31\Tests\Expected\Model\Order::class => false,
+            \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProductData::class => false,
+            \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProduct::class => false,
+            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+        ];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Normalizer/OrderNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Normalizer/OrderNormalizer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class OrderNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Expected\Model\Order::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Expected\Model\Order::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Expected\Model\Order();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\OrderConstraint());
+        }
+        if (\array_key_exists('product_data', $data)) {
+            $object->setProductData($this->denormalizer->denormalize($data['product_data'], \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProductData::class, 'json', $context));
+        }
+        if (\array_key_exists('product', $data)) {
+            $object->setProduct($this->denormalizer->denormalize($data['product'], \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProduct::class, 'json', $context));
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('productData') && null !== $data->getProductData()) {
+            $dataArray['product_data'] = $this->normalizer->normalize($data->getProductData(), 'json', $context);
+        }
+        if ($data->isInitialized('product') && null !== $data->getProduct()) {
+            $dataArray['product'] = $this->normalizer->normalize($data->getProduct(), 'json', $context);
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($dataArray, new \Jane\Component\OpenApi31\Tests\Expected\Validator\OrderConstraint());
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Expected\Model\Order::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Normalizer/OrderProductDataNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Normalizer/OrderProductDataNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class OrderProductDataNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProductData::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProductData::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProductData();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\OrderProductDataConstraint());
+        }
+        if (\array_key_exists('title', $data)) {
+            $object->setTitle($data['title']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('title') && null !== $data->getTitle()) {
+            $dataArray['title'] = $data->getTitle();
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($dataArray, new \Jane\Component\OpenApi31\Tests\Expected\Validator\OrderProductDataConstraint());
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Expected\Model\OrderProductData::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Normalizer/OrderProductNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Normalizer/OrderProductNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class OrderProductNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProduct::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProduct::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Expected\Model\OrderProduct();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\OrderProductConstraint());
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('id') && null !== $data->getId()) {
+            $dataArray['id'] = $data->getId();
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($dataArray, new \Jane\Component\OpenApi31\Tests\Expected\Validator\OrderProductConstraint());
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Expected\Model\OrderProduct::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(static function ($value) {
+            return $value ?? '';
+        }, $optionsResolved);
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            $allowReservedKey = in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Validator/OrderConstraint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Validator/OrderConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Validator;
+
+class OrderConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.'), new \Symfony\Component\Validator\Constraints\Collection(fields: ['product_data' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.'), new \Jane\Component\OpenApi31\Tests\Expected\Validator\OrderProductDataConstraint()]), 'product' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.'), new \Jane\Component\OpenApi31\Tests\Expected\Validator\OrderProductConstraint()])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Validator/OrderProductConstraint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Validator/OrderProductConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Validator;
+
+class OrderProductConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.'), new \Symfony\Component\Validator\Constraints\Collection(fields: ['id' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\Type(type: ['integer']), new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.')])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Validator/OrderProductDataConstraint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Validator/OrderProductDataConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Validator;
+
+class OrderProductDataConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.'), new \Symfony\Component\Validator\Constraints\Collection(fields: ['title' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\Type(type: ['string']), new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.')])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/openapi.json
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/openapi.json
@@ -1,0 +1,56 @@
+{
+    "openapi": "3.1.2",
+    "info": {
+        "title": "Test",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://api.example.com/v1",
+            "description": "Production server"
+        }
+    ],
+    "paths": {
+        "/order": {
+            "get": {
+                "operationId": "getOrder",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Order"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Order": {
+                "type": "object",
+                "properties": {
+                    "product_data": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "product": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`Registry\Schema::findPropertyClass()` locates the class generated for an inline object property by plain substring search:

```php
$referencePart = \sprintf('%s/properties/%s', $sourceObject, $propertyObject);

foreach ($this->classes as $class) {
    if (str_contains($class->getReference(), $referencePart)) {
        return [$class, $class->getReference()];
    }
}
```

The match is not anchored to reference segment boundaries, so it collides on both ends:

- searching for property `product` also matches the reference of its sibling `product_data` (prefix collision);
- `Order/properties/x` also matches `SubOrder/properties/x` (suffix collision on the source segment).

The first class in parse order wins, so the outcome depends on declaration order in the document. The property then receives the `*Constraint` class of **another** property. Generation succeeds and the code looks plausible — but response validation is wrong (rejects valid bodies or accepts invalid ones), which makes this painful to diagnose.

## Fix

Anchor the match so the reference part must start and end on a segment boundary (string edge or `/`):

```php
$referencePartPattern = '#(^|/)' . preg_quote($referencePart, '#') . '($|/)#';
```

## Reproduction / tests

New fixture `OpenApi31/Tests/fixtures/issue-966`: an `Order` object with `product_data` declared before `product`. Without the fix the generated `OrderConstraint` references `OrderProductDataConstraint` for **both** properties:

```php
'product' => new Optional([new NotNull(...), new OrderProductDataConstraint()])
```

With the fix each property gets its own constraint class (`OrderProductConstraint` / `OrderProductDataConstraint`). No existing fixture output changes — no name-prefix collisions exist in current fixtures.

Full suite, php-cs-fixer and PHPStan pass.

Fixes #966