### PR TITLE
feat(json-schema): allow registering additional validators via configuration

### DIFF
--- a/src/Component/JsonSchema/Console/Loader/ConfigLoader.php
+++ b/src/Component/JsonSchema/Console/Loader/ConfigLoader.php
@@ -76,6 +76,7 @@ class ConfigLoader implements ConfigLoaderInterface
             'skip-required-fields' => false,
             'custom-string-format-mapping' => [],
             'validation' => false,
+            'validators' => [],
             'include-null-value' => true,
             'allow-external-refs' => false,
             'external-ref-allowed-hosts' => [],

--- a/src/Component/JsonSchema/Console/Loader/SchemaLoader.php
+++ b/src/Component/JsonSchema/Console/Loader/SchemaLoader.php
@@ -42,6 +42,7 @@ class SchemaLoader implements SchemaLoaderInterface
             'skip-required-fields',
             'custom-string-format-mapping',
             'validation',
+            'validators',
             'include-null-value',
             'allow-external-refs',
             'external-ref-allowed-hosts',

--- a/src/Component/JsonSchema/Guesser/Validator/ChainValidatorFactory.php
+++ b/src/Component/JsonSchema/Guesser/Validator/ChainValidatorFactory.php
@@ -8,6 +8,19 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class ChainValidatorFactory
 {
+    /** @var list<ValidatorInterface> */
+    private static array $customValidators = [];
+
+    public static function addValidator(ValidatorInterface $validator): void
+    {
+        self::$customValidators[] = $validator;
+    }
+
+    public static function resetCustomValidators(): void
+    {
+        self::$customValidators = [];
+    }
+
     public static function create(Naming $naming, Registry $registry, DenormalizerInterface $denormalizer): ValidatorInterface
     {
         $chainValidator = new ChainValidator();
@@ -36,6 +49,12 @@ class ChainValidatorFactory
         $chainValidator->addValidator(new Format\IPv4Validator());
         $chainValidator->addValidator(new Format\IPv6Validator());
         $chainValidator->addValidator(new Format\UuidValidator());
+
+        // Custom validators emit their constraints before the generic Type/NotNull fallbacks below
+        foreach (self::$customValidators as $validator) {
+            $chainValidator->addValidator($validator);
+        }
+
         // Others
         $chainValidator->addValidator(new Any\TypeValidator());
         $chainValidator->addValidator(new Any\EnumValidator());

--- a/src/Component/JsonSchema/Jane.php
+++ b/src/Component/JsonSchema/Jane.php
@@ -92,6 +92,11 @@ class Jane extends ChainGenerator
             Reference::setAllowedExternalHosts($options['external-ref-allowed-hosts']);
         }
 
+        ChainValidatorFactory::resetCustomValidators();
+        foreach ($options['validators'] ?? [] as $validator) {
+            ChainValidatorFactory::addValidator($validator);
+        }
+
         $serializer = self::buildSerializer();
         $chainGuesser = JsonSchemaGuesserFactory::create($serializer, $options);
         $naming = new Naming();

--- a/src/Component/JsonSchema/Tests/fixtures/custom-validators/.jane
+++ b/src/Component/JsonSchema/Tests/fixtures/custom-validators/.jane
@@ -1,0 +1,30 @@
+<?php
+
+use Jane\Component\JsonSchema\Guesser\Validator\ValidatorGuess;
+use Jane\Component\JsonSchema\Guesser\Validator\ValidatorInterface;
+use Jane\Component\JsonSchema\JsonSchema\Model\JsonSchema;
+use Symfony\Component\Validator\Constraints\Regex;
+
+return [
+    'json-schema-file' => __DIR__ . '/schema.json',
+    'root-class' => 'Price',
+    'namespace' => 'Jane\JsonSchema\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'validation' => true,
+    'validators' => [
+        new class implements ValidatorInterface {
+            public function supports($object): bool
+            {
+                return $object instanceof JsonSchema && 'decimal-two' === $object->getFormat();
+            }
+
+            public function guess($object, string $name, $guess): void
+            {
+                $guess->addValidatorGuess(new ValidatorGuess(Regex::class, [
+                    'pattern' => '#^\d+\.\d{2}$#',
+                    'message' => 'This value is not a valid decimal with two fraction digits.',
+                ]));
+            }
+        },
+    ],
+];

--- a/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Model/Price.php
+++ b/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Model/Price.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Model;
+
+class Price
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $amount;
+    /**
+     * @var string
+     */
+    protected $comment;
+    /**
+     * @return string
+     */
+    public function getAmount(): string
+    {
+        return $this->amount;
+    }
+    /**
+     * @param string $amount
+     *
+     * @return self
+     */
+    public function setAmount(string $amount): self
+    {
+        $this->initialized['amount'] = true;
+        $this->amount = $amount;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getComment(): string
+    {
+        return $this->comment;
+    }
+    /**
+     * @param string $comment
+     *
+     * @return self
+     */
+    public function setComment(string $comment): self
+    {
+        $this->initialized['comment'] = true;
+        $this->comment = $comment;
+        return $this;
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\JsonSchema\Tests\Expected\Model\Price::class => \Jane\JsonSchema\Tests\Expected\Normalizer\PriceNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            
+            \Jane\JsonSchema\Tests\Expected\Model\Price::class => false,
+            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+        ];
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Normalizer/PriceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Normalizer/PriceNormalizer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\JsonSchema\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class PriceNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\JsonSchema\Tests\Expected\Model\Price::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof \Jane\JsonSchema\Tests\Expected\Model\Price;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\JsonSchema\Tests\Expected\Model\Price();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($data, new \Jane\JsonSchema\Tests\Expected\Validator\PriceConstraint());
+        }
+        if (\array_key_exists('amount', $data)) {
+            $object->setAmount($data['amount']);
+        }
+        if (\array_key_exists('comment', $data)) {
+            $object->setComment($data['comment']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('amount') && null !== $data->getAmount()) {
+            $dataArray['amount'] = $data->getAmount();
+        }
+        if ($data->isInitialized('comment') && null !== $data->getComment()) {
+            $dataArray['comment'] = $data->getComment();
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($dataArray, new \Jane\JsonSchema\Tests\Expected\Validator\PriceConstraint());
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\JsonSchema\Tests\Expected\Model\Price::class => false];
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Validator/PriceConstraint.php
+++ b/src/Component/JsonSchema/Tests/fixtures/custom-validators/expected/Validator/PriceConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\JsonSchema\Tests\Expected\Validator;
+
+class PriceConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.'), new \Symfony\Component\Validator\Constraints\Collection(fields: ['amount' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\Regex(pattern: '#^\d+\.\d{2}$#', message: 'This value is not a valid decimal with two fraction digits.'), new \Symfony\Component\Validator\Constraints\Type(type: ['string']), new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.')]), 'comment' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\Type(type: ['string']), new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.')])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/custom-validators/schema.json
+++ b/src/Component/JsonSchema/Tests/fixtures/custom-validators/schema.json
@@ -1,0 +1,12 @@
+{
+    "type": "object",
+    "properties": {
+        "amount": {
+            "type": "string",
+            "format": "decimal-two"
+        },
+        "comment": {
+            "type": "string"
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/.jane-openapi
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/.jane-openapi
@@ -1,0 +1,67 @@
+<?php
+
+use Jane\Component\JsonSchema\Guesser\Validator\ValidatorGuess;
+use Jane\Component\JsonSchema\Guesser\Validator\ValidatorInterface;
+use Jane\Component\JsonSchema\JsonSchema\Model\JsonSchema;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\LessThanOrEqual;
+use Symfony\Component\Validator\Constraints\Regex;
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\Component\OpenApi31\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'validation' => true,
+    'validators' => [
+        // A format validator: a custom string format gets a Regex constraint.
+        new class implements ValidatorInterface {
+            public function supports($object): bool
+            {
+                return $object instanceof JsonSchema && 'decimal-two' === $object->getFormat();
+            }
+
+            public function guess($object, string $name, $guess): void
+            {
+                $guess->addValidatorGuess(new ValidatorGuess(Regex::class, [
+                    'pattern' => '#^\d+\.\d{2}$#',
+                    'message' => 'This value is not a valid decimal with two fraction digits.',
+                ]));
+            }
+        },
+        // A validator with constructor dependencies: the allowed values are injected, which is why
+        // the option takes ValidatorInterface instances and not class names.
+        new class(['EUR', 'USD', 'GBP']) implements ValidatorInterface {
+            public function __construct(
+                private readonly array $allowedCodes,
+            ) {
+            }
+
+            public function supports($object): bool
+            {
+                return $object instanceof JsonSchema && 'currency-code' === $object->getFormat();
+            }
+
+            public function guess($object, string $name, $guess): void
+            {
+                $guess->addValidatorGuess(new ValidatorGuess(Choice::class, [
+                    'choices' => $this->allowedCodes,
+                    'message' => 'This value is not a supported currency code.',
+                ]));
+            }
+        },
+        // A validator emitting several constraints from one guess: a numeric format becomes a range.
+        new class implements ValidatorInterface {
+            public function supports($object): bool
+            {
+                return $object instanceof JsonSchema && 'percentage' === $object->getFormat();
+            }
+
+            public function guess($object, string $name, $guess): void
+            {
+                $guess->addValidatorGuess(new ValidatorGuess(GreaterThanOrEqual::class, ['value' => 0.0]));
+                $guess->addValidatorGuess(new ValidatorGuess(LessThanOrEqual::class, ['value' => 100.0]));
+            }
+        },
+    ],
+];

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Client.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Expected\Model\Price : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getPrice(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetPrice(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Endpoint/GetPrice.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Endpoint/GetPrice.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Endpoint;
+
+class GetPrice extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/price';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Expected\Model\Price
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Expected\Model\Price', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Model/Price.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Model/Price.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model;
+
+class Price
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $amount;
+    /**
+     * @var string
+     */
+    protected $currency;
+    /**
+     * @var float
+     */
+    protected $discount;
+    /**
+     * @var string
+     */
+    protected $comment;
+    /**
+     * @return string
+     */
+    public function getAmount(): string
+    {
+        return $this->amount;
+    }
+    /**
+     * @param string $amount
+     *
+     * @return self
+     */
+    public function setAmount(string $amount): self
+    {
+        $this->initialized['amount'] = true;
+        $this->amount = $amount;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+    /**
+     * @param string $currency
+     *
+     * @return self
+     */
+    public function setCurrency(string $currency): self
+    {
+        $this->initialized['currency'] = true;
+        $this->currency = $currency;
+        return $this;
+    }
+    /**
+     * @return float
+     */
+    public function getDiscount(): float
+    {
+        return $this->discount;
+    }
+    /**
+     * @param float $discount
+     *
+     * @return self
+     */
+    public function setDiscount(float $discount): self
+    {
+        $this->initialized['discount'] = true;
+        $this->discount = $discount;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getComment(): string
+    {
+        return $this->comment;
+    }
+    /**
+     * @param string $comment
+     *
+     * @return self
+     */
+    public function setComment(string $comment): self
+    {
+        $this->initialized['comment'] = true;
+        $this->comment = $comment;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi31\Tests\Expected\Model\Price::class => \Jane\Component\OpenApi31\Tests\Expected\Normalizer\PriceNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            
+            \Jane\Component\OpenApi31\Tests\Expected\Model\Price::class => false,
+            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+        ];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Normalizer/PriceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Normalizer/PriceNormalizer.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class PriceNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Expected\Model\Price::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Expected\Model\Price::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Expected\Model\Price();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('discount', $data) && \is_int($data['discount'])) {
+            $data['discount'] = (double) $data['discount'];
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\PriceConstraint());
+        }
+        if (\array_key_exists('amount', $data)) {
+            $object->setAmount($data['amount']);
+        }
+        if (\array_key_exists('currency', $data)) {
+            $object->setCurrency($data['currency']);
+        }
+        if (\array_key_exists('discount', $data)) {
+            $object->setDiscount($data['discount']);
+        }
+        if (\array_key_exists('comment', $data)) {
+            $object->setComment($data['comment']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('amount') && null !== $data->getAmount()) {
+            $dataArray['amount'] = $data->getAmount();
+        }
+        if ($data->isInitialized('currency') && null !== $data->getCurrency()) {
+            $dataArray['currency'] = $data->getCurrency();
+        }
+        if ($data->isInitialized('discount') && null !== $data->getDiscount()) {
+            $dataArray['discount'] = $data->getDiscount();
+        }
+        if ($data->isInitialized('comment') && null !== $data->getComment()) {
+            $dataArray['comment'] = $data->getComment();
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($dataArray, new \Jane\Component\OpenApi31\Tests\Expected\Validator\PriceConstraint());
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Expected\Model\Price::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(static function ($value) {
+            return $value ?? '';
+        }, $optionsResolved);
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            $allowReservedKey = in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Validator/PriceConstraint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Validator/PriceConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Validator;
+
+class PriceConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.'), new \Symfony\Component\Validator\Constraints\Collection(fields: ['amount' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\Regex(pattern: '#^\d+\.\d{2}$#', message: 'This value is not a valid decimal with two fraction digits.'), new \Symfony\Component\Validator\Constraints\Type(type: ['string']), new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.')]), 'currency' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\Choice(choices: ['EUR', 'USD', 'GBP'], message: 'This value is not a supported currency code.'), new \Symfony\Component\Validator\Constraints\Type(type: ['string']), new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.')]), 'discount' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\GreaterThanOrEqual(value: 0.0), new \Symfony\Component\Validator\Constraints\LessThanOrEqual(value: 100.0), new \Symfony\Component\Validator\Constraints\Type(type: ['float']), new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.')]), 'comment' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\Type(type: ['string']), new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.')])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/openapi.json
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/openapi.json
@@ -1,0 +1,55 @@
+{
+    "openapi": "3.1.2",
+    "info": {
+        "title": "Test",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://api.example.com/v1",
+            "description": "Production server"
+        }
+    ],
+    "paths": {
+        "/price": {
+            "get": {
+                "operationId": "getPrice",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Price"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Price": {
+                "type": "object",
+                "properties": {
+                    "amount": {
+                        "type": "string",
+                        "format": "decimal-two"
+                    },
+                    "currency": {
+                        "type": "string",
+                        "format": "currency-code"
+                    },
+                    "discount": {
+                        "type": "number",
+                        "format": "percentage"
+                    },
+                    "comment": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Component/OpenApiCommon/Console/Loader/SchemaLoader.php
+++ b/src/Component/OpenApiCommon/Console/Loader/SchemaLoader.php
@@ -31,6 +31,7 @@ class SchemaLoader extends BaseSchemaLoader implements SchemaLoaderInterface
             'skip-null-values',
             'skip-required-fields',
             'validation',
+            'validators',
             'version',
             'whitelisted-paths',
             'endpoint-generator',

--- a/src/Component/OpenApiCommon/JaneOpenApi.php
+++ b/src/Component/OpenApiCommon/JaneOpenApi.php
@@ -163,6 +163,11 @@ abstract class JaneOpenApi extends ChainGenerator
             Reference::setAllowedExternalHosts($options['external-ref-allowed-hosts']);
         }
 
+        ChainValidatorFactory::resetCustomValidators();
+        foreach ($options['validators'] ?? [] as $validator) {
+            ChainValidatorFactory::addValidator($validator);
+        }
+
         $instance = static::create($options);
 
         /** @var DenormalizerInterface $denormalizer */


### PR DESCRIPTION
## Problem

JSON Schema allows arbitrary `format` values, but the validator list is hardcoded in the body of `ChainValidatorFactory::create()`. A schema using a format outside that list gets no constraint at all when `validation: true`, and there is no registration point to add one — no config option, no event, nothing. The only options today are leaving such fields unvalidated or patching vendor code.

## Solution

A new `validators` config option holding a list of `ValidatorInterface` instances:

```php
// .jane-openapi
'validators' => [
    new App\Codegen\DecimalTwoValidator(),
    new App\Codegen\CurrencyCodeValidator(['EUR', 'USD', 'GBP']),
],
```

They are registered on `ChainValidatorFactory` by `Jane::build()` / `JaneOpenApi::build()` — the same pattern the `Reference` configuration (`allow-external-refs`) already uses in those exact methods — so every place a chain is created (`Jane`, `JaneOpenApi`, `ObjectGuesser`) picks them up without a single signature change.

Custom validators sit next to the built-in `Format` block, before the generic `Type`/`NotNull` fallbacks: every supporting validator in the chain contributes its constraints, and this position makes custom constraints appear in the generated code exactly the way built-in format constraints do (`[Regex, Type, NotNull]`), which also drives the violation order at runtime.

The option takes instances rather than class names because validators legitimately have constructor dependencies (`ItemsValidator` takes the chain, `SubObjectValidator` takes the denormalizer, a project validator may need an allowed-values list).

## Backwards compatibility

The option defaults to an empty list — nothing changes for existing configs. `ChainValidatorFactory::create()` keeps its signature; the two new static methods (`addValidator`, `resetCustomValidators`) are additive.

## Tests

New fixture `OpenApi31/Tests/fixtures/custom-validators` with three validators declared in `.jane-openapi`:

- `"format": "decimal-two"` → `Regex(pattern: '#^\\d+\\.\\d{2}$#')` — plain format validator;
- `"format": "currency-code"` → `Choice(choices: ['EUR', 'USD', 'GBP'])` — validator with constructor-injected dependencies;
- `"format": "percentage"` → `GreaterThanOrEqual(0) + LessThanOrEqual(100)` — one guess emitting several constraints;
- a property without a custom format keeps its usual `[Type, NotNull]` output as the control case.

A second fixture `JsonSchema/Tests/fixtures/custom-validators` covers the plain JsonSchema entry point (`Jane::build()`), which is wired separately from the shared OpenApi one.

Full suite, php-cs-fixer and PHPStan pass.

Fixes #970
