### PR TITLE
fix(json-schema): always generate the Constraint class so references never dangle

### DIFF
--- a/src/Component/JsonSchema/Generator/ValidatorGenerator.php
+++ b/src/Component/JsonSchema/Generator/ValidatorGenerator.php
@@ -30,97 +30,98 @@ class ValidatorGenerator implements GeneratorInterface
         $namespace = $schema->getNamespace() . '\\Validator';
 
         foreach ($schema->getClasses() as $class) {
-            if ($class->hasValidatorGuesses()) {
-                $className = $this->naming->getConstraintName($class->getName());
-                $collectionItemsConstraints = [];
-                $collectionItems = [];
+            // The Constraint class is always generated, even without any validator guess: normalizers and
+            // parent Compound constraints reference it unconditionally, so skipping it would leave a
+            // reference to a class that does not exist, fataling at runtime.
+            $className = $this->naming->getConstraintName($class->getName());
+            $collectionItemsConstraints = [];
+            $collectionItems = [];
 
-                foreach ($class->getPropertyValidatorGuesses() as $name => $propertyGuesses) {
-                    $constraints = [];
-                    foreach ($propertyGuesses as $propertyGuess) {
-                        $constraints[] = new Expr\ArrayItem($this->generateConstraint($propertyGuess));
-                    }
-
-                    $collectionItemsConstraints[$name] = $constraints;
+            foreach ($class->getPropertyValidatorGuesses() as $name => $propertyGuesses) {
+                $constraints = [];
+                foreach ($propertyGuesses as $propertyGuess) {
+                    $constraints[] = new Expr\ArrayItem($this->generateConstraint($propertyGuess));
                 }
 
-                $optionsVariable = new Expr\Variable('options');
+                $collectionItemsConstraints[$name] = $constraints;
+            }
 
-                $constraintsItems = [];
-                /** @var ValidatorGuess $classGuess */
-                foreach ($class->getValidatorGuesses() as $classGuess) {
-                    if ($classGuess->getSubProperty() === null) {
-                        $constraintsItems[] = new Expr\ArrayItem($this->generateConstraint($classGuess));
-                    } else {
-                        $localNamespace = $namespace;
-                        if (null !== $classGuess->getClassReference()) {
-                            foreach ($registry->getSchemas() as $localSchema) {
-                                if (null !== $localSchema->getClass($classGuess->getClassReference())) {
-                                    $localNamespace = $localSchema->getNamespace() . '\\Validator';
-                                }
+            $optionsVariable = new Expr\Variable('options');
+
+            $constraintsItems = [];
+            /** @var ValidatorGuess $classGuess */
+            foreach ($class->getValidatorGuesses() as $classGuess) {
+                if ($classGuess->getSubProperty() === null) {
+                    $constraintsItems[] = new Expr\ArrayItem($this->generateConstraint($classGuess));
+                } else {
+                    $localNamespace = $namespace;
+                    if (null !== $classGuess->getClassReference()) {
+                        foreach ($registry->getSchemas() as $localSchema) {
+                            if (null !== $localSchema->getClass($classGuess->getClassReference())) {
+                                $localNamespace = $localSchema->getNamespace() . '\\Validator';
                             }
                         }
-
-                        $classGuess->setConstraintClass(\sprintf('%s\%s', $localNamespace, $classGuess->getConstraintClass()));
-
-                        if (!\array_key_exists($classGuess->getSubProperty(), $collectionItemsConstraints)) {
-                            $collectionItemsConstraints[$classGuess->getSubProperty()] = [$this->generateConstraint($classGuess)];
-                        } else {
-                            $collectionItemsConstraints[$classGuess->getSubProperty()] = array_merge($collectionItemsConstraints[$classGuess->getSubProperty()], [$this->generateConstraint($classGuess)]);
-                        }
                     }
-                }
 
-                foreach ($collectionItemsConstraints as $name => $constraints) {
-                    $collectionClass = $class->isRequired($name) ? Required::class : Optional::class;
-                    $collectionItems[] = new Expr\ArrayItem(new Expr\New_(new Node\Name\FullyQualified($collectionClass), [
-                        new Node\Arg(new Expr\Array_($constraints)),
-                    ]), new Scalar\String_($name));
-                }
+                    $classGuess->setConstraintClass(\sprintf('%s\%s', $localNamespace, $classGuess->getConstraintClass()));
 
-                if (\count($collectionItems) > 0) {
-                    $allowExtraFields = $class->getObject()->getAdditionalProperties();
-                    if (null === $allowExtraFields || $allowExtraFields) {
-                        $allowExtraFields = 'true';
+                    if (!\array_key_exists($classGuess->getSubProperty(), $collectionItemsConstraints)) {
+                        $collectionItemsConstraints[$classGuess->getSubProperty()] = [$this->generateConstraint($classGuess)];
                     } else {
-                        $allowExtraFields = 'false';
+                        $collectionItemsConstraints[$classGuess->getSubProperty()] = array_merge($collectionItemsConstraints[$classGuess->getSubProperty()], [$this->generateConstraint($classGuess)]);
                     }
+                }
+            }
 
-                    $constraintsItems[] = new Expr\ArrayItem(new Expr\New_(new Node\Name\FullyQualified(Collection::class), [
-                        new Node\Arg(
-                            new Expr\Array_($collectionItems),
-                            name: new Node\Identifier('fields'),
-                        ),
-                        new Node\Arg(
-                            new Expr\ConstFetch(new Node\Name($allowExtraFields)),
-                            name: new Node\Identifier('allowExtraFields'),
-                        ),
-                    ]));
+            foreach ($collectionItemsConstraints as $name => $constraints) {
+                $collectionClass = $class->isRequired($name) ? Required::class : Optional::class;
+                $collectionItems[] = new Expr\ArrayItem(new Expr\New_(new Node\Name\FullyQualified($collectionClass), [
+                    new Node\Arg(new Expr\Array_($constraints)),
+                ]), new Scalar\String_($name));
+            }
+
+            if (\count($collectionItems) > 0) {
+                $allowExtraFields = $class->getObject()->getAdditionalProperties();
+                if (null === $allowExtraFields || $allowExtraFields) {
+                    $allowExtraFields = 'true';
+                } else {
+                    $allowExtraFields = 'false';
                 }
 
-                $class = new Node\Stmt\Class_(
-                    $className,
-                    [
-                        'stmts' => [
-                            new Node\Stmt\ClassMethod(
-                                'getConstraints',
-                                [
-                                    'flags' => Modifiers::PROTECTED,
-                                    'params' => [new Node\Param($optionsVariable)],
-                                    'stmts' => [
-                                        new Node\Stmt\Return_(new Expr\Array_($constraintsItems)),
-                                    ],
-                                    'returnType' => new Node\Identifier('array'),
-                                ]
-                            ),
-                        ],
-                        'extends' => new Node\Name('\\Symfony\\Component\\Validator\\Constraints\\Compound'),
-                    ]
-                );
-
-                $namespaceStmt = new Node\Stmt\Namespace_(new Node\Name($namespace), [$class]);
-                $schema->addFile(new File($schema->getDirectory() . '/Validator/' . $className . '.php', $namespaceStmt, self::FILE_TYPE_VALIDATOR));
+                $constraintsItems[] = new Expr\ArrayItem(new Expr\New_(new Node\Name\FullyQualified(Collection::class), [
+                    new Node\Arg(
+                        new Expr\Array_($collectionItems),
+                        name: new Node\Identifier('fields'),
+                    ),
+                    new Node\Arg(
+                        new Expr\ConstFetch(new Node\Name($allowExtraFields)),
+                        name: new Node\Identifier('allowExtraFields'),
+                    ),
+                ]));
             }
+
+            $class = new Node\Stmt\Class_(
+                $className,
+                [
+                    'stmts' => [
+                        new Node\Stmt\ClassMethod(
+                            'getConstraints',
+                            [
+                                'flags' => Modifiers::PROTECTED,
+                                'params' => [new Node\Param($optionsVariable)],
+                                'stmts' => [
+                                    new Node\Stmt\Return_(new Expr\Array_($constraintsItems)),
+                                ],
+                                'returnType' => new Node\Identifier('array'),
+                            ]
+                        ),
+                    ],
+                    'extends' => new Node\Name('\\Symfony\\Component\\Validator\\Constraints\\Compound'),
+                ]
+            );
+
+            $namespaceStmt = new Node\Stmt\Namespace_(new Node\Name($namespace), [$class]);
+            $schema->addFile(new File($schema->getDirectory() . '/Validator/' . $className . '.php', $namespaceStmt, self::FILE_TYPE_VALIDATOR));
         }
     }
 

--- a/src/Component/JsonSchema/Tests/ConstraintReferencesTest.php
+++ b/src/Component/JsonSchema/Tests/ConstraintReferencesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
+
+class ConstraintReferencesTest extends TestCase
+{
+    /**
+     * Generated code instantiates `new \Ns\Validator\FooConstraint()` from normalizers and from parent
+     * Compound constraints. Every constraint class referenced this way must have been generated too,
+     * otherwise the generated client fatals at runtime.
+     *
+     * @dataProvider expectedDirectoryProvider
+     */
+    public function testNoDanglingConstraintReference(string $expectedDirectory): void
+    {
+        $finder = new Finder();
+        $finder->files()->in($expectedDirectory)->name('*.php');
+
+        $generated = [];
+        $referenced = [];
+
+        foreach ($finder as $file) {
+            if (str_contains(strtr($file->getPathname(), '\\', '/'), '/Validator/')) {
+                $generated[$file->getBasename('.php')] = true;
+            }
+
+            if (preg_match_all('#new \\\\[A-Za-z0-9_\\\\]+\\\\Validator\\\\([A-Za-z0-9_]+Constraint)\(#', $file->getContents(), $matches)) {
+                foreach ($matches[1] as $constraintName) {
+                    $referenced[$constraintName][] = $file->getRelativePathname();
+                }
+            }
+        }
+
+        foreach ($referenced as $constraintName => $files) {
+            $this->assertArrayHasKey(
+                $constraintName,
+                $generated,
+                \sprintf('%s is instantiated in [%s] but no %s.php was generated', $constraintName, implode(', ', array_unique($files)), $constraintName)
+            );
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function expectedDirectoryProvider(): iterable
+    {
+        $finder = new Finder();
+        $finder->directories()->in(__DIR__ . '/../../*/Tests/fixtures')->depth('== 1')->name('expected');
+
+        foreach ($finder as $directory) {
+            $fixture = basename(\dirname($directory->getPathname()));
+            $component = basename(\dirname($directory->getPathname(), 4));
+
+            yield $component . '/' . $fixture => [$directory->getPathname()];
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/ContainerSummaryNetworkSettingsConstraint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/ContainerSummaryNetworkSettingsConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Docker\Api\Validator;
+
+class ContainerSummaryNetworkSettingsConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\Collection(fields: ['Networks' => new \Symfony\Component\Validator\Constraints\Optional([])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/GenericResourcesItemConstraint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/GenericResourcesItemConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Docker\Api\Validator;
+
+class GenericResourcesItemConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\Collection(fields: ['NamedResourceSpec' => new \Symfony\Component\Validator\Constraints\Optional([]), 'DiscreteResourceSpec' => new \Symfony\Component\Validator\Constraints\Optional([])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/NetworkingConfigConstraint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/NetworkingConfigConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Docker\Api\Validator;
+
+class NetworkingConfigConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\Collection(fields: ['EndpointsConfig' => new \Symfony\Component\Validator\Constraints\Optional([])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/ServiceSpecModeConstraint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/ServiceSpecModeConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Docker\Api\Validator;
+
+class ServiceSpecModeConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\Collection(fields: ['Replicated' => new \Symfony\Component\Validator\Constraints\Optional([]), 'Global' => new \Symfony\Component\Validator\Constraints\Optional([]), 'ReplicatedJob' => new \Symfony\Component\Validator\Constraints\Optional([]), 'GlobalJob' => new \Symfony\Component\Validator\Constraints\Optional([])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/SwarmSpecTaskDefaultsConstraint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/SwarmSpecTaskDefaultsConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Docker\Api\Validator;
+
+class SwarmSpecTaskDefaultsConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\Collection(fields: ['LogDriver' => new \Symfony\Component\Validator\Constraints\Optional([])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/TaskSpecContainerSpecPrivilegesConstraint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/TaskSpecContainerSpecPrivilegesConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Docker\Api\Validator;
+
+class TaskSpecContainerSpecPrivilegesConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\Collection(fields: ['CredentialSpec' => new \Symfony\Component\Validator\Constraints\Optional([]), 'SELinuxContext' => new \Symfony\Component\Validator\Constraints\Optional([])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/TaskSpecPlacementPreferencesItemConstraint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/TaskSpecPlacementPreferencesItemConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Docker\Api\Validator;
+
+class TaskSpecPlacementPreferencesItemConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\Collection(fields: ['Spread' => new \Symfony\Component\Validator\Constraints\Optional([])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/TaskSpecResourcesConstraint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Validator/TaskSpecResourcesConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Docker\Api\Validator;
+
+class TaskSpecResourcesConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\Collection(fields: ['Limits' => new \Symfony\Component\Validator\Constraints\Optional([]), 'Reservation' => new \Symfony\Component\Validator\Constraints\Optional([])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/.jane-openapi
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\Component\OpenApi31\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'validation' => true,
+];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Client.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Expected\Model\Report : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getReport(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetReport(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Endpoint/GetReport.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Endpoint/GetReport.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Endpoint;
+
+class GetReport extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/report';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Expected\Model\Report
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Expected\Model\Report', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Model/Report.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Model/Report.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model;
+
+class Report
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var ReportPeriod|null
+     */
+    protected $period;
+    /**
+     * @return ReportPeriod|null
+     */
+    public function getPeriod(): ?ReportPeriod
+    {
+        return $this->period;
+    }
+    /**
+     * @param ReportPeriod|null $period
+     *
+     * @return self
+     */
+    public function setPeriod(?ReportPeriod $period): self
+    {
+        $this->initialized['period'] = true;
+        $this->period = $period;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Model/ReportPeriod.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Model/ReportPeriod.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model;
+
+class ReportPeriod
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string|null
+     */
+    protected $from;
+    /**
+     * @return string|null
+     */
+    public function getFrom(): ?string
+    {
+        return $this->from;
+    }
+    /**
+     * @param string|null $from
+     *
+     * @return self
+     */
+    public function setFrom(?string $from): self
+    {
+        $this->initialized['from'] = true;
+        $this->from = $from;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi31\Tests\Expected\Model\Report::class => \Jane\Component\OpenApi31\Tests\Expected\Normalizer\ReportNormalizer::class,
+        
+        \Jane\Component\OpenApi31\Tests\Expected\Model\ReportPeriod::class => \Jane\Component\OpenApi31\Tests\Expected\Normalizer\ReportPeriodNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            
+            \Jane\Component\OpenApi31\Tests\Expected\Model\Report::class => false,
+            \Jane\Component\OpenApi31\Tests\Expected\Model\ReportPeriod::class => false,
+            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+        ];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Normalizer/ReportNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Normalizer/ReportNormalizer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReportNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Expected\Model\Report::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Expected\Model\Report::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Expected\Model\Report();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\ReportConstraint());
+        }
+        if (\array_key_exists('period', $data) && $data['period'] !== null) {
+            $object->setPeriod($this->denormalizer->denormalize($data['period'], \Jane\Component\OpenApi31\Tests\Expected\Model\ReportPeriod::class, 'json', $context));
+        }
+        elseif (\array_key_exists('period', $data) && $data['period'] === null) {
+            $object->setPeriod(null);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('period')) {
+            $dataArray['period'] = $this->normalizer->normalize($data->getPeriod(), 'json', $context);
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($dataArray, new \Jane\Component\OpenApi31\Tests\Expected\Validator\ReportConstraint());
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Expected\Model\Report::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Normalizer/ReportPeriodNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Normalizer/ReportPeriodNormalizer.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReportPeriodNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Expected\Model\ReportPeriod::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Expected\Model\ReportPeriod::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Expected\Model\ReportPeriod();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\ReportPeriodConstraint());
+        }
+        if (\array_key_exists('from', $data) && $data['from'] !== null) {
+            $value = $data['from'];
+            if (is_string($data['from'])) {
+                $value = $data['from'];
+            } elseif (is_null($data['from'])) {
+                $value = $data['from'];
+            }
+            $object->setFrom($value);
+        }
+        elseif (\array_key_exists('from', $data) && $data['from'] === null) {
+            $object->setFrom(null);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('from')) {
+            $value = $data->getFrom();
+            if (is_string($data->getFrom())) {
+                $value = $data->getFrom();
+            } elseif (is_null($data->getFrom())) {
+                $value = $data->getFrom();
+            }
+            $dataArray['from'] = $value;
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($dataArray, new \Jane\Component\OpenApi31\Tests\Expected\Validator\ReportPeriodConstraint());
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Expected\Model\ReportPeriod::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(static function ($value) {
+            return $value ?? '';
+        }, $optionsResolved);
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            $allowReservedKey = in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Validator/ReportConstraint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Validator/ReportConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Validator;
+
+class ReportConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\Collection(fields: ['period' => new \Symfony\Component\Validator\Constraints\Optional([new \Jane\Component\OpenApi31\Tests\Expected\Validator\ReportPeriodConstraint()])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Validator/ReportPeriodConstraint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Validator/ReportPeriodConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Validator;
+
+class ReportPeriodConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\Collection(fields: ['from' => new \Symfony\Component\Validator\Constraints\Optional([])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/openapi.json
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/openapi.json
@@ -1,0 +1,48 @@
+{
+    "openapi": "3.1.2",
+    "info": {
+        "title": "Test",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://api.example.com/v1",
+            "description": "Production server"
+        }
+    ],
+    "paths": {
+        "/report": {
+            "get": {
+                "operationId": "getReport",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Report"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Report": {
+                "type": ["object", "null"],
+                "properties": {
+                    "period": {
+                        "type": ["object", "null"],
+                        "properties": {
+                            "from": {
+                                "type": ["string", "null"]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The `*Constraint` class is generated **conditionally**, while references to it are emitted **unconditionally**:

- `ValidatorGenerator` only writes the class when `$class->hasValidatorGuesses()` is true:
  ```php
  foreach ($schema->getClasses() as $class) {
      if ($class->hasValidatorGuesses()) {
          $className = $this->naming->getConstraintName($class->getName());
  ```
- `NormalizerGenerator` / `DenormalizerGenerator` always emit the validate call when validation is enabled:
  ```php
  $constraintFqdn = $schema->getNamespace() . '\\Validator\\' . $this->naming->getConstraintName($classGuess->getName());
  // ... new Arg(new Expr\New_(new Name('\\' . $constraintFqdn))),
  ```
- `SubObjectValidator` additionally makes a **parent** Compound instantiate the child's constraint class, also without checking it will exist.

A class ends up with no validator guesses when it is nullable (no `NotNull`), its properties are nullable objects (`TypeValidator` bails out on `object`), and nothing else applies. The generated `new \Ns\Validator\FooConstraint()` then fatals — **not at generation time, but at runtime on the first call**: generation passes green and static analysis usually excludes generated code.

## Evidence in this repository

The committed `docker-api` fixture already shipped **8 dangling references**, e.g. `expected/Validator/ContainerSummaryConstraint.php` instantiates `ContainerSummaryNetworkSettingsConstraint` and `expected/Normalizer/NetworkingConfigNormalizer.php` instantiates `NetworkingConfigConstraint` — neither file existed under `expected/Validator/`.

## Fix

Drop the `hasValidatorGuesses()` gate in `ValidatorGenerator` — the Constraint class is now always generated. Fixing only the normalizer side would not cover the parent-Compound reference path, so generating the class unconditionally is the only variant that restores the invariant in every case. A class without guesses still yields a meaningful Compound: it checks the field structure via `Collection(fields: [...])`.

No existing fixture file changes — the regeneration only **adds** the 8 previously missing docker-api constraint files.

## Tests

- New fixture `OpenApi31/Tests/fixtures/issue-968` reproducing the minimal case (nullable object with a nullable-object property): before the fix the generated code instantiates `ReportPeriodConstraint` while only `ReportConstraint.php` is written.
- New guard test `ConstraintReferencesTest` scans every fixture's expected output (143 directories across all components), collects every `new \...\Validator\*Constraint(` instantiation and asserts the class file exists — it fails on the current `next` (docker-api) and catches the whole regression class, not just this instance.

Full suite, php-cs-fixer and PHPStan pass.

Fixes #968