### PR TITLE
fix(json-schema): emit (float) cast instead of deprecated (double)

### DIFF
--- a/src/Component/JsonSchema/Generator/Normalizer/DenormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/Normalizer/DenormalizerGenerator.php
@@ -119,7 +119,7 @@ trait DenormalizerGenerator
             $arrayElement = new Expr\ArrayDimFetch($dataVariable, new Scalar\String_($property->getName()));
             $intCondition = new Expr\FuncCall(new Name('\is_int'), [$arrayElement]);
             $condition = new Expr\BinaryOp\BooleanAnd($baseCondition, $intCondition);
-            $castFloat = new Stmt\Expression(new Expr\Assign($arrayElement, new Expr\Cast\Double($arrayElement)));
+            $castFloat = new Stmt\Expression(new Expr\Assign($arrayElement, new Expr\Cast\Double($arrayElement, ['kind' => Expr\Cast\Double::KIND_FLOAT])));
             $statements[] = new Stmt\If_($condition, ['stmts' => [$castFloat]]);
         }
         foreach ($classGuess->getProperties() as $property) {

--- a/src/Component/JsonSchema/JsonSchema/Normalizer/JsonSchemaNormalizer.php
+++ b/src/Component/JsonSchema/JsonSchema/Normalizer/JsonSchemaNormalizer.php
@@ -38,19 +38,19 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('multipleOf', $data) && \is_int($data['multipleOf'])) {
-            $data['multipleOf'] = (double) $data['multipleOf'];
+            $data['multipleOf'] = (float) $data['multipleOf'];
         }
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('exclusiveMaximum', $data) && \is_int($data['exclusiveMaximum'])) {
-            $data['exclusiveMaximum'] = (double) $data['exclusiveMaximum'];
+            $data['exclusiveMaximum'] = (float) $data['exclusiveMaximum'];
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (\array_key_exists('exclusiveMinimum', $data) && \is_int($data['exclusiveMinimum'])) {
-            $data['exclusiveMinimum'] = (double) $data['exclusiveMinimum'];
+            $data['exclusiveMinimum'] = (float) $data['exclusiveMinimum'];
         }
         if (\array_key_exists('uniqueItems', $data) && \is_int($data['uniqueItems'])) {
             $data['uniqueItems'] = (bool) $data['uniqueItems'];

--- a/src/Component/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/test-default/expected/Normalizer/TestNormalizer.php
@@ -38,7 +38,7 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('float', $data) && \is_int($data['float'])) {
-            $data['float'] = (double) $data['float'];
+            $data['float'] = (float) $data['float'];
         }
         if (\array_key_exists('bool', $data) && \is_int($data['bool'])) {
             $data['bool'] = (bool) $data['bool'];

--- a/src/Component/OpenApi2/JsonSchema/Normalizer/FormDataParameterSubSchemaNormalizer.php
+++ b/src/Component/OpenApi2/JsonSchema/Normalizer/FormDataParameterSubSchemaNormalizer.php
@@ -39,13 +39,13 @@ class FormDataParameterSubSchemaNormalizer implements DenormalizerInterface, Nor
         }
         $object = new \Jane\Component\OpenApi2\JsonSchema\Model\FormDataParameterSubSchema();
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (\array_key_exists('multipleOf', $data) && \is_int($data['multipleOf'])) {
-            $data['multipleOf'] = (double) $data['multipleOf'];
+            $data['multipleOf'] = (float) $data['multipleOf'];
         }
         if (null === $data || false === \is_array($data)) {
             return $object;

--- a/src/Component/OpenApi2/JsonSchema/Normalizer/HeaderNormalizer.php
+++ b/src/Component/OpenApi2/JsonSchema/Normalizer/HeaderNormalizer.php
@@ -39,13 +39,13 @@ class HeaderNormalizer implements DenormalizerInterface, NormalizerInterface, De
         }
         $object = new \Jane\Component\OpenApi2\JsonSchema\Model\Header();
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (\array_key_exists('multipleOf', $data) && \is_int($data['multipleOf'])) {
-            $data['multipleOf'] = (double) $data['multipleOf'];
+            $data['multipleOf'] = (float) $data['multipleOf'];
         }
         if (null === $data || false === \is_array($data)) {
             return $object;

--- a/src/Component/OpenApi2/JsonSchema/Normalizer/HeaderParameterSubSchemaNormalizer.php
+++ b/src/Component/OpenApi2/JsonSchema/Normalizer/HeaderParameterSubSchemaNormalizer.php
@@ -39,13 +39,13 @@ class HeaderParameterSubSchemaNormalizer implements DenormalizerInterface, Norma
         }
         $object = new \Jane\Component\OpenApi2\JsonSchema\Model\HeaderParameterSubSchema();
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (\array_key_exists('multipleOf', $data) && \is_int($data['multipleOf'])) {
-            $data['multipleOf'] = (double) $data['multipleOf'];
+            $data['multipleOf'] = (float) $data['multipleOf'];
         }
         if (null === $data || false === \is_array($data)) {
             return $object;

--- a/src/Component/OpenApi2/JsonSchema/Normalizer/PathParameterSubSchemaNormalizer.php
+++ b/src/Component/OpenApi2/JsonSchema/Normalizer/PathParameterSubSchemaNormalizer.php
@@ -39,13 +39,13 @@ class PathParameterSubSchemaNormalizer implements DenormalizerInterface, Normali
         }
         $object = new \Jane\Component\OpenApi2\JsonSchema\Model\PathParameterSubSchema();
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (\array_key_exists('multipleOf', $data) && \is_int($data['multipleOf'])) {
-            $data['multipleOf'] = (double) $data['multipleOf'];
+            $data['multipleOf'] = (float) $data['multipleOf'];
         }
         if (null === $data || false === \is_array($data)) {
             return $object;

--- a/src/Component/OpenApi2/JsonSchema/Normalizer/PrimitivesItemsNormalizer.php
+++ b/src/Component/OpenApi2/JsonSchema/Normalizer/PrimitivesItemsNormalizer.php
@@ -39,13 +39,13 @@ class PrimitivesItemsNormalizer implements DenormalizerInterface, NormalizerInte
         }
         $object = new \Jane\Component\OpenApi2\JsonSchema\Model\PrimitivesItems();
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (\array_key_exists('multipleOf', $data) && \is_int($data['multipleOf'])) {
-            $data['multipleOf'] = (double) $data['multipleOf'];
+            $data['multipleOf'] = (float) $data['multipleOf'];
         }
         if (null === $data || false === \is_array($data)) {
             return $object;

--- a/src/Component/OpenApi2/JsonSchema/Normalizer/QueryParameterSubSchemaNormalizer.php
+++ b/src/Component/OpenApi2/JsonSchema/Normalizer/QueryParameterSubSchemaNormalizer.php
@@ -39,13 +39,13 @@ class QueryParameterSubSchemaNormalizer implements DenormalizerInterface, Normal
         }
         $object = new \Jane\Component\OpenApi2\JsonSchema\Model\QueryParameterSubSchema();
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (\array_key_exists('multipleOf', $data) && \is_int($data['multipleOf'])) {
-            $data['multipleOf'] = (double) $data['multipleOf'];
+            $data['multipleOf'] = (float) $data['multipleOf'];
         }
         if (null === $data || false === \is_array($data)) {
             return $object;

--- a/src/Component/OpenApi2/JsonSchema/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi2/JsonSchema/Normalizer/SchemaNormalizer.php
@@ -39,13 +39,13 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
         }
         $object = new \Jane\Component\OpenApi2\JsonSchema\Model\Schema();
         if (\array_key_exists('multipleOf', $data) && \is_int($data['multipleOf'])) {
-            $data['multipleOf'] = (double) $data['multipleOf'];
+            $data['multipleOf'] = (float) $data['multipleOf'];
         }
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (null === $data || false === \is_array($data)) {
             return $object;

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
@@ -38,7 +38,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
-            $data['floatProperty'] = (double) $data['floatProperty'];
+            $data['floatProperty'] = (float) $data['floatProperty'];
         }
         if (\array_key_exists('stringProperty', $data)) {
             $object->setStringProperty($data['stringProperty']);

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
@@ -38,7 +38,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
-            $data['floatProperty'] = (double) $data['floatProperty'];
+            $data['floatProperty'] = (float) $data['floatProperty'];
         }
         if (\array_key_exists('stringProperty', $data)) {
             $object->setStringProperty($data['stringProperty']);

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Normalizer/ServiceSpecRollbackConfigNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Normalizer/ServiceSpecRollbackConfigNormalizer.php
@@ -38,7 +38,7 @@ class ServiceSpecRollbackConfigNormalizer implements DenormalizerInterface, Norm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('MaxFailureRatio', $data) && \is_int($data['MaxFailureRatio'])) {
-            $data['MaxFailureRatio'] = (double) $data['MaxFailureRatio'];
+            $data['MaxFailureRatio'] = (float) $data['MaxFailureRatio'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Docker\Api\Validator\ServiceSpecRollbackConfigConstraint());

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Normalizer/ServiceSpecUpdateConfigNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Normalizer/ServiceSpecUpdateConfigNormalizer.php
@@ -38,7 +38,7 @@ class ServiceSpecUpdateConfigNormalizer implements DenormalizerInterface, Normal
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('MaxFailureRatio', $data) && \is_int($data['MaxFailureRatio'])) {
-            $data['MaxFailureRatio'] = (double) $data['MaxFailureRatio'];
+            $data['MaxFailureRatio'] = (float) $data['MaxFailureRatio'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Docker\Api\Validator\ServiceSpecUpdateConfigConstraint());

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/AdministrationBackupFileNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/AdministrationBackupFileNormalizer.php
@@ -38,7 +38,7 @@ class AdministrationBackupFileNormalizer implements DenormalizerInterface, Norma
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('createdOn', $data) && \is_int($data['createdOn'])) {
-            $data['createdOn'] = (double) $data['createdOn'];
+            $data['createdOn'] = (float) $data['createdOn'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/AdministrationClusterBackupSummaryNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/AdministrationClusterBackupSummaryNormalizer.php
@@ -38,7 +38,7 @@ class AdministrationClusterBackupSummaryNormalizer implements DenormalizerInterf
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('filesize', $data) && \is_int($data['filesize'])) {
-            $data['filesize'] = (double) $data['filesize'];
+            $data['filesize'] = (float) $data['filesize'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApApConfigurationNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApApConfigurationNormalizer.php
@@ -38,10 +38,10 @@ class ApApConfigurationNormalizer implements DenormalizerInterface, NormalizerIn
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('directedMulticastFromWiredClientEnabled', $data) && \is_int($data['directedMulticastFromWiredClientEnabled'])) {
             $data['directedMulticastFromWiredClientEnabled'] = (bool) $data['directedMulticastFromWiredClientEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApApLinemanSummaryListItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApApLinemanSummaryListItemNormalizer.php
@@ -38,10 +38,10 @@ class ApApLinemanSummaryListItemNormalizer implements DenormalizerInterface, Nor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('mac', $data)) {
             $object->setMac($data['mac']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApApOperationalSummaryNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApApOperationalSummaryNormalizer.php
@@ -38,10 +38,10 @@ class ApApOperationalSummaryNormalizer implements DenormalizerInterface, Normali
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('isCriticalAP', $data) && \is_int($data['isCriticalAP'])) {
             $data['isCriticalAP'] = (bool) $data['isCriticalAP'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApCreateAPNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApCreateAPNormalizer.php
@@ -38,10 +38,10 @@ class ApCreateAPNormalizer implements DenormalizerInterface, NormalizerInterface
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('testSpeedEnabled', $data) && \is_int($data['testSpeedEnabled'])) {
             $data['testSpeedEnabled'] = (bool) $data['testSpeedEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApModifyAPNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApModifyAPNormalizer.php
@@ -38,10 +38,10 @@ class ApModifyAPNormalizer implements DenormalizerInterface, NormalizerInterface
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('directedMulticastFromWiredClientEnabled', $data) && \is_int($data['directedMulticastFromWiredClientEnabled'])) {
             $data['directedMulticastFromWiredClientEnabled'] = (bool) $data['directedMulticastFromWiredClientEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryCreateApQueryIndoorMapXyNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryCreateApQueryIndoorMapXyNormalizer.php
@@ -38,10 +38,10 @@ class ApQueryCreateApQueryIndoorMapXyNormalizer implements DenormalizerInterface
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('x', $data) && \is_int($data['x'])) {
-            $data['x'] = (double) $data['x'];
+            $data['x'] = (float) $data['x'];
         }
         if (\array_key_exists('y', $data) && \is_int($data['y'])) {
-            $data['y'] = (double) $data['y'];
+            $data['y'] = (float) $data['y'];
         }
         if (\array_key_exists('x', $data)) {
             $object->setX($data['x']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryCreateApQueryNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApQueryCreateApQueryNormalizer.php
@@ -38,7 +38,7 @@ class ApQueryCreateApQueryNormalizer implements DenormalizerInterface, Normalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('connectionFailure', $data) && \is_int($data['connectionFailure'])) {
-            $data['connectionFailure'] = (double) $data['connectionFailure'];
+            $data['connectionFailure'] = (float) $data['connectionFailure'];
         }
         if (\array_key_exists('configOverride', $data) && \is_int($data['configOverride'])) {
             $data['configOverride'] = (bool) $data['configOverride'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApgroupApGroupConfigurationNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApgroupApGroupConfigurationNormalizer.php
@@ -38,10 +38,10 @@ class ApgroupApGroupConfigurationNormalizer implements DenormalizerInterface, No
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('directedMulticastFromWiredClientEnabled', $data) && \is_int($data['directedMulticastFromWiredClientEnabled'])) {
             $data['directedMulticastFromWiredClientEnabled'] = (bool) $data['directedMulticastFromWiredClientEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApgroupCreateAPGroupNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApgroupCreateAPGroupNormalizer.php
@@ -38,10 +38,10 @@ class ApgroupCreateAPGroupNormalizer implements DenormalizerInterface, Normalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('directedMulticastFromWiredClientEnabled', $data) && \is_int($data['directedMulticastFromWiredClientEnabled'])) {
             $data['directedMulticastFromWiredClientEnabled'] = (bool) $data['directedMulticastFromWiredClientEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApgroupModifyAPGroupNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ApgroupModifyAPGroupNormalizer.php
@@ -38,10 +38,10 @@ class ApgroupModifyAPGroupNormalizer implements DenormalizerInterface, Normalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('directedMulticastFromWiredClientEnabled', $data) && \is_int($data['directedMulticastFromWiredClientEnabled'])) {
             $data['directedMulticastFromWiredClientEnabled'] = (bool) $data['directedMulticastFromWiredClientEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/AprulesGpsCoordinatesNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/AprulesGpsCoordinatesNormalizer.php
@@ -38,13 +38,13 @@ class AprulesGpsCoordinatesNormalizer implements DenormalizerInterface, Normaliz
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('distance', $data) && \is_int($data['distance'])) {
-            $data['distance'] = (double) $data['distance'];
+            $data['distance'] = (float) $data['distance'];
         }
         if (\array_key_exists('latitude', $data)) {
             $object->setLatitude($data['latitude']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ClusterbladeUploadPatchInfoNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ClusterbladeUploadPatchInfoNormalizer.php
@@ -38,7 +38,7 @@ class ClusterbladeUploadPatchInfoNormalizer implements DenormalizerInterface, No
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('fileSize', $data) && \is_int($data['fileSize'])) {
-            $data['fileSize'] = (double) $data['fileSize'];
+            $data['fileSize'] = (float) $data['fileSize'];
         }
         if (\array_key_exists('fileName', $data)) {
             $object->setFileName($data['fileName']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/CommonClientAdmissionControlNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/CommonClientAdmissionControlNormalizer.php
@@ -38,7 +38,7 @@ class CommonClientAdmissionControlNormalizer implements DenormalizerInterface, N
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('minClientThroughputMbps', $data) && \is_int($data['minClientThroughputMbps'])) {
-            $data['minClientThroughputMbps'] = (double) $data['minClientThroughputMbps'];
+            $data['minClientThroughputMbps'] = (float) $data['minClientThroughputMbps'];
         }
         if (\array_key_exists('maxRadioLoadPercent', $data)) {
             $object->setMaxRadioLoadPercent($data['maxRadioLoadPercent']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/CommonOverrideClientAdmissionControlNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/CommonOverrideClientAdmissionControlNormalizer.php
@@ -38,7 +38,7 @@ class CommonOverrideClientAdmissionControlNormalizer implements DenormalizerInte
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('minClientThroughputMbps', $data) && \is_int($data['minClientThroughputMbps'])) {
-            $data['minClientThroughputMbps'] = (double) $data['minClientThroughputMbps'];
+            $data['minClientThroughputMbps'] = (float) $data['minClientThroughputMbps'];
         }
         if (\array_key_exists('enabled', $data) && \is_int($data['enabled'])) {
             $data['enabled'] = (bool) $data['enabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/DevicePolicyDevicePolicyRuleNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/DevicePolicyDevicePolicyRuleNormalizer.php
@@ -38,10 +38,10 @@ class DevicePolicyDevicePolicyRuleNormalizer implements DenormalizerInterface, N
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('uplink', $data) && \is_int($data['uplink'])) {
-            $data['uplink'] = (double) $data['uplink'];
+            $data['uplink'] = (float) $data['uplink'];
         }
         if (\array_key_exists('downlink', $data) && \is_int($data['downlink'])) {
-            $data['downlink'] = (double) $data['downlink'];
+            $data['downlink'] = (float) $data['downlink'];
         }
         if (\array_key_exists('description', $data)) {
             $object->setDescription($data['description']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/DomainDevicePolicyDomainDevicePolicyRuleNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/DomainDevicePolicyDomainDevicePolicyRuleNormalizer.php
@@ -38,10 +38,10 @@ class DomainDevicePolicyDomainDevicePolicyRuleNormalizer implements Denormalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('uplink', $data) && \is_int($data['uplink'])) {
-            $data['uplink'] = (double) $data['uplink'];
+            $data['uplink'] = (float) $data['uplink'];
         }
         if (\array_key_exists('downlink', $data) && \is_int($data['downlink'])) {
-            $data['downlink'] = (double) $data['downlink'];
+            $data['downlink'] = (float) $data['downlink'];
         }
         if (\array_key_exists('description', $data)) {
             $object->setDescription($data['description']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/DpskDpskInfoItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/DpskDpskInfoItemNormalizer.php
@@ -38,7 +38,7 @@ class DpskDpskInfoItemNormalizer implements DenormalizerInterface, NormalizerInt
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('creationDateTime', $data) && \is_int($data['creationDateTime'])) {
-            $data['creationDateTime'] = (double) $data['creationDateTime'];
+            $data['creationDateTime'] = (float) $data['creationDateTime'];
         }
         if (\array_key_exists('groupDpsk', $data) && \is_int($data['groupDpsk'])) {
             $data['groupDpsk'] = (bool) $data['groupDpsk'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/DpskDpskQueryListListItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/DpskDpskQueryListListItemNormalizer.php
@@ -38,16 +38,16 @@ class DpskDpskQueryListListItemNormalizer implements DenormalizerInterface, Norm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('ttl', $data) && \is_int($data['ttl'])) {
-            $data['ttl'] = (double) $data['ttl'];
+            $data['ttl'] = (float) $data['ttl'];
         }
         if (\array_key_exists('expirationStartTime', $data) && \is_int($data['expirationStartTime'])) {
-            $data['expirationStartTime'] = (double) $data['expirationStartTime'];
+            $data['expirationStartTime'] = (float) $data['expirationStartTime'];
         }
         if (\array_key_exists('expirationTime', $data) && \is_int($data['expirationTime'])) {
-            $data['expirationTime'] = (double) $data['expirationTime'];
+            $data['expirationTime'] = (float) $data['expirationTime'];
         }
         if (\array_key_exists('createDateTime', $data) && \is_int($data['createDateTime'])) {
-            $data['createDateTime'] = (double) $data['createDateTime'];
+            $data['createDateTime'] = (float) $data['createDateTime'];
         }
         if (\array_key_exists('group', $data) && \is_int($data['group'])) {
             $data['group'] = (bool) $data['group'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaOptionsGuestPassExpirationNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaOptionsGuestPassExpirationNormalizer.php
@@ -38,13 +38,13 @@ class IdentityQueryCriteriaOptionsGuestPassExpirationNormalizer implements Denor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('start', $data) && \is_int($data['start'])) {
-            $data['start'] = (double) $data['start'];
+            $data['start'] = (float) $data['start'];
         }
         if (\array_key_exists('end', $data) && \is_int($data['end'])) {
-            $data['end'] = (double) $data['end'];
+            $data['end'] = (float) $data['end'];
         }
         if (\array_key_exists('interval', $data) && \is_int($data['interval'])) {
-            $data['interval'] = (double) $data['interval'];
+            $data['interval'] = (float) $data['interval'];
         }
         if (\array_key_exists('start', $data)) {
             $object->setStart($data['start']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaOptionsLocalUserAuditTimeNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IdentityQueryCriteriaOptionsLocalUserAuditTimeNormalizer.php
@@ -38,13 +38,13 @@ class IdentityQueryCriteriaOptionsLocalUserAuditTimeNormalizer implements Denorm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('start', $data) && \is_int($data['start'])) {
-            $data['start'] = (double) $data['start'];
+            $data['start'] = (float) $data['start'];
         }
         if (\array_key_exists('end', $data) && \is_int($data['end'])) {
-            $data['end'] = (double) $data['end'];
+            $data['end'] = (float) $data['end'];
         }
         if (\array_key_exists('interval', $data) && \is_int($data['interval'])) {
-            $data['interval'] = (double) $data['interval'];
+            $data['interval'] = (float) $data['interval'];
         }
         if (\array_key_exists('start', $data)) {
             $object->setStart($data['start']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IndoorMapBasicIndoorMapNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IndoorMapBasicIndoorMapNormalizer.php
@@ -38,10 +38,10 @@ class IndoorMapBasicIndoorMapNormalizer implements DenormalizerInterface, Normal
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IndoorMapIndoorMapNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IndoorMapIndoorMapNormalizer.php
@@ -38,10 +38,10 @@ class IndoorMapIndoorMapNormalizer implements DenormalizerInterface, NormalizerI
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IndoorMapIndoorMapSummaryNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IndoorMapIndoorMapSummaryNormalizer.php
@@ -38,13 +38,13 @@ class IndoorMapIndoorMapSummaryNormalizer implements DenormalizerInterface, Norm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('apCount', $data) && \is_int($data['apCount'])) {
-            $data['apCount'] = (double) $data['apCount'];
+            $data['apCount'] = (float) $data['apCount'];
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IndoorMapIndoorMapXyNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IndoorMapIndoorMapXyNormalizer.php
@@ -38,10 +38,10 @@ class IndoorMapIndoorMapXyNormalizer implements DenormalizerInterface, Normalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('x', $data) && \is_int($data['x'])) {
-            $data['x'] = (double) $data['x'];
+            $data['x'] = (float) $data['x'];
         }
         if (\array_key_exists('y', $data) && \is_int($data['y'])) {
-            $data['y'] = (double) $data['y'];
+            $data['y'] = (float) $data['y'];
         }
         if (\array_key_exists('x', $data)) {
             $object->setX($data['x']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IndoorMapScaleNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/IndoorMapScaleNormalizer.php
@@ -38,7 +38,7 @@ class IndoorMapScaleNormalizer implements DenormalizerInterface, NormalizerInter
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('distance', $data) && \is_int($data['distance'])) {
-            $data['distance'] = (double) $data['distance'];
+            $data['distance'] = (float) $data['distance'];
         }
         if (\array_key_exists('a', $data)) {
             $object->setA($this->denormalizer->denormalize($data['a'], \Jane\Component\OpenApi3\Tests\Expected\Model\IndoorMapIndoorMapXy::class, 'json', $context));

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/PortalserviceConnectionCapabilityNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/PortalserviceConnectionCapabilityNormalizer.php
@@ -38,10 +38,10 @@ class PortalserviceConnectionCapabilityNormalizer implements DenormalizerInterfa
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('protocolNumber', $data) && \is_int($data['protocolNumber'])) {
-            $data['protocolNumber'] = (double) $data['protocolNumber'];
+            $data['protocolNumber'] = (float) $data['protocolNumber'];
         }
         if (\array_key_exists('portNumber', $data) && \is_int($data['portNumber'])) {
-            $data['portNumber'] = (double) $data['portNumber'];
+            $data['portNumber'] = (float) $data['portNumber'];
         }
         if (\array_key_exists('protocolName', $data)) {
             $object->setProtocolName($data['protocolName']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/PortalserviceCreateHotspot20VenueProfileNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/PortalserviceCreateHotspot20VenueProfileNormalizer.php
@@ -38,10 +38,10 @@ class PortalserviceCreateHotspot20VenueProfileNormalizer implements Denormalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('downlinkSpeedInKbps', $data) && \is_int($data['downlinkSpeedInKbps'])) {
-            $data['downlinkSpeedInKbps'] = (double) $data['downlinkSpeedInKbps'];
+            $data['downlinkSpeedInKbps'] = (float) $data['downlinkSpeedInKbps'];
         }
         if (\array_key_exists('uplinkSpeedInKbps', $data) && \is_int($data['uplinkSpeedInKbps'])) {
-            $data['uplinkSpeedInKbps'] = (double) $data['uplinkSpeedInKbps'];
+            $data['uplinkSpeedInKbps'] = (float) $data['uplinkSpeedInKbps'];
         }
         if (\array_key_exists('name', $data)) {
             $object->setName($data['name']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/PortalserviceDefaultConnectionCapabilityNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/PortalserviceDefaultConnectionCapabilityNormalizer.php
@@ -38,10 +38,10 @@ class PortalserviceDefaultConnectionCapabilityNormalizer implements Denormalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('protocolNumber', $data) && \is_int($data['protocolNumber'])) {
-            $data['protocolNumber'] = (double) $data['protocolNumber'];
+            $data['protocolNumber'] = (float) $data['protocolNumber'];
         }
         if (\array_key_exists('portNumber', $data) && \is_int($data['portNumber'])) {
-            $data['portNumber'] = (double) $data['portNumber'];
+            $data['portNumber'] = (float) $data['portNumber'];
         }
         if (\array_key_exists('protocolName', $data)) {
             $object->setProtocolName($data['protocolName']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/PortalserviceHotspot20VeuneProfileNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/PortalserviceHotspot20VeuneProfileNormalizer.php
@@ -38,10 +38,10 @@ class PortalserviceHotspot20VeuneProfileNormalizer implements DenormalizerInterf
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('downlinkSpeedInKbps', $data) && \is_int($data['downlinkSpeedInKbps'])) {
-            $data['downlinkSpeedInKbps'] = (double) $data['downlinkSpeedInKbps'];
+            $data['downlinkSpeedInKbps'] = (float) $data['downlinkSpeedInKbps'];
         }
         if (\array_key_exists('uplinkSpeedInKbps', $data) && \is_int($data['uplinkSpeedInKbps'])) {
-            $data['uplinkSpeedInKbps'] = (double) $data['uplinkSpeedInKbps'];
+            $data['uplinkSpeedInKbps'] = (float) $data['uplinkSpeedInKbps'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/PortalserviceModifyHotspot20VenueProfileNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/PortalserviceModifyHotspot20VenueProfileNormalizer.php
@@ -38,10 +38,10 @@ class PortalserviceModifyHotspot20VenueProfileNormalizer implements Denormalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('downlinkSpeedInKbps', $data) && \is_int($data['downlinkSpeedInKbps'])) {
-            $data['downlinkSpeedInKbps'] = (double) $data['downlinkSpeedInKbps'];
+            $data['downlinkSpeedInKbps'] = (float) $data['downlinkSpeedInKbps'];
         }
         if (\array_key_exists('uplinkSpeedInKbps', $data) && \is_int($data['uplinkSpeedInKbps'])) {
-            $data['uplinkSpeedInKbps'] = (double) $data['uplinkSpeedInKbps'];
+            $data['uplinkSpeedInKbps'] = (float) $data['uplinkSpeedInKbps'];
         }
         if (\array_key_exists('name', $data)) {
             $object->setName($data['name']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileAdvancedOptionContentNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileAdvancedOptionContentNormalizer.php
@@ -38,28 +38,28 @@ class ProfileAdvancedOptionContentNormalizer implements DenormalizerInterface, N
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('dhcpOpt43Subcode', $data) && \is_int($data['dhcpOpt43Subcode'])) {
-            $data['dhcpOpt43Subcode'] = (double) $data['dhcpOpt43Subcode'];
+            $data['dhcpOpt43Subcode'] = (float) $data['dhcpOpt43Subcode'];
         }
         if (\array_key_exists('retryLimit', $data) && \is_int($data['retryLimit'])) {
-            $data['retryLimit'] = (double) $data['retryLimit'];
+            $data['retryLimit'] = (float) $data['retryLimit'];
         }
         if (\array_key_exists('replayWindow', $data) && \is_int($data['replayWindow'])) {
-            $data['replayWindow'] = (double) $data['replayWindow'];
+            $data['replayWindow'] = (float) $data['replayWindow'];
         }
         if (\array_key_exists('dpdDelay', $data) && \is_int($data['dpdDelay'])) {
-            $data['dpdDelay'] = (double) $data['dpdDelay'];
+            $data['dpdDelay'] = (float) $data['dpdDelay'];
         }
         if (\array_key_exists('keepAliveIntval', $data) && \is_int($data['keepAliveIntval'])) {
-            $data['keepAliveIntval'] = (double) $data['keepAliveIntval'];
+            $data['keepAliveIntval'] = (float) $data['keepAliveIntval'];
         }
         if (\array_key_exists('failoverRetryPeriod', $data) && \is_int($data['failoverRetryPeriod'])) {
-            $data['failoverRetryPeriod'] = (double) $data['failoverRetryPeriod'];
+            $data['failoverRetryPeriod'] = (float) $data['failoverRetryPeriod'];
         }
         if (\array_key_exists('failoverRetryInterval', $data) && \is_int($data['failoverRetryInterval'])) {
-            $data['failoverRetryInterval'] = (double) $data['failoverRetryInterval'];
+            $data['failoverRetryInterval'] = (float) $data['failoverRetryInterval'];
         }
         if (\array_key_exists('failoverPrimaryCheckInterval', $data) && \is_int($data['failoverPrimaryCheckInterval'])) {
-            $data['failoverPrimaryCheckInterval'] = (double) $data['failoverPrimaryCheckInterval'];
+            $data['failoverPrimaryCheckInterval'] = (float) $data['failoverPrimaryCheckInterval'];
         }
         if (\array_key_exists('dhcpOpt43Subcode', $data)) {
             $object->setDhcpOpt43Subcode($data['dhcpOpt43Subcode']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileCmProtocolOptionContentNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileCmProtocolOptionContentNormalizer.php
@@ -38,10 +38,10 @@ class ProfileCmProtocolOptionContentNormalizer implements DenormalizerInterface,
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('cmpDhcpOpt43Subcode', $data) && \is_int($data['cmpDhcpOpt43Subcode'])) {
-            $data['cmpDhcpOpt43Subcode'] = (double) $data['cmpDhcpOpt43Subcode'];
+            $data['cmpDhcpOpt43Subcode'] = (float) $data['cmpDhcpOpt43Subcode'];
         }
         if (\array_key_exists('cmpDhcpOpt43SubcodeRecipient', $data) && \is_int($data['cmpDhcpOpt43SubcodeRecipient'])) {
-            $data['cmpDhcpOpt43SubcodeRecipient'] = (double) $data['cmpDhcpOpt43SubcodeRecipient'];
+            $data['cmpDhcpOpt43SubcodeRecipient'] = (float) $data['cmpDhcpOpt43SubcodeRecipient'];
         }
         if (\array_key_exists('cmpDhcpOpt43Subcode', $data)) {
             $object->setCmpDhcpOpt43Subcode($data['cmpDhcpOpt43Subcode']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileCreateFirewallProfileNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileCreateFirewallProfileNormalizer.php
@@ -38,10 +38,10 @@ class ProfileCreateFirewallProfileNormalizer implements DenormalizerInterface, N
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('uplinkRateLimitingMbps', $data) && \is_int($data['uplinkRateLimitingMbps'])) {
-            $data['uplinkRateLimitingMbps'] = (double) $data['uplinkRateLimitingMbps'];
+            $data['uplinkRateLimitingMbps'] = (float) $data['uplinkRateLimitingMbps'];
         }
         if (\array_key_exists('downlinkRateLimitingMbps', $data) && \is_int($data['downlinkRateLimitingMbps'])) {
-            $data['downlinkRateLimitingMbps'] = (double) $data['downlinkRateLimitingMbps'];
+            $data['downlinkRateLimitingMbps'] = (float) $data['downlinkRateLimitingMbps'];
         }
         if (\array_key_exists('name', $data)) {
             $object->setName($data['name']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileCreateIpsecProfileNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileCreateIpsecProfileNormalizer.php
@@ -38,10 +38,10 @@ class ProfileCreateIpsecProfileNormalizer implements DenormalizerInterface, Norm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('ikeRekeyTime', $data) && \is_int($data['ikeRekeyTime'])) {
-            $data['ikeRekeyTime'] = (double) $data['ikeRekeyTime'];
+            $data['ikeRekeyTime'] = (float) $data['ikeRekeyTime'];
         }
         if (\array_key_exists('espRekeyTime', $data) && \is_int($data['espRekeyTime'])) {
-            $data['espRekeyTime'] = (double) $data['espRekeyTime'];
+            $data['espRekeyTime'] = (float) $data['espRekeyTime'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileFirewallProfileNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileFirewallProfileNormalizer.php
@@ -38,10 +38,10 @@ class ProfileFirewallProfileNormalizer implements DenormalizerInterface, Normali
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('uplinkRateLimitingMbps', $data) && \is_int($data['uplinkRateLimitingMbps'])) {
-            $data['uplinkRateLimitingMbps'] = (double) $data['uplinkRateLimitingMbps'];
+            $data['uplinkRateLimitingMbps'] = (float) $data['uplinkRateLimitingMbps'];
         }
         if (\array_key_exists('downlinkRateLimitingMbps', $data) && \is_int($data['downlinkRateLimitingMbps'])) {
-            $data['downlinkRateLimitingMbps'] = (double) $data['downlinkRateLimitingMbps'];
+            $data['downlinkRateLimitingMbps'] = (float) $data['downlinkRateLimitingMbps'];
         }
         if (\array_key_exists('factoryDefault', $data) && \is_int($data['factoryDefault'])) {
             $data['factoryDefault'] = (bool) $data['factoryDefault'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileIpAclRulesNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileIpAclRulesNormalizer.php
@@ -38,10 +38,10 @@ class ProfileIpAclRulesNormalizer implements DenormalizerInterface, NormalizerIn
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('uplinkRateLimitingMbps', $data) && \is_int($data['uplinkRateLimitingMbps'])) {
-            $data['uplinkRateLimitingMbps'] = (double) $data['uplinkRateLimitingMbps'];
+            $data['uplinkRateLimitingMbps'] = (float) $data['uplinkRateLimitingMbps'];
         }
         if (\array_key_exists('downlinkRateLimitingMbps', $data) && \is_int($data['downlinkRateLimitingMbps'])) {
-            $data['downlinkRateLimitingMbps'] = (double) $data['downlinkRateLimitingMbps'];
+            $data['downlinkRateLimitingMbps'] = (float) $data['downlinkRateLimitingMbps'];
         }
         if (\array_key_exists('uplinkRateLimitingEnabled', $data) && \is_int($data['uplinkRateLimitingEnabled'])) {
             $data['uplinkRateLimitingEnabled'] = (bool) $data['uplinkRateLimitingEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileIpsecProfileNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileIpsecProfileNormalizer.php
@@ -38,10 +38,10 @@ class ProfileIpsecProfileNormalizer implements DenormalizerInterface, Normalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('ikeRekeyTime', $data) && \is_int($data['ikeRekeyTime'])) {
-            $data['ikeRekeyTime'] = (double) $data['ikeRekeyTime'];
+            $data['ikeRekeyTime'] = (float) $data['ikeRekeyTime'];
         }
         if (\array_key_exists('espRekeyTime', $data) && \is_int($data['espRekeyTime'])) {
-            $data['espRekeyTime'] = (double) $data['espRekeyTime'];
+            $data['espRekeyTime'] = (float) $data['espRekeyTime'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileModifyFirewallProfileNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileModifyFirewallProfileNormalizer.php
@@ -38,10 +38,10 @@ class ProfileModifyFirewallProfileNormalizer implements DenormalizerInterface, N
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('uplinkRateLimitingMbps', $data) && \is_int($data['uplinkRateLimitingMbps'])) {
-            $data['uplinkRateLimitingMbps'] = (double) $data['uplinkRateLimitingMbps'];
+            $data['uplinkRateLimitingMbps'] = (float) $data['uplinkRateLimitingMbps'];
         }
         if (\array_key_exists('downlinkRateLimitingMbps', $data) && \is_int($data['downlinkRateLimitingMbps'])) {
-            $data['downlinkRateLimitingMbps'] = (double) $data['downlinkRateLimitingMbps'];
+            $data['downlinkRateLimitingMbps'] = (float) $data['downlinkRateLimitingMbps'];
         }
         if (\array_key_exists('name', $data)) {
             $object->setName($data['name']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileModifyIpAclRulesNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileModifyIpAclRulesNormalizer.php
@@ -38,10 +38,10 @@ class ProfileModifyIpAclRulesNormalizer implements DenormalizerInterface, Normal
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('uplinkRateLimitingMbps', $data) && \is_int($data['uplinkRateLimitingMbps'])) {
-            $data['uplinkRateLimitingMbps'] = (double) $data['uplinkRateLimitingMbps'];
+            $data['uplinkRateLimitingMbps'] = (float) $data['uplinkRateLimitingMbps'];
         }
         if (\array_key_exists('downlinkRateLimitingMbps', $data) && \is_int($data['downlinkRateLimitingMbps'])) {
-            $data['downlinkRateLimitingMbps'] = (double) $data['downlinkRateLimitingMbps'];
+            $data['downlinkRateLimitingMbps'] = (float) $data['downlinkRateLimitingMbps'];
         }
         if (\array_key_exists('uplinkRateLimitingEnabled', $data) && \is_int($data['uplinkRateLimitingEnabled'])) {
             $data['uplinkRateLimitingEnabled'] = (bool) $data['uplinkRateLimitingEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileModifyIpsecProfileNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileModifyIpsecProfileNormalizer.php
@@ -38,10 +38,10 @@ class ProfileModifyIpsecProfileNormalizer implements DenormalizerInterface, Norm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('ikeRekeyTime', $data) && \is_int($data['ikeRekeyTime'])) {
-            $data['ikeRekeyTime'] = (double) $data['ikeRekeyTime'];
+            $data['ikeRekeyTime'] = (float) $data['ikeRekeyTime'];
         }
         if (\array_key_exists('espRekeyTime', $data) && \is_int($data['espRekeyTime'])) {
-            $data['espRekeyTime'] = (double) $data['espRekeyTime'];
+            $data['espRekeyTime'] = (float) $data['espRekeyTime'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileReturnDPGroupDpGroupListWithPriorityItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ProfileReturnDPGroupDpGroupListWithPriorityItemNormalizer.php
@@ -38,7 +38,7 @@ class ProfileReturnDPGroupDpGroupListWithPriorityItemNormalizer implements Denor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('priority', $data) && \is_int($data['priority'])) {
-            $data['priority'] = (double) $data['priority'];
+            $data['priority'] = (float) $data['priority'];
         }
         if (\array_key_exists('priority', $data)) {
             $object->setPriority($data['priority']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/SystemPortStatisticNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/SystemPortStatisticNormalizer.php
@@ -38,40 +38,40 @@ class SystemPortStatisticNormalizer implements DenormalizerInterface, Normalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('rxBps', $data) && \is_int($data['rxBps'])) {
-            $data['rxBps'] = (double) $data['rxBps'];
+            $data['rxBps'] = (float) $data['rxBps'];
         }
         if (\array_key_exists('rxBpsMax', $data) && \is_int($data['rxBpsMax'])) {
-            $data['rxBpsMax'] = (double) $data['rxBpsMax'];
+            $data['rxBpsMax'] = (float) $data['rxBpsMax'];
         }
         if (\array_key_exists('rxBpsMin', $data) && \is_int($data['rxBpsMin'])) {
-            $data['rxBpsMin'] = (double) $data['rxBpsMin'];
+            $data['rxBpsMin'] = (float) $data['rxBpsMin'];
         }
         if (\array_key_exists('rxBytes', $data) && \is_int($data['rxBytes'])) {
-            $data['rxBytes'] = (double) $data['rxBytes'];
+            $data['rxBytes'] = (float) $data['rxBytes'];
         }
         if (\array_key_exists('rxDropped', $data) && \is_int($data['rxDropped'])) {
-            $data['rxDropped'] = (double) $data['rxDropped'];
+            $data['rxDropped'] = (float) $data['rxDropped'];
         }
         if (\array_key_exists('rxPackets', $data) && \is_int($data['rxPackets'])) {
-            $data['rxPackets'] = (double) $data['rxPackets'];
+            $data['rxPackets'] = (float) $data['rxPackets'];
         }
         if (\array_key_exists('txBps', $data) && \is_int($data['txBps'])) {
-            $data['txBps'] = (double) $data['txBps'];
+            $data['txBps'] = (float) $data['txBps'];
         }
         if (\array_key_exists('txBpsMax', $data) && \is_int($data['txBpsMax'])) {
-            $data['txBpsMax'] = (double) $data['txBpsMax'];
+            $data['txBpsMax'] = (float) $data['txBpsMax'];
         }
         if (\array_key_exists('txBpsMin', $data) && \is_int($data['txBpsMin'])) {
-            $data['txBpsMin'] = (double) $data['txBpsMin'];
+            $data['txBpsMin'] = (float) $data['txBpsMin'];
         }
         if (\array_key_exists('txBytes', $data) && \is_int($data['txBytes'])) {
-            $data['txBytes'] = (double) $data['txBytes'];
+            $data['txBytes'] = (float) $data['txBytes'];
         }
         if (\array_key_exists('txDropped', $data) && \is_int($data['txDropped'])) {
-            $data['txDropped'] = (double) $data['txDropped'];
+            $data['txDropped'] = (float) $data['txDropped'];
         }
         if (\array_key_exists('txPackets', $data) && \is_int($data['txPackets'])) {
-            $data['txPackets'] = (double) $data['txPackets'];
+            $data['txPackets'] = (float) $data['txPackets'];
         }
         if (\array_key_exists('rxBps', $data)) {
             $object->setRxBps($data['rxBps']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/SystemStatisticListItemCpuNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/SystemStatisticListItemCpuNormalizer.php
@@ -38,13 +38,13 @@ class SystemStatisticListItemCpuNormalizer implements DenormalizerInterface, Nor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('percent', $data) && \is_int($data['percent'])) {
-            $data['percent'] = (double) $data['percent'];
+            $data['percent'] = (float) $data['percent'];
         }
         if (\array_key_exists('maxPercent', $data) && \is_int($data['maxPercent'])) {
-            $data['maxPercent'] = (double) $data['maxPercent'];
+            $data['maxPercent'] = (float) $data['maxPercent'];
         }
         if (\array_key_exists('minPercent', $data) && \is_int($data['minPercent'])) {
-            $data['minPercent'] = (double) $data['minPercent'];
+            $data['minPercent'] = (float) $data['minPercent'];
         }
         if (\array_key_exists('percent', $data)) {
             $object->setPercent($data['percent']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/SystemStatisticListItemDiskNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/SystemStatisticListItemDiskNormalizer.php
@@ -38,16 +38,16 @@ class SystemStatisticListItemDiskNormalizer implements DenormalizerInterface, No
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('total', $data) && \is_int($data['total'])) {
-            $data['total'] = (double) $data['total'];
+            $data['total'] = (float) $data['total'];
         }
         if (\array_key_exists('free', $data) && \is_int($data['free'])) {
-            $data['free'] = (double) $data['free'];
+            $data['free'] = (float) $data['free'];
         }
         if (\array_key_exists('maxFree', $data) && \is_int($data['maxFree'])) {
-            $data['maxFree'] = (double) $data['maxFree'];
+            $data['maxFree'] = (float) $data['maxFree'];
         }
         if (\array_key_exists('minFree', $data) && \is_int($data['minFree'])) {
-            $data['minFree'] = (double) $data['minFree'];
+            $data['minFree'] = (float) $data['minFree'];
         }
         if (\array_key_exists('total', $data)) {
             $object->setTotal($data['total']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/SystemStatisticListItemMemoryNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/SystemStatisticListItemMemoryNormalizer.php
@@ -38,13 +38,13 @@ class SystemStatisticListItemMemoryNormalizer implements DenormalizerInterface, 
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('percent', $data) && \is_int($data['percent'])) {
-            $data['percent'] = (double) $data['percent'];
+            $data['percent'] = (float) $data['percent'];
         }
         if (\array_key_exists('maxPercent', $data) && \is_int($data['maxPercent'])) {
-            $data['maxPercent'] = (double) $data['maxPercent'];
+            $data['maxPercent'] = (float) $data['maxPercent'];
         }
         if (\array_key_exists('minPercent', $data) && \is_int($data['minPercent'])) {
-            $data['minPercent'] = (double) $data['minPercent'];
+            $data['minPercent'] = (float) $data['minPercent'];
         }
         if (\array_key_exists('percent', $data)) {
             $object->setPercent($data['percent']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/SystemStatisticListItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/SystemStatisticListItemNormalizer.php
@@ -38,7 +38,7 @@ class SystemStatisticListItemNormalizer implements DenormalizerInterface, Normal
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('timestamp', $data) && \is_int($data['timestamp'])) {
-            $data['timestamp'] = (double) $data['timestamp'];
+            $data['timestamp'] = (float) $data['timestamp'];
         }
         if (\array_key_exists('timestamp', $data)) {
             $object->setTimestamp($data['timestamp']);

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateGuestAccessWlanNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateGuestAccessWlanNormalizer.php
@@ -38,10 +38,10 @@ class WlanCreateGuestAccessWlanNormalizer implements DenormalizerInterface, Norm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('firewallUplinkRateLimitingMbps', $data) && \is_int($data['firewallUplinkRateLimitingMbps'])) {
-            $data['firewallUplinkRateLimitingMbps'] = (double) $data['firewallUplinkRateLimitingMbps'];
+            $data['firewallUplinkRateLimitingMbps'] = (float) $data['firewallUplinkRateLimitingMbps'];
         }
         if (\array_key_exists('firewallDownlinkRateLimitingMbps', $data) && \is_int($data['firewallDownlinkRateLimitingMbps'])) {
-            $data['firewallDownlinkRateLimitingMbps'] = (double) $data['firewallDownlinkRateLimitingMbps'];
+            $data['firewallDownlinkRateLimitingMbps'] = (float) $data['firewallDownlinkRateLimitingMbps'];
         }
         if (\array_key_exists('bypassCNA', $data) && \is_int($data['bypassCNA'])) {
             $data['bypassCNA'] = (bool) $data['bypassCNA'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateHotspot20OpenWlanNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateHotspot20OpenWlanNormalizer.php
@@ -38,10 +38,10 @@ class WlanCreateHotspot20OpenWlanNormalizer implements DenormalizerInterface, No
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('firewallUplinkRateLimitingMbps', $data) && \is_int($data['firewallUplinkRateLimitingMbps'])) {
-            $data['firewallUplinkRateLimitingMbps'] = (double) $data['firewallUplinkRateLimitingMbps'];
+            $data['firewallUplinkRateLimitingMbps'] = (float) $data['firewallUplinkRateLimitingMbps'];
         }
         if (\array_key_exists('firewallDownlinkRateLimitingMbps', $data) && \is_int($data['firewallDownlinkRateLimitingMbps'])) {
-            $data['firewallDownlinkRateLimitingMbps'] = (double) $data['firewallDownlinkRateLimitingMbps'];
+            $data['firewallDownlinkRateLimitingMbps'] = (float) $data['firewallDownlinkRateLimitingMbps'];
         }
         if (\array_key_exists('caleaEnabled', $data) && \is_int($data['caleaEnabled'])) {
             $data['caleaEnabled'] = (bool) $data['caleaEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateHotspot20WlanNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateHotspot20WlanNormalizer.php
@@ -38,10 +38,10 @@ class WlanCreateHotspot20WlanNormalizer implements DenormalizerInterface, Normal
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('firewallUplinkRateLimitingMbps', $data) && \is_int($data['firewallUplinkRateLimitingMbps'])) {
-            $data['firewallUplinkRateLimitingMbps'] = (double) $data['firewallUplinkRateLimitingMbps'];
+            $data['firewallUplinkRateLimitingMbps'] = (float) $data['firewallUplinkRateLimitingMbps'];
         }
         if (\array_key_exists('firewallDownlinkRateLimitingMbps', $data) && \is_int($data['firewallDownlinkRateLimitingMbps'])) {
-            $data['firewallDownlinkRateLimitingMbps'] = (double) $data['firewallDownlinkRateLimitingMbps'];
+            $data['firewallDownlinkRateLimitingMbps'] = (float) $data['firewallDownlinkRateLimitingMbps'];
         }
         if (\array_key_exists('caleaEnabled', $data) && \is_int($data['caleaEnabled'])) {
             $data['caleaEnabled'] = (bool) $data['caleaEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateHotspotWlanNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateHotspotWlanNormalizer.php
@@ -38,10 +38,10 @@ class WlanCreateHotspotWlanNormalizer implements DenormalizerInterface, Normaliz
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('firewallUplinkRateLimitingMbps', $data) && \is_int($data['firewallUplinkRateLimitingMbps'])) {
-            $data['firewallUplinkRateLimitingMbps'] = (double) $data['firewallUplinkRateLimitingMbps'];
+            $data['firewallUplinkRateLimitingMbps'] = (float) $data['firewallUplinkRateLimitingMbps'];
         }
         if (\array_key_exists('firewallDownlinkRateLimitingMbps', $data) && \is_int($data['firewallDownlinkRateLimitingMbps'])) {
-            $data['firewallDownlinkRateLimitingMbps'] = (double) $data['firewallDownlinkRateLimitingMbps'];
+            $data['firewallDownlinkRateLimitingMbps'] = (float) $data['firewallDownlinkRateLimitingMbps'];
         }
         if (\array_key_exists('bypassCNA', $data) && \is_int($data['bypassCNA'])) {
             $data['bypassCNA'] = (bool) $data['bypassCNA'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateStandard80211WlanNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateStandard80211WlanNormalizer.php
@@ -38,10 +38,10 @@ class WlanCreateStandard80211WlanNormalizer implements DenormalizerInterface, No
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('firewallUplinkRateLimitingMbps', $data) && \is_int($data['firewallUplinkRateLimitingMbps'])) {
-            $data['firewallUplinkRateLimitingMbps'] = (double) $data['firewallUplinkRateLimitingMbps'];
+            $data['firewallUplinkRateLimitingMbps'] = (float) $data['firewallUplinkRateLimitingMbps'];
         }
         if (\array_key_exists('firewallDownlinkRateLimitingMbps', $data) && \is_int($data['firewallDownlinkRateLimitingMbps'])) {
-            $data['firewallDownlinkRateLimitingMbps'] = (double) $data['firewallDownlinkRateLimitingMbps'];
+            $data['firewallDownlinkRateLimitingMbps'] = (float) $data['firewallDownlinkRateLimitingMbps'];
         }
         if (\array_key_exists('caleaEnabled', $data) && \is_int($data['caleaEnabled'])) {
             $data['caleaEnabled'] = (bool) $data['caleaEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateStandardOpenWlanNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateStandardOpenWlanNormalizer.php
@@ -38,10 +38,10 @@ class WlanCreateStandardOpenWlanNormalizer implements DenormalizerInterface, Nor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('firewallUplinkRateLimitingMbps', $data) && \is_int($data['firewallUplinkRateLimitingMbps'])) {
-            $data['firewallUplinkRateLimitingMbps'] = (double) $data['firewallUplinkRateLimitingMbps'];
+            $data['firewallUplinkRateLimitingMbps'] = (float) $data['firewallUplinkRateLimitingMbps'];
         }
         if (\array_key_exists('firewallDownlinkRateLimitingMbps', $data) && \is_int($data['firewallDownlinkRateLimitingMbps'])) {
-            $data['firewallDownlinkRateLimitingMbps'] = (double) $data['firewallDownlinkRateLimitingMbps'];
+            $data['firewallDownlinkRateLimitingMbps'] = (float) $data['firewallDownlinkRateLimitingMbps'];
         }
         if (\array_key_exists('caleaEnabled', $data) && \is_int($data['caleaEnabled'])) {
             $data['caleaEnabled'] = (bool) $data['caleaEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateWebAuthWlanNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateWebAuthWlanNormalizer.php
@@ -38,10 +38,10 @@ class WlanCreateWebAuthWlanNormalizer implements DenormalizerInterface, Normaliz
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('firewallUplinkRateLimitingMbps', $data) && \is_int($data['firewallUplinkRateLimitingMbps'])) {
-            $data['firewallUplinkRateLimitingMbps'] = (double) $data['firewallUplinkRateLimitingMbps'];
+            $data['firewallUplinkRateLimitingMbps'] = (float) $data['firewallUplinkRateLimitingMbps'];
         }
         if (\array_key_exists('firewallDownlinkRateLimitingMbps', $data) && \is_int($data['firewallDownlinkRateLimitingMbps'])) {
-            $data['firewallDownlinkRateLimitingMbps'] = (double) $data['firewallDownlinkRateLimitingMbps'];
+            $data['firewallDownlinkRateLimitingMbps'] = (float) $data['firewallDownlinkRateLimitingMbps'];
         }
         if (\array_key_exists('bypassCNA', $data) && \is_int($data['bypassCNA'])) {
             $data['bypassCNA'] = (bool) $data['bypassCNA'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateWechatWlanNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanCreateWechatWlanNormalizer.php
@@ -38,10 +38,10 @@ class WlanCreateWechatWlanNormalizer implements DenormalizerInterface, Normalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('firewallUplinkRateLimitingMbps', $data) && \is_int($data['firewallUplinkRateLimitingMbps'])) {
-            $data['firewallUplinkRateLimitingMbps'] = (double) $data['firewallUplinkRateLimitingMbps'];
+            $data['firewallUplinkRateLimitingMbps'] = (float) $data['firewallUplinkRateLimitingMbps'];
         }
         if (\array_key_exists('firewallDownlinkRateLimitingMbps', $data) && \is_int($data['firewallDownlinkRateLimitingMbps'])) {
-            $data['firewallDownlinkRateLimitingMbps'] = (double) $data['firewallDownlinkRateLimitingMbps'];
+            $data['firewallDownlinkRateLimitingMbps'] = (float) $data['firewallDownlinkRateLimitingMbps'];
         }
         if (\array_key_exists('caleaEnabled', $data) && \is_int($data['caleaEnabled'])) {
             $data['caleaEnabled'] = (bool) $data['caleaEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanModifyWlanNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanModifyWlanNormalizer.php
@@ -38,10 +38,10 @@ class WlanModifyWlanNormalizer implements DenormalizerInterface, NormalizerInter
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('firewallUplinkRateLimitingMbps', $data) && \is_int($data['firewallUplinkRateLimitingMbps'])) {
-            $data['firewallUplinkRateLimitingMbps'] = (double) $data['firewallUplinkRateLimitingMbps'];
+            $data['firewallUplinkRateLimitingMbps'] = (float) $data['firewallUplinkRateLimitingMbps'];
         }
         if (\array_key_exists('firewallDownlinkRateLimitingMbps', $data) && \is_int($data['firewallDownlinkRateLimitingMbps'])) {
-            $data['firewallDownlinkRateLimitingMbps'] = (double) $data['firewallDownlinkRateLimitingMbps'];
+            $data['firewallDownlinkRateLimitingMbps'] = (float) $data['firewallDownlinkRateLimitingMbps'];
         }
         if (\array_key_exists('bypassCNA', $data) && \is_int($data['bypassCNA'])) {
             $data['bypassCNA'] = (bool) $data['bypassCNA'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanWlanAdvancedNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanWlanAdvancedNormalizer.php
@@ -38,10 +38,10 @@ class WlanWlanAdvancedNormalizer implements DenormalizerInterface, NormalizerInt
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('uplinkRate', $data) && \is_int($data['uplinkRate'])) {
-            $data['uplinkRate'] = (double) $data['uplinkRate'];
+            $data['uplinkRate'] = (float) $data['uplinkRate'];
         }
         if (\array_key_exists('downlinkRate', $data) && \is_int($data['downlinkRate'])) {
-            $data['downlinkRate'] = (double) $data['downlinkRate'];
+            $data['downlinkRate'] = (float) $data['downlinkRate'];
         }
         if (\array_key_exists('clientIsolationEnabled', $data) && \is_int($data['clientIsolationEnabled'])) {
             $data['clientIsolationEnabled'] = (bool) $data['clientIsolationEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanWlanConfigurationNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/WlanWlanConfigurationNormalizer.php
@@ -38,10 +38,10 @@ class WlanWlanConfigurationNormalizer implements DenormalizerInterface, Normaliz
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('firewallUplinkRateLimitingMbps', $data) && \is_int($data['firewallUplinkRateLimitingMbps'])) {
-            $data['firewallUplinkRateLimitingMbps'] = (double) $data['firewallUplinkRateLimitingMbps'];
+            $data['firewallUplinkRateLimitingMbps'] = (float) $data['firewallUplinkRateLimitingMbps'];
         }
         if (\array_key_exists('firewallDownlinkRateLimitingMbps', $data) && \is_int($data['firewallDownlinkRateLimitingMbps'])) {
-            $data['firewallDownlinkRateLimitingMbps'] = (double) $data['firewallDownlinkRateLimitingMbps'];
+            $data['firewallDownlinkRateLimitingMbps'] = (float) $data['firewallDownlinkRateLimitingMbps'];
         }
         if (\array_key_exists('bypassCNA', $data) && \is_int($data['bypassCNA'])) {
             $data['bypassCNA'] = (bool) $data['bypassCNA'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneCreateZoneNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneCreateZoneNormalizer.php
@@ -38,10 +38,10 @@ class ZoneCreateZoneNormalizer implements DenormalizerInterface, NormalizerInter
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('enforcePriorityDpGroupEnable', $data) && \is_int($data['enforcePriorityDpGroupEnable'])) {
             $data['enforcePriorityDpGroupEnable'] = (bool) $data['enforcePriorityDpGroupEnable'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneModifyZoneNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneModifyZoneNormalizer.php
@@ -38,10 +38,10 @@ class ZoneModifyZoneNormalizer implements DenormalizerInterface, NormalizerInter
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('enforcePriorityDpGroupEnable', $data) && \is_int($data['enforcePriorityDpGroupEnable'])) {
             $data['enforcePriorityDpGroupEnable'] = (bool) $data['enforcePriorityDpGroupEnable'];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneZoneConfigurationNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Normalizer/ZoneZoneConfigurationNormalizer.php
@@ -38,10 +38,10 @@ class ZoneZoneConfigurationNormalizer implements DenormalizerInterface, Normaliz
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('latitude', $data) && \is_int($data['latitude'])) {
-            $data['latitude'] = (double) $data['latitude'];
+            $data['latitude'] = (float) $data['latitude'];
         }
         if (\array_key_exists('longitude', $data) && \is_int($data['longitude'])) {
-            $data['longitude'] = (double) $data['longitude'];
+            $data['longitude'] = (float) $data['longitude'];
         }
         if (\array_key_exists('vlanOverlappingEnabled', $data) && \is_int($data['vlanOverlappingEnabled'])) {
             $data['vlanOverlappingEnabled'] = (bool) $data['vlanOverlappingEnabled'];

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
@@ -38,7 +38,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
-            $data['floatProperty'] = (double) $data['floatProperty'];
+            $data['floatProperty'] = (float) $data['floatProperty'];
         }
         if (\array_key_exists('stringProperty', $data)) {
             $object->setStringProperty($data['stringProperty']);

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
@@ -39,7 +39,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
-            $data['floatProperty'] = (double) $data['floatProperty'];
+            $data['floatProperty'] = (float) $data['floatProperty'];
         }
         if (\array_key_exists('stringProperty', $data)) {
             $object->setStringProperty($data['stringProperty']);

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Normalizer/ProjectNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Normalizer/ProjectNormalizer.php
@@ -38,19 +38,19 @@ class ProjectNormalizer implements DenormalizerInterface, NormalizerInterface, D
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('hourly_rate', $data) && \is_int($data['hourly_rate'])) {
-            $data['hourly_rate'] = (double) $data['hourly_rate'];
+            $data['hourly_rate'] = (float) $data['hourly_rate'];
         }
         if (\array_key_exists('budget', $data) && \is_int($data['budget'])) {
-            $data['budget'] = (double) $data['budget'];
+            $data['budget'] = (float) $data['budget'];
         }
         if (\array_key_exists('over_budget_notification_percentage', $data) && \is_int($data['over_budget_notification_percentage'])) {
-            $data['over_budget_notification_percentage'] = (double) $data['over_budget_notification_percentage'];
+            $data['over_budget_notification_percentage'] = (float) $data['over_budget_notification_percentage'];
         }
         if (\array_key_exists('cost_budget', $data) && \is_int($data['cost_budget'])) {
-            $data['cost_budget'] = (double) $data['cost_budget'];
+            $data['cost_budget'] = (float) $data['cost_budget'];
         }
         if (\array_key_exists('fee', $data) && \is_int($data['fee'])) {
-            $data['fee'] = (double) $data['fee'];
+            $data['fee'] = (float) $data['fee'];
         }
         if (\array_key_exists('is_active', $data) && \is_int($data['is_active'])) {
             $data['is_active'] = (bool) $data['is_active'];

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Normalizer/ProjectNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Normalizer/ProjectNormalizer.php
@@ -38,19 +38,19 @@ class ProjectNormalizer implements DenormalizerInterface, NormalizerInterface, D
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('hourly_rate', $data) && \is_int($data['hourly_rate'])) {
-            $data['hourly_rate'] = (double) $data['hourly_rate'];
+            $data['hourly_rate'] = (float) $data['hourly_rate'];
         }
         if (\array_key_exists('budget', $data) && \is_int($data['budget'])) {
-            $data['budget'] = (double) $data['budget'];
+            $data['budget'] = (float) $data['budget'];
         }
         if (\array_key_exists('over_budget_notification_percentage', $data) && \is_int($data['over_budget_notification_percentage'])) {
-            $data['over_budget_notification_percentage'] = (double) $data['over_budget_notification_percentage'];
+            $data['over_budget_notification_percentage'] = (float) $data['over_budget_notification_percentage'];
         }
         if (\array_key_exists('cost_budget', $data) && \is_int($data['cost_budget'])) {
-            $data['cost_budget'] = (double) $data['cost_budget'];
+            $data['cost_budget'] = (float) $data['cost_budget'];
         }
         if (\array_key_exists('fee', $data) && \is_int($data['fee'])) {
-            $data['fee'] = (double) $data['fee'];
+            $data['fee'] = (float) $data['fee'];
         }
         if (\array_key_exists('is_active', $data) && \is_int($data['is_active'])) {
             $data['is_active'] = (bool) $data['is_active'];

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Normalizer/ProjectsPostBodyNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Normalizer/ProjectsPostBodyNormalizer.php
@@ -38,19 +38,19 @@ class ProjectsPostBodyNormalizer implements DenormalizerInterface, NormalizerInt
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('hourly_rate', $data) && \is_int($data['hourly_rate'])) {
-            $data['hourly_rate'] = (double) $data['hourly_rate'];
+            $data['hourly_rate'] = (float) $data['hourly_rate'];
         }
         if (\array_key_exists('budget', $data) && \is_int($data['budget'])) {
-            $data['budget'] = (double) $data['budget'];
+            $data['budget'] = (float) $data['budget'];
         }
         if (\array_key_exists('over_budget_notification_percentage', $data) && \is_int($data['over_budget_notification_percentage'])) {
-            $data['over_budget_notification_percentage'] = (double) $data['over_budget_notification_percentage'];
+            $data['over_budget_notification_percentage'] = (float) $data['over_budget_notification_percentage'];
         }
         if (\array_key_exists('cost_budget', $data) && \is_int($data['cost_budget'])) {
-            $data['cost_budget'] = (double) $data['cost_budget'];
+            $data['cost_budget'] = (float) $data['cost_budget'];
         }
         if (\array_key_exists('fee', $data) && \is_int($data['fee'])) {
-            $data['fee'] = (double) $data['fee'];
+            $data['fee'] = (float) $data['fee'];
         }
         if (\array_key_exists('is_active', $data) && \is_int($data['is_active'])) {
             $data['is_active'] = (bool) $data['is_active'];

--- a/src/Component/OpenApi3/JsonSchema/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi3/JsonSchema/Normalizer/SchemaNormalizer.php
@@ -39,13 +39,13 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
         }
         $object = new \Jane\Component\OpenApi3\JsonSchema\Model\Schema();
         if (\array_key_exists('multipleOf', $data) && \is_int($data['multipleOf'])) {
-            $data['multipleOf'] = (double) $data['multipleOf'];
+            $data['multipleOf'] = (float) $data['multipleOf'];
         }
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (null === $data || false === \is_array($data)) {
             return $object;

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Normalizer/SchemaNormalizer.php
@@ -38,7 +38,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
-            $data['floatProperty'] = (double) $data['floatProperty'];
+            $data['floatProperty'] = (float) $data['floatProperty'];
         }
         if (\array_key_exists('stringProperty', $data)) {
             $object->setStringProperty($data['stringProperty']);

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Normalizer/SchemaNormalizer.php
@@ -38,7 +38,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
-            $data['floatProperty'] = (double) $data['floatProperty'];
+            $data['floatProperty'] = (float) $data['floatProperty'];
         }
         if (\array_key_exists('stringProperty', $data)) {
             $object->setStringProperty($data['stringProperty']);

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Normalizer/SchemaNormalizer.php
@@ -38,7 +38,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
-            $data['floatProperty'] = (double) $data['floatProperty'];
+            $data['floatProperty'] = (float) $data['floatProperty'];
         }
         if (\array_key_exists('attribute1', $data)) {
             $object->setAttribute1($data['attribute1']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/CompanyEventsResponseNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/CompanyEventsResponseNormalizer.php
@@ -38,7 +38,7 @@ class CompanyEventsResponseNormalizer implements DenormalizerInterface, Normaliz
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('totalCount', $data) && \is_int($data['totalCount'])) {
-            $data['totalCount'] = (double) $data['totalCount'];
+            $data['totalCount'] = (float) $data['totalCount'];
         }
         if (\array_key_exists('totalCount', $data)) {
             $object->setTotalCount($data['totalCount']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/CompanyNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/CompanyNormalizer.php
@@ -38,7 +38,7 @@ class CompanyNormalizer implements DenormalizerInterface, NormalizerInterface, D
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('portfolioId', $data) && \is_int($data['portfolioId'])) {
-            $data['portfolioId'] = (double) $data['portfolioId'];
+            $data['portfolioId'] = (float) $data['portfolioId'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/CompanySearchSuccessResultNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/CompanySearchSuccessResultNormalizer.php
@@ -38,7 +38,7 @@ class CompanySearchSuccessResultNormalizer implements DenormalizerInterface, Nor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('totalSize', $data) && \is_int($data['totalSize'])) {
-            $data['totalSize'] = (double) $data['totalSize'];
+            $data['totalSize'] = (float) $data['totalSize'];
         }
         if (\array_key_exists('totalSize', $data)) {
             $object->setTotalSize($data['totalSize']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/EventNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/EventNormalizer.php
@@ -38,13 +38,13 @@ class EventNormalizer implements DenormalizerInterface, NormalizerInterface, Den
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('eventId', $data) && \is_int($data['eventId'])) {
-            $data['eventId'] = (double) $data['eventId'];
+            $data['eventId'] = (float) $data['eventId'];
         }
         if (\array_key_exists('companyId', $data) && \is_int($data['companyId'])) {
-            $data['companyId'] = (double) $data['companyId'];
+            $data['companyId'] = (float) $data['companyId'];
         }
         if (\array_key_exists('portfolioId', $data) && \is_int($data['portfolioId'])) {
-            $data['portfolioId'] = (double) $data['portfolioId'];
+            $data['portfolioId'] = (float) $data['portfolioId'];
         }
         if (\array_key_exists('eventId', $data)) {
             $object->setEventId($data['eventId']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/EventRulesResponseNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/EventRulesResponseNormalizer.php
@@ -38,10 +38,10 @@ class EventRulesResponseNormalizer implements DenormalizerInterface, NormalizerI
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('ruleCode', $data) && \is_int($data['ruleCode'])) {
-            $data['ruleCode'] = (double) $data['ruleCode'];
+            $data['ruleCode'] = (float) $data['ruleCode'];
         }
         if (\array_key_exists('ruleType', $data) && \is_int($data['ruleType'])) {
-            $data['ruleType'] = (double) $data['ruleType'];
+            $data['ruleType'] = (float) $data['ruleType'];
         }
         if (\array_key_exists('isActive', $data) && \is_int($data['isActive'])) {
             $data['isActive'] = (bool) $data['isActive'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportAdditionalInformationBadDebtDetailsItemAmountNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportAdditionalInformationBadDebtDetailsItemAmountNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportAdditionalInformationBadDebtDetailsIte
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportAdditionalInformationCreditLimitHistoryItemCompanyValueNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportAdditionalInformationCreditLimitHistoryItemCompanyValueNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportAdditionalInformationCreditLimitHistor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportAdditionalInformationMortgageSummaryNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportAdditionalInformationMortgageSummaryNormalizer.php
@@ -38,10 +38,10 @@ class GbCompanyReportExampleResponseReportAdditionalInformationMortgageSummaryNo
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('outstanding', $data) && \is_int($data['outstanding'])) {
-            $data['outstanding'] = (double) $data['outstanding'];
+            $data['outstanding'] = (float) $data['outstanding'];
         }
         if (\array_key_exists('satisfied', $data) && \is_int($data['satisfied'])) {
-            $data['satisfied'] = (double) $data['satisfied'];
+            $data['satisfied'] = (float) $data['satisfied'];
         }
         if (\array_key_exists('outstanding', $data)) {
             $object->setOutstanding($data['outstanding']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportAdditionalInformationRatingHistoryItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportAdditionalInformationRatingHistoryItemNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportAdditionalInformationRatingHistoryItem
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('companyValue', $data) && \is_int($data['companyValue'])) {
-            $data['companyValue'] = (double) $data['companyValue'];
+            $data['companyValue'] = (float) $data['companyValue'];
         }
         if (\array_key_exists('date', $data)) {
             $object->setDate($data['date']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportCompanySummaryLatestShareholdersEquityFigureNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportCompanySummaryLatestShareholdersEquityFigureNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportCompanySummaryLatestShareholdersEquity
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportCompanySummaryLatestTurnoverFigureNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportCompanySummaryLatestTurnoverFigureNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportCompanySummaryLatestTurnoverFigureNorm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportCreditScoreCurrentContractLimitNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportCreditScoreCurrentContractLimitNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportCreditScoreCurrentContractLimitNormali
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportExtendedGroupStructureItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportExtendedGroupStructureItemNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportExtendedGroupStructureItemNormalizer i
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('level', $data) && \is_int($data['level'])) {
-            $data['level'] = (double) $data['level'];
+            $data['level'] = (float) $data['level'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportFinancialStatementsItemBalanceSheetNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportFinancialStatementsItemBalanceSheetNormalizer.php
@@ -38,82 +38,82 @@ class GbCompanyReportExampleResponseReportFinancialStatementsItemBalanceSheetNor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('totalTangibleAssets', $data) && \is_int($data['totalTangibleAssets'])) {
-            $data['totalTangibleAssets'] = (double) $data['totalTangibleAssets'];
+            $data['totalTangibleAssets'] = (float) $data['totalTangibleAssets'];
         }
         if (\array_key_exists('totalIntangibleAssets', $data) && \is_int($data['totalIntangibleAssets'])) {
-            $data['totalIntangibleAssets'] = (double) $data['totalIntangibleAssets'];
+            $data['totalIntangibleAssets'] = (float) $data['totalIntangibleAssets'];
         }
         if (\array_key_exists('totalOtherFixedAssets', $data) && \is_int($data['totalOtherFixedAssets'])) {
-            $data['totalOtherFixedAssets'] = (double) $data['totalOtherFixedAssets'];
+            $data['totalOtherFixedAssets'] = (float) $data['totalOtherFixedAssets'];
         }
         if (\array_key_exists('totalFixedAssets', $data) && \is_int($data['totalFixedAssets'])) {
-            $data['totalFixedAssets'] = (double) $data['totalFixedAssets'];
+            $data['totalFixedAssets'] = (float) $data['totalFixedAssets'];
         }
         if (\array_key_exists('totalInventories', $data) && \is_int($data['totalInventories'])) {
-            $data['totalInventories'] = (double) $data['totalInventories'];
+            $data['totalInventories'] = (float) $data['totalInventories'];
         }
         if (\array_key_exists('tradeReceivables', $data) && \is_int($data['tradeReceivables'])) {
-            $data['tradeReceivables'] = (double) $data['tradeReceivables'];
+            $data['tradeReceivables'] = (float) $data['tradeReceivables'];
         }
         if (\array_key_exists('miscellaneousReceivables', $data) && \is_int($data['miscellaneousReceivables'])) {
-            $data['miscellaneousReceivables'] = (double) $data['miscellaneousReceivables'];
+            $data['miscellaneousReceivables'] = (float) $data['miscellaneousReceivables'];
         }
         if (\array_key_exists('totalReceivables', $data) && \is_int($data['totalReceivables'])) {
-            $data['totalReceivables'] = (double) $data['totalReceivables'];
+            $data['totalReceivables'] = (float) $data['totalReceivables'];
         }
         if (\array_key_exists('cash', $data) && \is_int($data['cash'])) {
-            $data['cash'] = (double) $data['cash'];
+            $data['cash'] = (float) $data['cash'];
         }
         if (\array_key_exists('otherCurrentAssets', $data) && \is_int($data['otherCurrentAssets'])) {
-            $data['otherCurrentAssets'] = (double) $data['otherCurrentAssets'];
+            $data['otherCurrentAssets'] = (float) $data['otherCurrentAssets'];
         }
         if (\array_key_exists('totalCurrentAssets', $data) && \is_int($data['totalCurrentAssets'])) {
-            $data['totalCurrentAssets'] = (double) $data['totalCurrentAssets'];
+            $data['totalCurrentAssets'] = (float) $data['totalCurrentAssets'];
         }
         if (\array_key_exists('totalAssets', $data) && \is_int($data['totalAssets'])) {
-            $data['totalAssets'] = (double) $data['totalAssets'];
+            $data['totalAssets'] = (float) $data['totalAssets'];
         }
         if (\array_key_exists('tradePayables', $data) && \is_int($data['tradePayables'])) {
-            $data['tradePayables'] = (double) $data['tradePayables'];
+            $data['tradePayables'] = (float) $data['tradePayables'];
         }
         if (\array_key_exists('bankLiabilities', $data) && \is_int($data['bankLiabilities'])) {
-            $data['bankLiabilities'] = (double) $data['bankLiabilities'];
+            $data['bankLiabilities'] = (float) $data['bankLiabilities'];
         }
         if (\array_key_exists('otherLoansOrFinance', $data) && \is_int($data['otherLoansOrFinance'])) {
-            $data['otherLoansOrFinance'] = (double) $data['otherLoansOrFinance'];
+            $data['otherLoansOrFinance'] = (float) $data['otherLoansOrFinance'];
         }
         if (\array_key_exists('miscellaneousLiabilities', $data) && \is_int($data['miscellaneousLiabilities'])) {
-            $data['miscellaneousLiabilities'] = (double) $data['miscellaneousLiabilities'];
+            $data['miscellaneousLiabilities'] = (float) $data['miscellaneousLiabilities'];
         }
         if (\array_key_exists('totalCurrentLiabilities', $data) && \is_int($data['totalCurrentLiabilities'])) {
-            $data['totalCurrentLiabilities'] = (double) $data['totalCurrentLiabilities'];
+            $data['totalCurrentLiabilities'] = (float) $data['totalCurrentLiabilities'];
         }
         if (\array_key_exists('bankLiabilitiesDueAfter1Year', $data) && \is_int($data['bankLiabilitiesDueAfter1Year'])) {
-            $data['bankLiabilitiesDueAfter1Year'] = (double) $data['bankLiabilitiesDueAfter1Year'];
+            $data['bankLiabilitiesDueAfter1Year'] = (float) $data['bankLiabilitiesDueAfter1Year'];
         }
         if (\array_key_exists('otherLoansOrFinanceDueAfter1Year', $data) && \is_int($data['otherLoansOrFinanceDueAfter1Year'])) {
-            $data['otherLoansOrFinanceDueAfter1Year'] = (double) $data['otherLoansOrFinanceDueAfter1Year'];
+            $data['otherLoansOrFinanceDueAfter1Year'] = (float) $data['otherLoansOrFinanceDueAfter1Year'];
         }
         if (\array_key_exists('miscellaneousLiabilitiesDueAfter1Year', $data) && \is_int($data['miscellaneousLiabilitiesDueAfter1Year'])) {
-            $data['miscellaneousLiabilitiesDueAfter1Year'] = (double) $data['miscellaneousLiabilitiesDueAfter1Year'];
+            $data['miscellaneousLiabilitiesDueAfter1Year'] = (float) $data['miscellaneousLiabilitiesDueAfter1Year'];
         }
         if (\array_key_exists('totalLongTermLiabilities', $data) && \is_int($data['totalLongTermLiabilities'])) {
-            $data['totalLongTermLiabilities'] = (double) $data['totalLongTermLiabilities'];
+            $data['totalLongTermLiabilities'] = (float) $data['totalLongTermLiabilities'];
         }
         if (\array_key_exists('totalLiabilities', $data) && \is_int($data['totalLiabilities'])) {
-            $data['totalLiabilities'] = (double) $data['totalLiabilities'];
+            $data['totalLiabilities'] = (float) $data['totalLiabilities'];
         }
         if (\array_key_exists('calledUpShareCapital', $data) && \is_int($data['calledUpShareCapital'])) {
-            $data['calledUpShareCapital'] = (double) $data['calledUpShareCapital'];
+            $data['calledUpShareCapital'] = (float) $data['calledUpShareCapital'];
         }
         if (\array_key_exists('revenueReserves', $data) && \is_int($data['revenueReserves'])) {
-            $data['revenueReserves'] = (double) $data['revenueReserves'];
+            $data['revenueReserves'] = (float) $data['revenueReserves'];
         }
         if (\array_key_exists('otherReserves', $data) && \is_int($data['otherReserves'])) {
-            $data['otherReserves'] = (double) $data['otherReserves'];
+            $data['otherReserves'] = (float) $data['otherReserves'];
         }
         if (\array_key_exists('totalShareholdersEquity', $data) && \is_int($data['totalShareholdersEquity'])) {
-            $data['totalShareholdersEquity'] = (double) $data['totalShareholdersEquity'];
+            $data['totalShareholdersEquity'] = (float) $data['totalShareholdersEquity'];
         }
         if (\array_key_exists('totalTangibleAssets', $data)) {
             $object->setTotalTangibleAssets($data['totalTangibleAssets']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportFinancialStatementsItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportFinancialStatementsItemNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportFinancialStatementsItemNormalizer impl
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('numberOfWeeks', $data) && \is_int($data['numberOfWeeks'])) {
-            $data['numberOfWeeks'] = (double) $data['numberOfWeeks'];
+            $data['numberOfWeeks'] = (float) $data['numberOfWeeks'];
         }
         if (\array_key_exists('consolidatedAccounts', $data) && \is_int($data['consolidatedAccounts'])) {
             $data['consolidatedAccounts'] = (bool) $data['consolidatedAccounts'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportFinancialStatementsItemOtherFinancialsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportFinancialStatementsItemOtherFinancialsNormalizer.php
@@ -38,10 +38,10 @@ class GbCompanyReportExampleResponseReportFinancialStatementsItemOtherFinancials
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('workingCapital', $data) && \is_int($data['workingCapital'])) {
-            $data['workingCapital'] = (double) $data['workingCapital'];
+            $data['workingCapital'] = (float) $data['workingCapital'];
         }
         if (\array_key_exists('netWorth', $data) && \is_int($data['netWorth'])) {
-            $data['netWorth'] = (double) $data['netWorth'];
+            $data['netWorth'] = (float) $data['netWorth'];
         }
         if (\array_key_exists('contingentLiabilities', $data)) {
             $object->setContingentLiabilities($data['contingentLiabilities']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportFinancialStatementsItemProfitAndLossNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportFinancialStatementsItemProfitAndLossNormalizer.php
@@ -38,49 +38,49 @@ class GbCompanyReportExampleResponseReportFinancialStatementsItemProfitAndLossNo
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('revenue', $data) && \is_int($data['revenue'])) {
-            $data['revenue'] = (double) $data['revenue'];
+            $data['revenue'] = (float) $data['revenue'];
         }
         if (\array_key_exists('operatingCosts', $data) && \is_int($data['operatingCosts'])) {
-            $data['operatingCosts'] = (double) $data['operatingCosts'];
+            $data['operatingCosts'] = (float) $data['operatingCosts'];
         }
         if (\array_key_exists('operatingProfit', $data) && \is_int($data['operatingProfit'])) {
-            $data['operatingProfit'] = (double) $data['operatingProfit'];
+            $data['operatingProfit'] = (float) $data['operatingProfit'];
         }
         if (\array_key_exists('wagesAndSalaries', $data) && \is_int($data['wagesAndSalaries'])) {
-            $data['wagesAndSalaries'] = (double) $data['wagesAndSalaries'];
+            $data['wagesAndSalaries'] = (float) $data['wagesAndSalaries'];
         }
         if (\array_key_exists('pensionCosts', $data) && \is_int($data['pensionCosts'])) {
-            $data['pensionCosts'] = (double) $data['pensionCosts'];
+            $data['pensionCosts'] = (float) $data['pensionCosts'];
         }
         if (\array_key_exists('depreciation', $data) && \is_int($data['depreciation'])) {
-            $data['depreciation'] = (double) $data['depreciation'];
+            $data['depreciation'] = (float) $data['depreciation'];
         }
         if (\array_key_exists('amortisation', $data) && \is_int($data['amortisation'])) {
-            $data['amortisation'] = (double) $data['amortisation'];
+            $data['amortisation'] = (float) $data['amortisation'];
         }
         if (\array_key_exists('financialExpenses', $data) && \is_int($data['financialExpenses'])) {
-            $data['financialExpenses'] = (double) $data['financialExpenses'];
+            $data['financialExpenses'] = (float) $data['financialExpenses'];
         }
         if (\array_key_exists('profitBeforeTax', $data) && \is_int($data['profitBeforeTax'])) {
-            $data['profitBeforeTax'] = (double) $data['profitBeforeTax'];
+            $data['profitBeforeTax'] = (float) $data['profitBeforeTax'];
         }
         if (\array_key_exists('tax', $data) && \is_int($data['tax'])) {
-            $data['tax'] = (double) $data['tax'];
+            $data['tax'] = (float) $data['tax'];
         }
         if (\array_key_exists('profitAfterTax', $data) && \is_int($data['profitAfterTax'])) {
-            $data['profitAfterTax'] = (double) $data['profitAfterTax'];
+            $data['profitAfterTax'] = (float) $data['profitAfterTax'];
         }
         if (\array_key_exists('dividends', $data) && \is_int($data['dividends'])) {
-            $data['dividends'] = (double) $data['dividends'];
+            $data['dividends'] = (float) $data['dividends'];
         }
         if (\array_key_exists('minorityInterests', $data) && \is_int($data['minorityInterests'])) {
-            $data['minorityInterests'] = (double) $data['minorityInterests'];
+            $data['minorityInterests'] = (float) $data['minorityInterests'];
         }
         if (\array_key_exists('otherAppropriations', $data) && \is_int($data['otherAppropriations'])) {
-            $data['otherAppropriations'] = (double) $data['otherAppropriations'];
+            $data['otherAppropriations'] = (float) $data['otherAppropriations'];
         }
         if (\array_key_exists('retainedProfit', $data) && \is_int($data['retainedProfit'])) {
-            $data['retainedProfit'] = (double) $data['retainedProfit'];
+            $data['retainedProfit'] = (float) $data['retainedProfit'];
         }
         if (\array_key_exists('revenue', $data)) {
             $object->setRevenue($data['revenue']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportFinancialStatementsItemRatiosNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportFinancialStatementsItemRatiosNormalizer.php
@@ -38,46 +38,46 @@ class GbCompanyReportExampleResponseReportFinancialStatementsItemRatiosNormalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('preTaxProfitMargin', $data) && \is_int($data['preTaxProfitMargin'])) {
-            $data['preTaxProfitMargin'] = (double) $data['preTaxProfitMargin'];
+            $data['preTaxProfitMargin'] = (float) $data['preTaxProfitMargin'];
         }
         if (\array_key_exists('returnOnCapitalEmployed', $data) && \is_int($data['returnOnCapitalEmployed'])) {
-            $data['returnOnCapitalEmployed'] = (double) $data['returnOnCapitalEmployed'];
+            $data['returnOnCapitalEmployed'] = (float) $data['returnOnCapitalEmployed'];
         }
         if (\array_key_exists('returnOnTotalAssetsEmployed', $data) && \is_int($data['returnOnTotalAssetsEmployed'])) {
-            $data['returnOnTotalAssetsEmployed'] = (double) $data['returnOnTotalAssetsEmployed'];
+            $data['returnOnTotalAssetsEmployed'] = (float) $data['returnOnTotalAssetsEmployed'];
         }
         if (\array_key_exists('returnOnNetAssetsEmployed', $data) && \is_int($data['returnOnNetAssetsEmployed'])) {
-            $data['returnOnNetAssetsEmployed'] = (double) $data['returnOnNetAssetsEmployed'];
+            $data['returnOnNetAssetsEmployed'] = (float) $data['returnOnNetAssetsEmployed'];
         }
         if (\array_key_exists('salesOrNetWorkingCapital', $data) && \is_int($data['salesOrNetWorkingCapital'])) {
-            $data['salesOrNetWorkingCapital'] = (double) $data['salesOrNetWorkingCapital'];
+            $data['salesOrNetWorkingCapital'] = (float) $data['salesOrNetWorkingCapital'];
         }
         if (\array_key_exists('stockTurnoverRatio', $data) && \is_int($data['stockTurnoverRatio'])) {
-            $data['stockTurnoverRatio'] = (double) $data['stockTurnoverRatio'];
+            $data['stockTurnoverRatio'] = (float) $data['stockTurnoverRatio'];
         }
         if (\array_key_exists('debtorDays', $data) && \is_int($data['debtorDays'])) {
-            $data['debtorDays'] = (double) $data['debtorDays'];
+            $data['debtorDays'] = (float) $data['debtorDays'];
         }
         if (\array_key_exists('creditorDays', $data) && \is_int($data['creditorDays'])) {
-            $data['creditorDays'] = (double) $data['creditorDays'];
+            $data['creditorDays'] = (float) $data['creditorDays'];
         }
         if (\array_key_exists('currentRatio', $data) && \is_int($data['currentRatio'])) {
-            $data['currentRatio'] = (double) $data['currentRatio'];
+            $data['currentRatio'] = (float) $data['currentRatio'];
         }
         if (\array_key_exists('liquidityRatioOrAcidTest', $data) && \is_int($data['liquidityRatioOrAcidTest'])) {
-            $data['liquidityRatioOrAcidTest'] = (double) $data['liquidityRatioOrAcidTest'];
+            $data['liquidityRatioOrAcidTest'] = (float) $data['liquidityRatioOrAcidTest'];
         }
         if (\array_key_exists('currentDebtRatio', $data) && \is_int($data['currentDebtRatio'])) {
-            $data['currentDebtRatio'] = (double) $data['currentDebtRatio'];
+            $data['currentDebtRatio'] = (float) $data['currentDebtRatio'];
         }
         if (\array_key_exists('gearing', $data) && \is_int($data['gearing'])) {
-            $data['gearing'] = (double) $data['gearing'];
+            $data['gearing'] = (float) $data['gearing'];
         }
         if (\array_key_exists('equityInPercentage', $data) && \is_int($data['equityInPercentage'])) {
-            $data['equityInPercentage'] = (double) $data['equityInPercentage'];
+            $data['equityInPercentage'] = (float) $data['equityInPercentage'];
         }
         if (\array_key_exists('totalDebtRatio', $data) && \is_int($data['totalDebtRatio'])) {
-            $data['totalDebtRatio'] = (double) $data['totalDebtRatio'];
+            $data['totalDebtRatio'] = (float) $data['totalDebtRatio'];
         }
         if (\array_key_exists('preTaxProfitMargin', $data)) {
             $object->setPreTaxProfitMargin($data['preTaxProfitMargin']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemBalanceSheetNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemBalanceSheetNormalizer.php
@@ -38,76 +38,76 @@ class GbCompanyReportExampleResponseReportLocalFinancialStatementsItemBalanceShe
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('tangibleAssets', $data) && \is_int($data['tangibleAssets'])) {
-            $data['tangibleAssets'] = (double) $data['tangibleAssets'];
+            $data['tangibleAssets'] = (float) $data['tangibleAssets'];
         }
         if (\array_key_exists('intangibleAssets', $data) && \is_int($data['intangibleAssets'])) {
-            $data['intangibleAssets'] = (double) $data['intangibleAssets'];
+            $data['intangibleAssets'] = (float) $data['intangibleAssets'];
         }
         if (\array_key_exists('totalFixedAssets', $data) && \is_int($data['totalFixedAssets'])) {
-            $data['totalFixedAssets'] = (double) $data['totalFixedAssets'];
+            $data['totalFixedAssets'] = (float) $data['totalFixedAssets'];
         }
         if (\array_key_exists('stock', $data) && \is_int($data['stock'])) {
-            $data['stock'] = (double) $data['stock'];
+            $data['stock'] = (float) $data['stock'];
         }
         if (\array_key_exists('tradeDebtors', $data) && \is_int($data['tradeDebtors'])) {
-            $data['tradeDebtors'] = (double) $data['tradeDebtors'];
+            $data['tradeDebtors'] = (float) $data['tradeDebtors'];
         }
         if (\array_key_exists('otherDebtors', $data) && \is_int($data['otherDebtors'])) {
-            $data['otherDebtors'] = (double) $data['otherDebtors'];
+            $data['otherDebtors'] = (float) $data['otherDebtors'];
         }
         if (\array_key_exists('cash', $data) && \is_int($data['cash'])) {
-            $data['cash'] = (double) $data['cash'];
+            $data['cash'] = (float) $data['cash'];
         }
         if (\array_key_exists('miscCurrentAssets', $data) && \is_int($data['miscCurrentAssets'])) {
-            $data['miscCurrentAssets'] = (double) $data['miscCurrentAssets'];
+            $data['miscCurrentAssets'] = (float) $data['miscCurrentAssets'];
         }
         if (\array_key_exists('totalCurrentAssets', $data) && \is_int($data['totalCurrentAssets'])) {
-            $data['totalCurrentAssets'] = (double) $data['totalCurrentAssets'];
+            $data['totalCurrentAssets'] = (float) $data['totalCurrentAssets'];
         }
         if (\array_key_exists('totalAssets', $data) && \is_int($data['totalAssets'])) {
-            $data['totalAssets'] = (double) $data['totalAssets'];
+            $data['totalAssets'] = (float) $data['totalAssets'];
         }
         if (\array_key_exists('tradeCreditors', $data) && \is_int($data['tradeCreditors'])) {
-            $data['tradeCreditors'] = (double) $data['tradeCreditors'];
+            $data['tradeCreditors'] = (float) $data['tradeCreditors'];
         }
         if (\array_key_exists('bankBorrowingsCurrent', $data) && \is_int($data['bankBorrowingsCurrent'])) {
-            $data['bankBorrowingsCurrent'] = (double) $data['bankBorrowingsCurrent'];
+            $data['bankBorrowingsCurrent'] = (float) $data['bankBorrowingsCurrent'];
         }
         if (\array_key_exists('otherShortTermFinance', $data) && \is_int($data['otherShortTermFinance'])) {
-            $data['otherShortTermFinance'] = (double) $data['otherShortTermFinance'];
+            $data['otherShortTermFinance'] = (float) $data['otherShortTermFinance'];
         }
         if (\array_key_exists('miscCurrentLiabilities', $data) && \is_int($data['miscCurrentLiabilities'])) {
-            $data['miscCurrentLiabilities'] = (double) $data['miscCurrentLiabilities'];
+            $data['miscCurrentLiabilities'] = (float) $data['miscCurrentLiabilities'];
         }
         if (\array_key_exists('totalCurrentLiabilities', $data) && \is_int($data['totalCurrentLiabilities'])) {
-            $data['totalCurrentLiabilities'] = (double) $data['totalCurrentLiabilities'];
+            $data['totalCurrentLiabilities'] = (float) $data['totalCurrentLiabilities'];
         }
         if (\array_key_exists('otherLongTermFinance', $data) && \is_int($data['otherLongTermFinance'])) {
-            $data['otherLongTermFinance'] = (double) $data['otherLongTermFinance'];
+            $data['otherLongTermFinance'] = (float) $data['otherLongTermFinance'];
         }
         if (\array_key_exists('totalLongTermLiabilities', $data) && \is_int($data['totalLongTermLiabilities'])) {
-            $data['totalLongTermLiabilities'] = (double) $data['totalLongTermLiabilities'];
+            $data['totalLongTermLiabilities'] = (float) $data['totalLongTermLiabilities'];
         }
         if (\array_key_exists('totalLiabilities', $data) && \is_int($data['totalLiabilities'])) {
-            $data['totalLiabilities'] = (double) $data['totalLiabilities'];
+            $data['totalLiabilities'] = (float) $data['totalLiabilities'];
         }
         if (\array_key_exists('netAssets', $data) && \is_int($data['netAssets'])) {
-            $data['netAssets'] = (double) $data['netAssets'];
+            $data['netAssets'] = (float) $data['netAssets'];
         }
         if (\array_key_exists('issuedShareCapital', $data) && \is_int($data['issuedShareCapital'])) {
-            $data['issuedShareCapital'] = (double) $data['issuedShareCapital'];
+            $data['issuedShareCapital'] = (float) $data['issuedShareCapital'];
         }
         if (\array_key_exists('revaluationReserve', $data) && \is_int($data['revaluationReserve'])) {
-            $data['revaluationReserve'] = (double) $data['revaluationReserve'];
+            $data['revaluationReserve'] = (float) $data['revaluationReserve'];
         }
         if (\array_key_exists('revenueReserves', $data) && \is_int($data['revenueReserves'])) {
-            $data['revenueReserves'] = (double) $data['revenueReserves'];
+            $data['revenueReserves'] = (float) $data['revenueReserves'];
         }
         if (\array_key_exists('otherReserves', $data) && \is_int($data['otherReserves'])) {
-            $data['otherReserves'] = (double) $data['otherReserves'];
+            $data['otherReserves'] = (float) $data['otherReserves'];
         }
         if (\array_key_exists('totalShareholdersEquity', $data) && \is_int($data['totalShareholdersEquity'])) {
-            $data['totalShareholdersEquity'] = (double) $data['totalShareholdersEquity'];
+            $data['totalShareholdersEquity'] = (float) $data['totalShareholdersEquity'];
         }
         if (\array_key_exists('tangibleAssets', $data)) {
             $object->setTangibleAssets($data['tangibleAssets']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemCashFlowNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemCashFlowNormalizer.php
@@ -38,16 +38,16 @@ class GbCompanyReportExampleResponseReportLocalFinancialStatementsItemCashFlowNo
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('netCashFlowFromOperations', $data) && \is_int($data['netCashFlowFromOperations'])) {
-            $data['netCashFlowFromOperations'] = (double) $data['netCashFlowFromOperations'];
+            $data['netCashFlowFromOperations'] = (float) $data['netCashFlowFromOperations'];
         }
         if (\array_key_exists('netCashFlowBeforeFinancing', $data) && \is_int($data['netCashFlowBeforeFinancing'])) {
-            $data['netCashFlowBeforeFinancing'] = (double) $data['netCashFlowBeforeFinancing'];
+            $data['netCashFlowBeforeFinancing'] = (float) $data['netCashFlowBeforeFinancing'];
         }
         if (\array_key_exists('netCashFlowFromFinancing', $data) && \is_int($data['netCashFlowFromFinancing'])) {
-            $data['netCashFlowFromFinancing'] = (double) $data['netCashFlowFromFinancing'];
+            $data['netCashFlowFromFinancing'] = (float) $data['netCashFlowFromFinancing'];
         }
         if (\array_key_exists('increaseInCash', $data) && \is_int($data['increaseInCash'])) {
-            $data['increaseInCash'] = (double) $data['increaseInCash'];
+            $data['increaseInCash'] = (float) $data['increaseInCash'];
         }
         if (\array_key_exists('netCashFlowFromOperations', $data)) {
             $object->setNetCashFlowFromOperations($data['netCashFlowFromOperations']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportLocalFinancialStatementsItemNormalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('numberOfWeeks', $data) && \is_int($data['numberOfWeeks'])) {
-            $data['numberOfWeeks'] = (double) $data['numberOfWeeks'];
+            $data['numberOfWeeks'] = (float) $data['numberOfWeeks'];
         }
         if (\array_key_exists('consolidatedAccounts', $data) && \is_int($data['consolidatedAccounts'])) {
             $data['consolidatedAccounts'] = (bool) $data['consolidatedAccounts'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemOtherFinancialsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemOtherFinancialsNormalizer.php
@@ -38,16 +38,16 @@ class GbCompanyReportExampleResponseReportLocalFinancialStatementsItemOtherFinan
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('bankOverdraftAndLTL', $data) && \is_int($data['bankOverdraftAndLTL'])) {
-            $data['bankOverdraftAndLTL'] = (double) $data['bankOverdraftAndLTL'];
+            $data['bankOverdraftAndLTL'] = (float) $data['bankOverdraftAndLTL'];
         }
         if (\array_key_exists('workingCapital', $data) && \is_int($data['workingCapital'])) {
-            $data['workingCapital'] = (double) $data['workingCapital'];
+            $data['workingCapital'] = (float) $data['workingCapital'];
         }
         if (\array_key_exists('capitalEmployed', $data) && \is_int($data['capitalEmployed'])) {
-            $data['capitalEmployed'] = (double) $data['capitalEmployed'];
+            $data['capitalEmployed'] = (float) $data['capitalEmployed'];
         }
         if (\array_key_exists('netWorth', $data) && \is_int($data['netWorth'])) {
-            $data['netWorth'] = (double) $data['netWorth'];
+            $data['netWorth'] = (float) $data['netWorth'];
         }
         if (\array_key_exists('contingentLiabilities', $data) && \is_int($data['contingentLiabilities'])) {
             $data['contingentLiabilities'] = (bool) $data['contingentLiabilities'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemProfitAndLossNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemProfitAndLossNormalizer.php
@@ -38,46 +38,46 @@ class GbCompanyReportExampleResponseReportLocalFinancialStatementsItemProfitAndL
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('turnover', $data) && \is_int($data['turnover'])) {
-            $data['turnover'] = (double) $data['turnover'];
+            $data['turnover'] = (float) $data['turnover'];
         }
         if (\array_key_exists('costOfSales', $data) && \is_int($data['costOfSales'])) {
-            $data['costOfSales'] = (double) $data['costOfSales'];
+            $data['costOfSales'] = (float) $data['costOfSales'];
         }
         if (\array_key_exists('grossProfit', $data) && \is_int($data['grossProfit'])) {
-            $data['grossProfit'] = (double) $data['grossProfit'];
+            $data['grossProfit'] = (float) $data['grossProfit'];
         }
         if (\array_key_exists('depreciation', $data) && \is_int($data['depreciation'])) {
-            $data['depreciation'] = (double) $data['depreciation'];
+            $data['depreciation'] = (float) $data['depreciation'];
         }
         if (\array_key_exists('auditFees', $data) && \is_int($data['auditFees'])) {
-            $data['auditFees'] = (double) $data['auditFees'];
+            $data['auditFees'] = (float) $data['auditFees'];
         }
         if (\array_key_exists('wagesAndSalaries', $data) && \is_int($data['wagesAndSalaries'])) {
-            $data['wagesAndSalaries'] = (double) $data['wagesAndSalaries'];
+            $data['wagesAndSalaries'] = (float) $data['wagesAndSalaries'];
         }
         if (\array_key_exists('directorsRemuneration', $data) && \is_int($data['directorsRemuneration'])) {
-            $data['directorsRemuneration'] = (double) $data['directorsRemuneration'];
+            $data['directorsRemuneration'] = (float) $data['directorsRemuneration'];
         }
         if (\array_key_exists('operatingProfit', $data) && \is_int($data['operatingProfit'])) {
-            $data['operatingProfit'] = (double) $data['operatingProfit'];
+            $data['operatingProfit'] = (float) $data['operatingProfit'];
         }
         if (\array_key_exists('interestExpense', $data) && \is_int($data['interestExpense'])) {
-            $data['interestExpense'] = (double) $data['interestExpense'];
+            $data['interestExpense'] = (float) $data['interestExpense'];
         }
         if (\array_key_exists('profitBeforeTax', $data) && \is_int($data['profitBeforeTax'])) {
-            $data['profitBeforeTax'] = (double) $data['profitBeforeTax'];
+            $data['profitBeforeTax'] = (float) $data['profitBeforeTax'];
         }
         if (\array_key_exists('taxation', $data) && \is_int($data['taxation'])) {
-            $data['taxation'] = (double) $data['taxation'];
+            $data['taxation'] = (float) $data['taxation'];
         }
         if (\array_key_exists('profitAfterTax', $data) && \is_int($data['profitAfterTax'])) {
-            $data['profitAfterTax'] = (double) $data['profitAfterTax'];
+            $data['profitAfterTax'] = (float) $data['profitAfterTax'];
         }
         if (\array_key_exists('dividends', $data) && \is_int($data['dividends'])) {
-            $data['dividends'] = (double) $data['dividends'];
+            $data['dividends'] = (float) $data['dividends'];
         }
         if (\array_key_exists('retainedProfit', $data) && \is_int($data['retainedProfit'])) {
-            $data['retainedProfit'] = (double) $data['retainedProfit'];
+            $data['retainedProfit'] = (float) $data['retainedProfit'];
         }
         if (\array_key_exists('turnover', $data)) {
             $object->setTurnover($data['turnover']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemRatiosNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportLocalFinancialStatementsItemRatiosNormalizer.php
@@ -38,46 +38,46 @@ class GbCompanyReportExampleResponseReportLocalFinancialStatementsItemRatiosNorm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('preTaxProfitMargin', $data) && \is_int($data['preTaxProfitMargin'])) {
-            $data['preTaxProfitMargin'] = (double) $data['preTaxProfitMargin'];
+            $data['preTaxProfitMargin'] = (float) $data['preTaxProfitMargin'];
         }
         if (\array_key_exists('returnOnCapitalEmployed', $data) && \is_int($data['returnOnCapitalEmployed'])) {
-            $data['returnOnCapitalEmployed'] = (double) $data['returnOnCapitalEmployed'];
+            $data['returnOnCapitalEmployed'] = (float) $data['returnOnCapitalEmployed'];
         }
         if (\array_key_exists('returnOnTotalAssetsEmployed', $data) && \is_int($data['returnOnTotalAssetsEmployed'])) {
-            $data['returnOnTotalAssetsEmployed'] = (double) $data['returnOnTotalAssetsEmployed'];
+            $data['returnOnTotalAssetsEmployed'] = (float) $data['returnOnTotalAssetsEmployed'];
         }
         if (\array_key_exists('returnOnNetAssetsEmployed', $data) && \is_int($data['returnOnNetAssetsEmployed'])) {
-            $data['returnOnNetAssetsEmployed'] = (double) $data['returnOnNetAssetsEmployed'];
+            $data['returnOnNetAssetsEmployed'] = (float) $data['returnOnNetAssetsEmployed'];
         }
         if (\array_key_exists('salesOrNetWorkingCapital', $data) && \is_int($data['salesOrNetWorkingCapital'])) {
-            $data['salesOrNetWorkingCapital'] = (double) $data['salesOrNetWorkingCapital'];
+            $data['salesOrNetWorkingCapital'] = (float) $data['salesOrNetWorkingCapital'];
         }
         if (\array_key_exists('stocKTurnoverRatio', $data) && \is_int($data['stocKTurnoverRatio'])) {
-            $data['stocKTurnoverRatio'] = (double) $data['stocKTurnoverRatio'];
+            $data['stocKTurnoverRatio'] = (float) $data['stocKTurnoverRatio'];
         }
         if (\array_key_exists('debtorDays', $data) && \is_int($data['debtorDays'])) {
-            $data['debtorDays'] = (double) $data['debtorDays'];
+            $data['debtorDays'] = (float) $data['debtorDays'];
         }
         if (\array_key_exists('creditorDays', $data) && \is_int($data['creditorDays'])) {
-            $data['creditorDays'] = (double) $data['creditorDays'];
+            $data['creditorDays'] = (float) $data['creditorDays'];
         }
         if (\array_key_exists('currentRatio', $data) && \is_int($data['currentRatio'])) {
-            $data['currentRatio'] = (double) $data['currentRatio'];
+            $data['currentRatio'] = (float) $data['currentRatio'];
         }
         if (\array_key_exists('liquidityRatioOrAcidTest', $data) && \is_int($data['liquidityRatioOrAcidTest'])) {
-            $data['liquidityRatioOrAcidTest'] = (double) $data['liquidityRatioOrAcidTest'];
+            $data['liquidityRatioOrAcidTest'] = (float) $data['liquidityRatioOrAcidTest'];
         }
         if (\array_key_exists('currentDebtRatio', $data) && \is_int($data['currentDebtRatio'])) {
-            $data['currentDebtRatio'] = (double) $data['currentDebtRatio'];
+            $data['currentDebtRatio'] = (float) $data['currentDebtRatio'];
         }
         if (\array_key_exists('gearing', $data) && \is_int($data['gearing'])) {
-            $data['gearing'] = (double) $data['gearing'];
+            $data['gearing'] = (float) $data['gearing'];
         }
         if (\array_key_exists('equityInPercentage', $data) && \is_int($data['equityInPercentage'])) {
-            $data['equityInPercentage'] = (double) $data['equityInPercentage'];
+            $data['equityInPercentage'] = (float) $data['equityInPercentage'];
         }
         if (\array_key_exists('totalDebtRatio', $data) && \is_int($data['totalDebtRatio'])) {
-            $data['totalDebtRatio'] = (double) $data['totalDebtRatio'];
+            $data['totalDebtRatio'] = (float) $data['totalDebtRatio'];
         }
         if (\array_key_exists('preTaxProfitMargin', $data)) {
             $object->setPreTaxProfitMargin($data['preTaxProfitMargin']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportNegativeInformationCcjSummaryNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportNegativeInformationCcjSummaryNormalizer.php
@@ -38,10 +38,10 @@ class GbCompanyReportExampleResponseReportNegativeInformationCcjSummaryNormalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('exactRegistered', $data) && \is_int($data['exactRegistered'])) {
-            $data['exactRegistered'] = (double) $data['exactRegistered'];
+            $data['exactRegistered'] = (float) $data['exactRegistered'];
         }
         if (\array_key_exists('possibleRegistered', $data) && \is_int($data['possibleRegistered'])) {
-            $data['possibleRegistered'] = (double) $data['possibleRegistered'];
+            $data['possibleRegistered'] = (float) $data['possibleRegistered'];
         }
         if (\array_key_exists('exactRegistered', $data)) {
             $object->setExactRegistered($data['exactRegistered']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportNegativeInformationCountyCourtJudgementsRegisteredExactItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportNegativeInformationCountyCourtJudgementsRegisteredExactItemNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportNegativeInformationCountyCourtJudgemen
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('ccjAmount', $data) && \is_int($data['ccjAmount'])) {
-            $data['ccjAmount'] = (double) $data['ccjAmount'];
+            $data['ccjAmount'] = (float) $data['ccjAmount'];
         }
         if (\array_key_exists('ccjDate', $data)) {
             $object->setCcjDate($data['ccjDate']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportNegativeInformationCountyCourtJudgementsRegisteredPossibleItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportNegativeInformationCountyCourtJudgementsRegisteredPossibleItemNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportNegativeInformationCountyCourtJudgemen
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('ccjAmount', $data) && \is_int($data['ccjAmount'])) {
-            $data['ccjAmount'] = (double) $data['ccjAmount'];
+            $data['ccjAmount'] = (float) $data['ccjAmount'];
         }
         if (\array_key_exists('ccjDate', $data)) {
             $object->setCcjDate($data['ccjDate']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportOtherInformationEmployeesInformationItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportOtherInformationEmployeesInformationItemNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportOtherInformationEmployeesInformationIt
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('year', $data) && \is_int($data['year'])) {
-            $data['year'] = (double) $data['year'];
+            $data['year'] = (float) $data['year'];
         }
         if (\array_key_exists('year', $data)) {
             $object->setYear($data['year']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportPaymentDataNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportPaymentDataNormalizer.php
@@ -38,73 +38,73 @@ class GbCompanyReportExampleResponseReportPaymentDataNormalizer implements Denor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('paymentsOnFile', $data) && \is_int($data['paymentsOnFile'])) {
-            $data['paymentsOnFile'] = (double) $data['paymentsOnFile'];
+            $data['paymentsOnFile'] = (float) $data['paymentsOnFile'];
         }
         if (\array_key_exists('paymentsOnTime', $data) && \is_int($data['paymentsOnTime'])) {
-            $data['paymentsOnTime'] = (double) $data['paymentsOnTime'];
+            $data['paymentsOnTime'] = (float) $data['paymentsOnTime'];
         }
         if (\array_key_exists('paymentsPaidLate', $data) && \is_int($data['paymentsPaidLate'])) {
-            $data['paymentsPaidLate'] = (double) $data['paymentsPaidLate'];
+            $data['paymentsPaidLate'] = (float) $data['paymentsPaidLate'];
         }
         if (\array_key_exists('paymentsSentLegal', $data) && \is_int($data['paymentsSentLegal'])) {
-            $data['paymentsSentLegal'] = (double) $data['paymentsSentLegal'];
+            $data['paymentsSentLegal'] = (float) $data['paymentsSentLegal'];
         }
         if (\array_key_exists('paymentsStillOwingLate', $data) && \is_int($data['paymentsStillOwingLate'])) {
-            $data['paymentsStillOwingLate'] = (double) $data['paymentsStillOwingLate'];
+            $data['paymentsStillOwingLate'] = (float) $data['paymentsStillOwingLate'];
         }
         if (\array_key_exists('paymentsPaid0to30Days', $data) && \is_int($data['paymentsPaid0to30Days'])) {
-            $data['paymentsPaid0to30Days'] = (double) $data['paymentsPaid0to30Days'];
+            $data['paymentsPaid0to30Days'] = (float) $data['paymentsPaid0to30Days'];
         }
         if (\array_key_exists('highestInvoiceValueOutstandingLate', $data) && \is_int($data['highestInvoiceValueOutstandingLate'])) {
-            $data['highestInvoiceValueOutstandingLate'] = (double) $data['highestInvoiceValueOutstandingLate'];
+            $data['highestInvoiceValueOutstandingLate'] = (float) $data['highestInvoiceValueOutstandingLate'];
         }
         if (\array_key_exists('paymentsPaid90DaysplusLate', $data) && \is_int($data['paymentsPaid90DaysplusLate'])) {
-            $data['paymentsPaid90DaysplusLate'] = (double) $data['paymentsPaid90DaysplusLate'];
+            $data['paymentsPaid90DaysplusLate'] = (float) $data['paymentsPaid90DaysplusLate'];
         }
         if (\array_key_exists('totalBalanceStillOwingLate', $data) && \is_int($data['totalBalanceStillOwingLate'])) {
-            $data['totalBalanceStillOwingLate'] = (double) $data['totalBalanceStillOwingLate'];
+            $data['totalBalanceStillOwingLate'] = (float) $data['totalBalanceStillOwingLate'];
         }
         if (\array_key_exists('dbt', $data) && \is_int($data['dbt'])) {
-            $data['dbt'] = (double) $data['dbt'];
+            $data['dbt'] = (float) $data['dbt'];
         }
         if (\array_key_exists('paymentsPaid61to90Days', $data) && \is_int($data['paymentsPaid61to90Days'])) {
-            $data['paymentsPaid61to90Days'] = (double) $data['paymentsPaid61to90Days'];
+            $data['paymentsPaid61to90Days'] = (float) $data['paymentsPaid61to90Days'];
         }
         if (\array_key_exists('totalBalanceStillOwing', $data) && \is_int($data['totalBalanceStillOwing'])) {
-            $data['totalBalanceStillOwing'] = (double) $data['totalBalanceStillOwing'];
+            $data['totalBalanceStillOwing'] = (float) $data['totalBalanceStillOwing'];
         }
         if (\array_key_exists('payments31to60DaysLate', $data) && \is_int($data['payments31to60DaysLate'])) {
-            $data['payments31to60DaysLate'] = (double) $data['payments31to60DaysLate'];
+            $data['payments31to60DaysLate'] = (float) $data['payments31to60DaysLate'];
         }
         if (\array_key_exists('payments61to90DaysLate', $data) && \is_int($data['payments61to90DaysLate'])) {
-            $data['payments61to90DaysLate'] = (double) $data['payments61to90DaysLate'];
+            $data['payments61to90DaysLate'] = (float) $data['payments61to90DaysLate'];
         }
         if (\array_key_exists('highestInvoiceValueOutstanding', $data) && \is_int($data['highestInvoiceValueOutstanding'])) {
-            $data['highestInvoiceValueOutstanding'] = (double) $data['highestInvoiceValueOutstanding'];
+            $data['highestInvoiceValueOutstanding'] = (float) $data['highestInvoiceValueOutstanding'];
         }
         if (\array_key_exists('paymentsStillOwing', $data) && \is_int($data['paymentsStillOwing'])) {
-            $data['paymentsStillOwing'] = (double) $data['paymentsStillOwing'];
+            $data['paymentsStillOwing'] = (float) $data['paymentsStillOwing'];
         }
         if (\array_key_exists('paymentsWithinTerms', $data) && \is_int($data['paymentsWithinTerms'])) {
-            $data['paymentsWithinTerms'] = (double) $data['paymentsWithinTerms'];
+            $data['paymentsWithinTerms'] = (float) $data['paymentsWithinTerms'];
         }
         if (\array_key_exists('payments0to30Dayslate', $data) && \is_int($data['payments0to30Dayslate'])) {
-            $data['payments0to30Dayslate'] = (double) $data['payments0to30Dayslate'];
+            $data['payments0to30Dayslate'] = (float) $data['payments0to30Dayslate'];
         }
         if (\array_key_exists('averageInvoiceValue', $data) && \is_int($data['averageInvoiceValue'])) {
-            $data['averageInvoiceValue'] = (double) $data['averageInvoiceValue'];
+            $data['averageInvoiceValue'] = (float) $data['averageInvoiceValue'];
         }
         if (\array_key_exists('paymentsPaid31to60Days', $data) && \is_int($data['paymentsPaid31to60Days'])) {
-            $data['paymentsPaid31to60Days'] = (double) $data['paymentsPaid31to60Days'];
+            $data['paymentsPaid31to60Days'] = (float) $data['paymentsPaid31to60Days'];
         }
         if (\array_key_exists('paymentsPaid90Daysplus', $data) && \is_int($data['paymentsPaid90Daysplus'])) {
-            $data['paymentsPaid90Daysplus'] = (double) $data['paymentsPaid90Daysplus'];
+            $data['paymentsPaid90Daysplus'] = (float) $data['paymentsPaid90Daysplus'];
         }
         if (\array_key_exists('totalInvoiceValues', $data) && \is_int($data['totalInvoiceValues'])) {
-            $data['totalInvoiceValues'] = (double) $data['totalInvoiceValues'];
+            $data['totalInvoiceValues'] = (float) $data['totalInvoiceValues'];
         }
         if (\array_key_exists('industryDBT', $data) && \is_int($data['industryDBT'])) {
-            $data['industryDBT'] = (double) $data['industryDBT'];
+            $data['industryDBT'] = (float) $data['industryDBT'];
         }
         if (\array_key_exists('paymentsOnFile', $data)) {
             $object->setPaymentsOnFile($data['paymentsOnFile']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportShareCapitalStructureIssuedShareCapitalNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportShareCapitalStructureIssuedShareCapitalNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportShareCapitalStructureIssuedShareCapita
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportShareCapitalStructureNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportShareCapitalStructureNormalizer.php
@@ -38,7 +38,7 @@ class GbCompanyReportExampleResponseReportShareCapitalStructureNormalizer implem
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('numberOfSharesIssued', $data) && \is_int($data['numberOfSharesIssued'])) {
-            $data['numberOfSharesIssued'] = (double) $data['numberOfSharesIssued'];
+            $data['numberOfSharesIssued'] = (float) $data['numberOfSharesIssued'];
         }
         if (\array_key_exists('issuedShareCapital', $data)) {
             $object->setIssuedShareCapital($this->denormalizer->denormalize($data['issuedShareCapital'], \CreditSafe\API\Model\GbCompanyReportExampleResponseReportShareCapitalStructureIssuedShareCapital::class, 'json', $context));

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportShareCapitalStructureShareHoldersItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbCompanyReportExampleResponseReportShareCapitalStructureShareHoldersItemNormalizer.php
@@ -38,10 +38,10 @@ class GbCompanyReportExampleResponseReportShareCapitalStructureShareHoldersItemN
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('totalNumberOfSharesOwned', $data) && \is_int($data['totalNumberOfSharesOwned'])) {
-            $data['totalNumberOfSharesOwned'] = (double) $data['totalNumberOfSharesOwned'];
+            $data['totalNumberOfSharesOwned'] = (float) $data['totalNumberOfSharesOwned'];
         }
         if (\array_key_exists('percentSharesHeld', $data) && \is_int($data['percentSharesHeld'])) {
-            $data['percentSharesHeld'] = (double) $data['percentSharesHeld'];
+            $data['percentSharesHeld'] = (float) $data['percentSharesHeld'];
         }
         if (\array_key_exists('name', $data)) {
             $object->setName($data['name']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsCurrentItemAdditionalDataNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsCurrentItemAdditionalDataNormalizer.php
@@ -38,7 +38,7 @@ class GbPeopleReportReponseReportDirectorshipsCurrentItemAdditionalDataNormalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('gearing', $data) && \is_int($data['gearing'])) {
-            $data['gearing'] = (double) $data['gearing'];
+            $data['gearing'] = (float) $data['gearing'];
         }
         if (\array_key_exists('occupation', $data)) {
             $object->setOccupation($data['occupation']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsCurrentItemLatestTurnoverFigureNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsCurrentItemLatestTurnoverFigureNormalizer.php
@@ -38,7 +38,7 @@ class GbPeopleReportReponseReportDirectorshipsCurrentItemLatestTurnoverFigureNor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsCurrentItemLegalAmountNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsCurrentItemLegalAmountNormalizer.php
@@ -38,7 +38,7 @@ class GbPeopleReportReponseReportDirectorshipsCurrentItemLegalAmountNormalizer i
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsCurrentItemNetWorthNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsCurrentItemNetWorthNormalizer.php
@@ -38,7 +38,7 @@ class GbPeopleReportReponseReportDirectorshipsCurrentItemNetWorthNormalizer impl
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsInactiveItemAdditionalDataNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsInactiveItemAdditionalDataNormalizer.php
@@ -38,7 +38,7 @@ class GbPeopleReportReponseReportDirectorshipsInactiveItemAdditionalDataNormaliz
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('gearing', $data) && \is_int($data['gearing'])) {
-            $data['gearing'] = (double) $data['gearing'];
+            $data['gearing'] = (float) $data['gearing'];
         }
         if (\array_key_exists('occupation', $data)) {
             $object->setOccupation($data['occupation']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsInactiveItemNetWorthNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsInactiveItemNetWorthNormalizer.php
@@ -38,7 +38,7 @@ class GbPeopleReportReponseReportDirectorshipsInactiveItemNetWorthNormalizer imp
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsPreviousItemAdditionalDataNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsPreviousItemAdditionalDataNormalizer.php
@@ -38,7 +38,7 @@ class GbPeopleReportReponseReportDirectorshipsPreviousItemAdditionalDataNormaliz
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('gearing', $data) && \is_int($data['gearing'])) {
-            $data['gearing'] = (double) $data['gearing'];
+            $data['gearing'] = (float) $data['gearing'];
         }
         if (\array_key_exists('occupation', $data)) {
             $object->setOccupation($data['occupation']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsPreviousItemLatestTurnoverFigureNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsPreviousItemLatestTurnoverFigureNormalizer.php
@@ -38,7 +38,7 @@ class GbPeopleReportReponseReportDirectorshipsPreviousItemLatestTurnoverFigureNo
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsPreviousItemNetWorthNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/GbPeopleReportReponseReportDirectorshipsPreviousItemNetWorthNormalizer.php
@@ -38,7 +38,7 @@ class GbPeopleReportReponseReportDirectorshipsPreviousItemNetWorthNormalizer imp
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('currency', $data)) {
             $object->setCurrency($data['currency']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/NotificationEventNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/NotificationEventNormalizer.php
@@ -38,13 +38,13 @@ class NotificationEventNormalizer implements DenormalizerInterface, NormalizerIn
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('eventId', $data) && \is_int($data['eventId'])) {
-            $data['eventId'] = (double) $data['eventId'];
+            $data['eventId'] = (float) $data['eventId'];
         }
         if (\array_key_exists('notificationEventId', $data) && \is_int($data['notificationEventId'])) {
-            $data['notificationEventId'] = (double) $data['notificationEventId'];
+            $data['notificationEventId'] = (float) $data['notificationEventId'];
         }
         if (\array_key_exists('ruleCode', $data) && \is_int($data['ruleCode'])) {
-            $data['ruleCode'] = (double) $data['ruleCode'];
+            $data['ruleCode'] = (float) $data['ruleCode'];
         }
         if (\array_key_exists('company', $data)) {
             $object->setCompany($this->denormalizer->denormalize($data['company'], \CreditSafe\API\Model\Company::class, 'json', $context));

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/NotificationEventsResponseNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/NotificationEventsResponseNormalizer.php
@@ -38,7 +38,7 @@ class NotificationEventsResponseNormalizer implements DenormalizerInterface, Nor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('totalCount', $data) && \is_int($data['totalCount'])) {
-            $data['totalCount'] = (double) $data['totalCount'];
+            $data['totalCount'] = (float) $data['totalCount'];
         }
         if (\array_key_exists('totalCount', $data)) {
             $object->setTotalCount($data['totalCount']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/PagingNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/PagingNormalizer.php
@@ -38,16 +38,16 @@ class PagingNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('size', $data) && \is_int($data['size'])) {
-            $data['size'] = (double) $data['size'];
+            $data['size'] = (float) $data['size'];
         }
         if (\array_key_exists('prev', $data) && \is_int($data['prev'])) {
-            $data['prev'] = (double) $data['prev'];
+            $data['prev'] = (float) $data['prev'];
         }
         if (\array_key_exists('next', $data) && \is_int($data['next'])) {
-            $data['next'] = (double) $data['next'];
+            $data['next'] = (float) $data['next'];
         }
         if (\array_key_exists('last', $data) && \is_int($data['last'])) {
-            $data['last'] = (double) $data['last'];
+            $data['last'] = (float) $data['last'];
         }
         if (\array_key_exists('size', $data)) {
             $object->setSize($data['size']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/SearchNoResultsErrorNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/SearchNoResultsErrorNormalizer.php
@@ -38,7 +38,7 @@ class SearchNoResultsErrorNormalizer implements DenormalizerInterface, Normalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('totalSize', $data) && \is_int($data['totalSize'])) {
-            $data['totalSize'] = (double) $data['totalSize'];
+            $data['totalSize'] = (float) $data['totalSize'];
         }
         if (\array_key_exists('totalSize', $data)) {
             $object->setTotalSize($data['totalSize']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/UserDetailsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Normalizer/UserDetailsNormalizer.php
@@ -38,13 +38,13 @@ class UserDetailsNormalizer implements DenormalizerInterface, NormalizerInterfac
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('csCustomerId', $data) && \is_int($data['csCustomerId'])) {
-            $data['csCustomerId'] = (double) $data['csCustomerId'];
+            $data['csCustomerId'] = (float) $data['csCustomerId'];
         }
         if (\array_key_exists('csUserId', $data) && \is_int($data['csUserId'])) {
-            $data['csUserId'] = (double) $data['csUserId'];
+            $data['csUserId'] = (float) $data['csUserId'];
         }
         if (\array_key_exists('userId', $data) && \is_int($data['userId'])) {
-            $data['userId'] = (double) $data['userId'];
+            $data['userId'] = (float) $data['userId'];
         }
         if (\array_key_exists('isAutoTracker', $data) && \is_int($data['isAutoTracker'])) {
             $data['isAutoTracker'] = (bool) $data['isAutoTracker'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/AudioStreamNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/AudioStreamNormalizer.php
@@ -38,7 +38,7 @@ class AudioStreamNormalizer implements DenormalizerInterface, NormalizerInterfac
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('durationInSeconds', $data) && \is_int($data['durationInSeconds'])) {
-            $data['durationInSeconds'] = (double) $data['durationInSeconds'];
+            $data['durationInSeconds'] = (float) $data['durationInSeconds'];
         }
         if (\array_key_exists('bitRate', $data) && $data['bitRate'] !== null) {
             $object->setBitRate($data['bitRate']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/EpsMetadataNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/EpsMetadataNormalizer.php
@@ -38,10 +38,10 @@ class EpsMetadataNormalizer implements DenormalizerInterface, NormalizerInterfac
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('widthInPoints', $data) && \is_int($data['widthInPoints'])) {
-            $data['widthInPoints'] = (double) $data['widthInPoints'];
+            $data['widthInPoints'] = (float) $data['widthInPoints'];
         }
         if (\array_key_exists('heightInPoints', $data) && \is_int($data['heightInPoints'])) {
-            $data['heightInPoints'] = (double) $data['heightInPoints'];
+            $data['heightInPoints'] = (float) $data['heightInPoints'];
         }
         if (\array_key_exists('isRasterized', $data) && \is_int($data['isRasterized'])) {
             $data['isRasterized'] = (bool) $data['isRasterized'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldBooleanNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldBooleanNormalizer.php
@@ -38,7 +38,7 @@ class FieldBooleanNormalizer implements DenormalizerInterface, NormalizerInterfa
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDateNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDateNormalizer.php
@@ -38,7 +38,7 @@ class FieldDateNormalizer implements DenormalizerInterface, NormalizerInterface,
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDateTimeArrayNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDateTimeArrayNormalizer.php
@@ -38,7 +38,7 @@ class FieldDateTimeArrayNormalizer implements DenormalizerInterface, NormalizerI
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDateTimeNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDateTimeNormalizer.php
@@ -38,7 +38,7 @@ class FieldDateTimeNormalizer implements DenormalizerInterface, NormalizerInterf
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDecimalNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDecimalNormalizer.php
@@ -38,13 +38,13 @@ class FieldDecimalNormalizer implements DenormalizerInterface, NormalizerInterfa
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDictionaryArrayNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDictionaryArrayNormalizer.php
@@ -38,7 +38,7 @@ class FieldDictionaryArrayNormalizer implements DenormalizerInterface, Normalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDictionaryNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldDictionaryNormalizer.php
@@ -38,7 +38,7 @@ class FieldDictionaryNormalizer implements DenormalizerInterface, NormalizerInte
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldGeoPointNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldGeoPointNormalizer.php
@@ -38,7 +38,7 @@ class FieldGeoPointNormalizer implements DenormalizerInterface, NormalizerInterf
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldIndexingInfoNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldIndexingInfoNormalizer.php
@@ -38,7 +38,7 @@ class FieldIndexingInfoNormalizer implements DenormalizerInterface, NormalizerIn
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('index', $data) && \is_int($data['index'])) {
             $data['index'] = (bool) $data['index'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldLongArrayNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldLongArrayNormalizer.php
@@ -38,13 +38,13 @@ class FieldLongArrayNormalizer implements DenormalizerInterface, NormalizerInter
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldLongNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldLongNormalizer.php
@@ -38,13 +38,13 @@ class FieldLongNormalizer implements DenormalizerInterface, NormalizerInterface,
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('minimum', $data) && \is_int($data['minimum'])) {
-            $data['minimum'] = (double) $data['minimum'];
+            $data['minimum'] = (float) $data['minimum'];
         }
         if (\array_key_exists('maximum', $data) && \is_int($data['maximum'])) {
-            $data['maximum'] = (double) $data['maximum'];
+            $data['maximum'] = (float) $data['maximum'];
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldStringArrayNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldStringArrayNormalizer.php
@@ -38,7 +38,7 @@ class FieldStringArrayNormalizer implements DenormalizerInterface, NormalizerInt
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldStringNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldStringNormalizer.php
@@ -38,7 +38,7 @@ class FieldStringNormalizer implements DenormalizerInterface, NormalizerInterfac
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldTranslatedStringNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldTranslatedStringNormalizer.php
@@ -38,7 +38,7 @@ class FieldTranslatedStringNormalizer implements DenormalizerInterface, Normaliz
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldTriggerNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/FieldTriggerNormalizer.php
@@ -38,7 +38,7 @@ class FieldTriggerNormalizer implements DenormalizerInterface, NormalizerInterfa
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('required', $data) && \is_int($data['required'])) {
             $data['required'] = (bool) $data['required'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/GeoDistanceFilterNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/GeoDistanceFilterNormalizer.php
@@ -38,7 +38,7 @@ class GeoDistanceFilterNormalizer implements DenormalizerInterface, NormalizerIn
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('distance', $data) && \is_int($data['distance'])) {
-            $data['distance'] = (double) $data['distance'];
+            $data['distance'] = (float) $data['distance'];
         }
         if (\array_key_exists('kind', $data)) {
             $object->setKind($data['kind']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/GeoDistanceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/GeoDistanceNormalizer.php
@@ -38,7 +38,7 @@ class GeoDistanceNormalizer implements DenormalizerInterface, NormalizerInterfac
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('distance', $data) && \is_int($data['distance'])) {
-            $data['distance'] = (double) $data['distance'];
+            $data['distance'] = (float) $data['distance'];
         }
         if (\array_key_exists('names', $data) && $data['names'] !== null) {
             $object->setNames($data['names']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/GeoLocationNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/GeoLocationNormalizer.php
@@ -38,10 +38,10 @@ class GeoLocationNormalizer implements DenormalizerInterface, NormalizerInterfac
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('lat', $data) && \is_int($data['lat'])) {
-            $data['lat'] = (double) $data['lat'];
+            $data['lat'] = (float) $data['lat'];
         }
         if (\array_key_exists('lon', $data) && \is_int($data['lon'])) {
-            $data['lon'] = (double) $data['lon'];
+            $data['lon'] = (float) $data['lon'];
         }
         if (\array_key_exists('lat', $data)) {
             $object->setLat($data['lat']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/ImageFormatBaseNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/ImageFormatBaseNormalizer.php
@@ -38,10 +38,10 @@ class ImageFormatBaseNormalizer implements DenormalizerInterface, NormalizerInte
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('horizontalResolution', $data) && \is_int($data['horizontalResolution'])) {
-            $data['horizontalResolution'] = (double) $data['horizontalResolution'];
+            $data['horizontalResolution'] = (float) $data['horizontalResolution'];
         }
         if (\array_key_exists('verticalResolution', $data) && \is_int($data['verticalResolution'])) {
-            $data['verticalResolution'] = (double) $data['verticalResolution'];
+            $data['verticalResolution'] = (float) $data['verticalResolution'];
         }
         if (\array_key_exists('keepClippingPath', $data) && \is_int($data['keepClippingPath'])) {
             $data['keepClippingPath'] = (bool) $data['keepClippingPath'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/ImageMetadataNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/ImageMetadataNormalizer.php
@@ -38,22 +38,22 @@ class ImageMetadataNormalizer implements DenormalizerInterface, NormalizerInterf
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('widthInInch', $data) && \is_int($data['widthInInch'])) {
-            $data['widthInInch'] = (double) $data['widthInInch'];
+            $data['widthInInch'] = (float) $data['widthInInch'];
         }
         if (\array_key_exists('heightInInch', $data) && \is_int($data['heightInInch'])) {
-            $data['heightInInch'] = (double) $data['heightInInch'];
+            $data['heightInInch'] = (float) $data['heightInInch'];
         }
         if (\array_key_exists('widthInCm', $data) && \is_int($data['widthInCm'])) {
-            $data['widthInCm'] = (double) $data['widthInCm'];
+            $data['widthInCm'] = (float) $data['widthInCm'];
         }
         if (\array_key_exists('heightInCm', $data) && \is_int($data['heightInCm'])) {
-            $data['heightInCm'] = (double) $data['heightInCm'];
+            $data['heightInCm'] = (float) $data['heightInCm'];
         }
         if (\array_key_exists('horizontalResolution', $data) && \is_int($data['horizontalResolution'])) {
-            $data['horizontalResolution'] = (double) $data['horizontalResolution'];
+            $data['horizontalResolution'] = (float) $data['horizontalResolution'];
         }
         if (\array_key_exists('verticalResolution', $data) && \is_int($data['verticalResolution'])) {
-            $data['verticalResolution'] = (double) $data['verticalResolution'];
+            $data['verticalResolution'] = (float) $data['verticalResolution'];
         }
         if (\array_key_exists('hasAlpha', $data) && \is_int($data['hasAlpha'])) {
             $data['hasAlpha'] = (bool) $data['hasAlpha'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/IndexFieldNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/IndexFieldNormalizer.php
@@ -38,7 +38,7 @@ class IndexFieldNormalizer implements DenormalizerInterface, NormalizerInterface
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('ignoreForSearch', $data) && \is_int($data['ignoreForSearch'])) {
             $data['ignoreForSearch'] = (bool) $data['ignoreForSearch'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/IndexedFieldThresholdExceededExceptionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/IndexedFieldThresholdExceededExceptionNormalizer.php
@@ -38,7 +38,7 @@ class IndexedFieldThresholdExceededExceptionNormalizer implements DenormalizerIn
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('indexedFieldCount', $data) && \is_int($data['indexedFieldCount'])) {
-            $data['indexedFieldCount'] = (double) $data['indexedFieldCount'];
+            $data['indexedFieldCount'] = (float) $data['indexedFieldCount'];
         }
         if (\array_key_exists('traceLevel', $data)) {
             $object->setTraceLevel($data['traceLevel']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/JpegFormatNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/JpegFormatNormalizer.php
@@ -38,10 +38,10 @@ class JpegFormatNormalizer implements DenormalizerInterface, NormalizerInterface
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('horizontalResolution', $data) && \is_int($data['horizontalResolution'])) {
-            $data['horizontalResolution'] = (double) $data['horizontalResolution'];
+            $data['horizontalResolution'] = (float) $data['horizontalResolution'];
         }
         if (\array_key_exists('verticalResolution', $data) && \is_int($data['verticalResolution'])) {
-            $data['verticalResolution'] = (double) $data['verticalResolution'];
+            $data['verticalResolution'] = (float) $data['verticalResolution'];
         }
         if (\array_key_exists('keepClippingPath', $data) && \is_int($data['keepClippingPath'])) {
             $data['keepClippingPath'] = (bool) $data['keepClippingPath'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/LatLonNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/LatLonNormalizer.php
@@ -38,10 +38,10 @@ class LatLonNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('lat', $data) && \is_int($data['lat'])) {
-            $data['lat'] = (double) $data['lat'];
+            $data['lat'] = (float) $data['lat'];
         }
         if (\array_key_exists('lon', $data) && \is_int($data['lon'])) {
-            $data['lon'] = (double) $data['lon'];
+            $data['lon'] = (float) $data['lon'];
         }
         if (\array_key_exists('lat', $data)) {
             $object->setLat($data['lat']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/NumberCompareConditionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/NumberCompareConditionNormalizer.php
@@ -38,7 +38,7 @@ class NumberCompareConditionNormalizer implements DenormalizerInterface, Normali
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('traceRefId', $data) && $data['traceRefId'] !== null) {
             $object->setTraceRefId($data['traceRefId']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/NumericRangeForAggregatorNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/NumericRangeForAggregatorNormalizer.php
@@ -38,10 +38,10 @@ class NumericRangeForAggregatorNormalizer implements DenormalizerInterface, Norm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('from', $data) && \is_int($data['from'])) {
-            $data['from'] = (double) $data['from'];
+            $data['from'] = (float) $data['from'];
         }
         if (\array_key_exists('to', $data) && \is_int($data['to'])) {
-            $data['to'] = (double) $data['to'];
+            $data['to'] = (float) $data['to'];
         }
         if (\array_key_exists('names', $data) && $data['names'] !== null) {
             $object->setNames($data['names']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/NumericRangeNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/NumericRangeNormalizer.php
@@ -38,10 +38,10 @@ class NumericRangeNormalizer implements DenormalizerInterface, NormalizerInterfa
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('from', $data) && \is_int($data['from'])) {
-            $data['from'] = (double) $data['from'];
+            $data['from'] = (float) $data['from'];
         }
         if (\array_key_exists('to', $data) && \is_int($data['to'])) {
-            $data['to'] = (double) $data['to'];
+            $data['to'] = (float) $data['to'];
         }
         if (\array_key_exists('names', $data) && $data['names'] !== null) {
             $object->setNames($data['names']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/OutputDataAudioNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/OutputDataAudioNormalizer.php
@@ -38,7 +38,7 @@ class OutputDataAudioNormalizer implements DenormalizerInterface, NormalizerInte
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('durationInSeconds', $data) && \is_int($data['durationInSeconds'])) {
-            $data['durationInSeconds'] = (double) $data['durationInSeconds'];
+            $data['durationInSeconds'] = (float) $data['durationInSeconds'];
         }
         if (\array_key_exists('fileExtension', $data) && $data['fileExtension'] !== null) {
             $object->setFileExtension($data['fileExtension']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/OutputDataVideoNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/OutputDataVideoNormalizer.php
@@ -38,7 +38,7 @@ class OutputDataVideoNormalizer implements DenormalizerInterface, NormalizerInte
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('durationInSeconds', $data) && \is_int($data['durationInSeconds'])) {
-            $data['durationInSeconds'] = (double) $data['durationInSeconds'];
+            $data['durationInSeconds'] = (float) $data['durationInSeconds'];
         }
         if (\array_key_exists('fileExtension', $data) && $data['fileExtension'] !== null) {
             $object->setFileExtension($data['fileExtension']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/PngFormatNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/PngFormatNormalizer.php
@@ -38,10 +38,10 @@ class PngFormatNormalizer implements DenormalizerInterface, NormalizerInterface,
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('horizontalResolution', $data) && \is_int($data['horizontalResolution'])) {
-            $data['horizontalResolution'] = (double) $data['horizontalResolution'];
+            $data['horizontalResolution'] = (float) $data['horizontalResolution'];
         }
         if (\array_key_exists('verticalResolution', $data) && \is_int($data['verticalResolution'])) {
-            $data['verticalResolution'] = (double) $data['verticalResolution'];
+            $data['verticalResolution'] = (float) $data['verticalResolution'];
         }
         if (\array_key_exists('keepClippingPath', $data) && \is_int($data['keepClippingPath'])) {
             $data['keepClippingPath'] = (bool) $data['keepClippingPath'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/SchemaFieldInvalidBoostExceptionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/SchemaFieldInvalidBoostExceptionNormalizer.php
@@ -38,7 +38,7 @@ class SchemaFieldInvalidBoostExceptionNormalizer implements DenormalizerInterfac
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('boost', $data) && \is_int($data['boost'])) {
-            $data['boost'] = (double) $data['boost'];
+            $data['boost'] = (float) $data['boost'];
         }
         if (\array_key_exists('traceLevel', $data)) {
             $object->setTraceLevel($data['traceLevel']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/SchemaFieldNumberRangeExceptionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/SchemaFieldNumberRangeExceptionNormalizer.php
@@ -38,10 +38,10 @@ class SchemaFieldNumberRangeExceptionNormalizer implements DenormalizerInterface
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('minValue', $data) && \is_int($data['minValue'])) {
-            $data['minValue'] = (double) $data['minValue'];
+            $data['minValue'] = (float) $data['minValue'];
         }
         if (\array_key_exists('maxValue', $data) && \is_int($data['maxValue'])) {
-            $data['maxValue'] = (double) $data['maxValue'];
+            $data['maxValue'] = (float) $data['maxValue'];
         }
         if (\array_key_exists('traceLevel', $data)) {
             $object->setTraceLevel($data['traceLevel']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/SortableFieldThresholdExceededExceptionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/SortableFieldThresholdExceededExceptionNormalizer.php
@@ -38,7 +38,7 @@ class SortableFieldThresholdExceededExceptionNormalizer implements DenormalizerI
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('sortableFieldCount', $data) && \is_int($data['sortableFieldCount'])) {
-            $data['sortableFieldCount'] = (double) $data['sortableFieldCount'];
+            $data['sortableFieldCount'] = (float) $data['sortableFieldCount'];
         }
         if (\array_key_exists('traceLevel', $data)) {
             $object->setTraceLevel($data['traceLevel']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/TiffFormatNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/TiffFormatNormalizer.php
@@ -38,10 +38,10 @@ class TiffFormatNormalizer implements DenormalizerInterface, NormalizerInterface
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('horizontalResolution', $data) && \is_int($data['horizontalResolution'])) {
-            $data['horizontalResolution'] = (double) $data['horizontalResolution'];
+            $data['horizontalResolution'] = (float) $data['horizontalResolution'];
         }
         if (\array_key_exists('verticalResolution', $data) && \is_int($data['verticalResolution'])) {
-            $data['verticalResolution'] = (double) $data['verticalResolution'];
+            $data['verticalResolution'] = (float) $data['verticalResolution'];
         }
         if (\array_key_exists('keepClippingPath', $data) && \is_int($data['keepClippingPath'])) {
             $data['keepClippingPath'] = (bool) $data['keepClippingPath'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/UnsharpenMaskActionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/UnsharpenMaskActionNormalizer.php
@@ -38,13 +38,13 @@ class UnsharpenMaskActionNormalizer implements DenormalizerInterface, Normalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('amount', $data) && \is_int($data['amount'])) {
-            $data['amount'] = (double) $data['amount'];
+            $data['amount'] = (float) $data['amount'];
         }
         if (\array_key_exists('radius', $data) && \is_int($data['radius'])) {
-            $data['radius'] = (double) $data['radius'];
+            $data['radius'] = (float) $data['radius'];
         }
         if (\array_key_exists('threshold', $data) && \is_int($data['threshold'])) {
-            $data['threshold'] = (double) $data['threshold'];
+            $data['threshold'] = (float) $data['threshold'];
         }
         if (\array_key_exists('kind', $data)) {
             $object->setKind($data['kind']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/VideoMetadataNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/VideoMetadataNormalizer.php
@@ -38,7 +38,7 @@ class VideoMetadataNormalizer implements DenormalizerInterface, NormalizerInterf
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('durationInSeconds', $data) && \is_int($data['durationInSeconds'])) {
-            $data['durationInSeconds'] = (double) $data['durationInSeconds'];
+            $data['durationInSeconds'] = (float) $data['durationInSeconds'];
         }
         if (\array_key_exists('names', $data) && $data['names'] !== null) {
             $object->setNames($data['names']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/VideoStreamNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/VideoStreamNormalizer.php
@@ -38,16 +38,16 @@ class VideoStreamNormalizer implements DenormalizerInterface, NormalizerInterfac
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('durationInSeconds', $data) && \is_int($data['durationInSeconds'])) {
-            $data['durationInSeconds'] = (double) $data['durationInSeconds'];
+            $data['durationInSeconds'] = (float) $data['durationInSeconds'];
         }
         if (\array_key_exists('frameRate', $data) && \is_int($data['frameRate'])) {
-            $data['frameRate'] = (double) $data['frameRate'];
+            $data['frameRate'] = (float) $data['frameRate'];
         }
         if (\array_key_exists('pixelAspectRatio', $data) && \is_int($data['pixelAspectRatio'])) {
-            $data['pixelAspectRatio'] = (double) $data['pixelAspectRatio'];
+            $data['pixelAspectRatio'] = (float) $data['pixelAspectRatio'];
         }
         if (\array_key_exists('rotation', $data) && \is_int($data['rotation'])) {
-            $data['rotation'] = (double) $data['rotation'];
+            $data['rotation'] = (float) $data['rotation'];
         }
         if (\array_key_exists('bitRate', $data) && $data['bitRate'] !== null) {
             $object->setBitRate($data['bitRate']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/WatermarkActionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Normalizer/WatermarkActionNormalizer.php
@@ -38,13 +38,13 @@ class WatermarkActionNormalizer implements DenormalizerInterface, NormalizerInte
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('opacity', $data) && \is_int($data['opacity'])) {
-            $data['opacity'] = (double) $data['opacity'];
+            $data['opacity'] = (float) $data['opacity'];
         }
         if (\array_key_exists('widthRatio', $data) && \is_int($data['widthRatio'])) {
-            $data['widthRatio'] = (double) $data['widthRatio'];
+            $data['widthRatio'] = (float) $data['widthRatio'];
         }
         if (\array_key_exists('heightRatio', $data) && \is_int($data['heightRatio'])) {
-            $data['heightRatio'] = (double) $data['heightRatio'];
+            $data['heightRatio'] = (float) $data['heightRatio'];
         }
         if (\array_key_exists('kind', $data)) {
             $object->setKind($data['kind']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AlertPolicyNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AlertPolicyNormalizer.php
@@ -38,7 +38,7 @@ class AlertPolicyNormalizer implements DenormalizerInterface, NormalizerInterfac
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('enabled', $data) && \is_int($data['enabled'])) {
             $data['enabled'] = (bool) $data['enabled'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AlertPolicyRequestNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AlertPolicyRequestNormalizer.php
@@ -38,7 +38,7 @@ class AlertPolicyRequestNormalizer implements DenormalizerInterface, NormalizerI
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('enabled', $data) && \is_int($data['enabled'])) {
             $data['enabled'] = (bool) $data['enabled'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiAgentNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiAgentNormalizer.php
@@ -38,10 +38,10 @@ class ApiAgentNormalizer implements DenormalizerInterface, NormalizerInterface, 
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('temperature', $data) && \is_int($data['temperature'])) {
-            $data['temperature'] = (double) $data['temperature'];
+            $data['temperature'] = (float) $data['temperature'];
         }
         if (\array_key_exists('top_p', $data) && \is_int($data['top_p'])) {
-            $data['top_p'] = (double) $data['top_p'];
+            $data['top_p'] = (float) $data['top_p'];
         }
         if (\array_key_exists('conversation_logs_enabled', $data) && \is_int($data['conversation_logs_enabled'])) {
             $data['conversation_logs_enabled'] = (bool) $data['conversation_logs_enabled'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiAgentPublicNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiAgentPublicNormalizer.php
@@ -38,10 +38,10 @@ class ApiAgentPublicNormalizer implements DenormalizerInterface, NormalizerInter
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('temperature', $data) && \is_int($data['temperature'])) {
-            $data['temperature'] = (double) $data['temperature'];
+            $data['temperature'] = (float) $data['temperature'];
         }
         if (\array_key_exists('top_p', $data) && \is_int($data['top_p'])) {
-            $data['top_p'] = (double) $data['top_p'];
+            $data['top_p'] = (float) $data['top_p'];
         }
         if (\array_key_exists('provide_citations', $data) && \is_int($data['provide_citations'])) {
             $data['provide_citations'] = (bool) $data['provide_citations'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiAgentTemplateNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiAgentTemplateNormalizer.php
@@ -38,10 +38,10 @@ class ApiAgentTemplateNormalizer implements DenormalizerInterface, NormalizerInt
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('temperature', $data) && \is_int($data['temperature'])) {
-            $data['temperature'] = (double) $data['temperature'];
+            $data['temperature'] = (float) $data['temperature'];
         }
         if (\array_key_exists('top_p', $data) && \is_int($data['top_p'])) {
-            $data['top_p'] = (double) $data['top_p'];
+            $data['top_p'] = (float) $data['top_p'];
         }
         if (\array_key_exists('created_at', $data)) {
             $object->setCreatedAt(\DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['created_at']));

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiAgentVersionNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiAgentVersionNormalizer.php
@@ -38,10 +38,10 @@ class ApiAgentVersionNormalizer implements DenormalizerInterface, NormalizerInte
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('temperature', $data) && \is_int($data['temperature'])) {
-            $data['temperature'] = (double) $data['temperature'];
+            $data['temperature'] = (float) $data['temperature'];
         }
         if (\array_key_exists('top_p', $data) && \is_int($data['top_p'])) {
-            $data['top_p'] = (double) $data['top_p'];
+            $data['top_p'] = (float) $data['top_p'];
         }
         if (\array_key_exists('can_rollback', $data) && \is_int($data['can_rollback'])) {
             $data['can_rollback'] = (bool) $data['can_rollback'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiChunkingOptionsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiChunkingOptionsNormalizer.php
@@ -38,7 +38,7 @@ class ApiChunkingOptionsNormalizer implements DenormalizerInterface, NormalizerI
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('semantic_threshold', $data) && \is_int($data['semantic_threshold'])) {
-            $data['semantic_threshold'] = (double) $data['semantic_threshold'];
+            $data['semantic_threshold'] = (float) $data['semantic_threshold'];
         }
         if (\array_key_exists('child_chunk_size', $data)) {
             $object->setChildChunkSize($data['child_chunk_size']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiEvaluationMetricNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiEvaluationMetricNormalizer.php
@@ -38,10 +38,10 @@ class ApiEvaluationMetricNormalizer implements DenormalizerInterface, Normalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('range_max', $data) && \is_int($data['range_max'])) {
-            $data['range_max'] = (double) $data['range_max'];
+            $data['range_max'] = (float) $data['range_max'];
         }
         if (\array_key_exists('range_min', $data) && \is_int($data['range_min'])) {
-            $data['range_min'] = (double) $data['range_min'];
+            $data['range_min'] = (float) $data['range_min'];
         }
         if (\array_key_exists('inverted', $data) && \is_int($data['inverted'])) {
             $data['inverted'] = (bool) $data['inverted'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiEvaluationMetricResultNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiEvaluationMetricResultNormalizer.php
@@ -38,7 +38,7 @@ class ApiEvaluationMetricResultNormalizer implements DenormalizerInterface, Norm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('number_value', $data) && \is_int($data['number_value'])) {
-            $data['number_value'] = (double) $data['number_value'];
+            $data['number_value'] = (float) $data['number_value'];
         }
         if (\array_key_exists('error_description', $data)) {
             $object->setErrorDescription($data['error_description']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiPromptChunkNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiPromptChunkNormalizer.php
@@ -38,7 +38,7 @@ class ApiPromptChunkNormalizer implements DenormalizerInterface, NormalizerInter
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('chunk_usage_pct', $data) && \is_int($data['chunk_usage_pct'])) {
-            $data['chunk_usage_pct'] = (double) $data['chunk_usage_pct'];
+            $data['chunk_usage_pct'] = (float) $data['chunk_usage_pct'];
         }
         if (\array_key_exists('chunk_used', $data) && \is_int($data['chunk_used'])) {
             $data['chunk_used'] = (bool) $data['chunk_used'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiStarMetricNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiStarMetricNormalizer.php
@@ -38,7 +38,7 @@ class ApiStarMetricNormalizer implements DenormalizerInterface, NormalizerInterf
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('success_threshold', $data) && \is_int($data['success_threshold'])) {
-            $data['success_threshold'] = (double) $data['success_threshold'];
+            $data['success_threshold'] = (float) $data['success_threshold'];
         }
         if (\array_key_exists('metric_uuid', $data)) {
             $object->setMetricUuid($data['metric_uuid']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiUpdateAgentInputPublicNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ApiUpdateAgentInputPublicNormalizer.php
@@ -38,10 +38,10 @@ class ApiUpdateAgentInputPublicNormalizer implements DenormalizerInterface, Norm
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('temperature', $data) && \is_int($data['temperature'])) {
-            $data['temperature'] = (double) $data['temperature'];
+            $data['temperature'] = (float) $data['temperature'];
         }
         if (\array_key_exists('top_p', $data) && \is_int($data['top_p'])) {
-            $data['top_p'] = (double) $data['top_p'];
+            $data['top_p'] = (float) $data['top_p'];
         }
         if (\array_key_exists('agent_log_insights_enabled', $data) && \is_int($data['agent_log_insights_enabled'])) {
             $data['agent_log_insights_enabled'] = (bool) $data['agent_log_insights_enabled'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppAlertSpecNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppAlertSpecNormalizer.php
@@ -38,7 +38,7 @@ class AppAlertSpecNormalizer implements DenormalizerInterface, NormalizerInterfa
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('value', $data) && \is_int($data['value'])) {
-            $data['value'] = (double) $data['value'];
+            $data['value'] = (float) $data['value'];
         }
         if (\array_key_exists('disabled', $data) && \is_int($data['disabled'])) {
             $data['disabled'] = (bool) $data['disabled'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppComponentHealthNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppComponentHealthNormalizer.php
@@ -38,10 +38,10 @@ class AppComponentHealthNormalizer implements DenormalizerInterface, NormalizerI
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('cpu_usage_percent', $data) && \is_int($data['cpu_usage_percent'])) {
-            $data['cpu_usage_percent'] = (double) $data['cpu_usage_percent'];
+            $data['cpu_usage_percent'] = (float) $data['cpu_usage_percent'];
         }
         if (\array_key_exists('memory_usage_percent', $data) && \is_int($data['memory_usage_percent'])) {
-            $data['memory_usage_percent'] = (double) $data['memory_usage_percent'];
+            $data['memory_usage_percent'] = (float) $data['memory_usage_percent'];
         }
         if (\array_key_exists('name', $data)) {
             $object->setName($data['name']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppFunctionsComponentHealthFunctionsComponentHealthMetricsItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppFunctionsComponentHealthFunctionsComponentHealthMetricsItemNormalizer.php
@@ -38,7 +38,7 @@ class AppFunctionsComponentHealthFunctionsComponentHealthMetricsItemNormalizer i
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('metric_value', $data) && \is_int($data['metric_value'])) {
-            $data['metric_value'] = (double) $data['metric_value'];
+            $data['metric_value'] = (float) $data['metric_value'];
         }
         if (\array_key_exists('metric_label', $data)) {
             $object->setMetricLabel($data['metric_label']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppsListInstanceSizesResponseNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AppsListInstanceSizesResponseNormalizer.php
@@ -38,7 +38,7 @@ class AppsListInstanceSizesResponseNormalizer implements DenormalizerInterface, 
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('discount_percent', $data) && \is_int($data['discount_percent'])) {
-            $data['discount_percent'] = (double) $data['discount_percent'];
+            $data['discount_percent'] = (float) $data['discount_percent'];
         }
         if (\array_key_exists('discount_percent', $data)) {
             $object->setDiscountPercent($data['discount_percent']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AutoscalePoolDynamicConfigNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/AutoscalePoolDynamicConfigNormalizer.php
@@ -38,10 +38,10 @@ class AutoscalePoolDynamicConfigNormalizer implements DenormalizerInterface, Nor
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('target_cpu_utilization', $data) && \is_int($data['target_cpu_utilization'])) {
-            $data['target_cpu_utilization'] = (double) $data['target_cpu_utilization'];
+            $data['target_cpu_utilization'] = (float) $data['target_cpu_utilization'];
         }
         if (\array_key_exists('target_memory_utilization', $data) && \is_int($data['target_memory_utilization'])) {
-            $data['target_memory_utilization'] = (double) $data['target_memory_utilization'];
+            $data['target_memory_utilization'] = (float) $data['target_memory_utilization'];
         }
         if (\array_key_exists('min_instances', $data)) {
             $object->setMinInstances($data['min_instances']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/BackupNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/BackupNormalizer.php
@@ -38,7 +38,7 @@ class BackupNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('size_gigabytes', $data) && \is_int($data['size_gigabytes'])) {
-            $data['size_gigabytes'] = (double) $data['size_gigabytes'];
+            $data['size_gigabytes'] = (float) $data['size_gigabytes'];
         }
         if (\array_key_exists('incremental', $data) && \is_int($data['incremental'])) {
             $data['incremental'] = (bool) $data['incremental'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ClusterAutoscalerConfigurationNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ClusterAutoscalerConfigurationNormalizer.php
@@ -38,7 +38,7 @@ class ClusterAutoscalerConfigurationNormalizer implements DenormalizerInterface,
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('scale_down_utilization_threshold', $data) && \is_int($data['scale_down_utilization_threshold'])) {
-            $data['scale_down_utilization_threshold'] = (double) $data['scale_down_utilization_threshold'];
+            $data['scale_down_utilization_threshold'] = (float) $data['scale_down_utilization_threshold'];
         }
         if (\array_key_exists('scale_down_utilization_threshold', $data)) {
             $object->setScaleDownUtilizationThreshold($data['scale_down_utilization_threshold']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/CurrentUtilizationNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/CurrentUtilizationNormalizer.php
@@ -38,10 +38,10 @@ class CurrentUtilizationNormalizer implements DenormalizerInterface, NormalizerI
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('memory', $data) && \is_int($data['memory'])) {
-            $data['memory'] = (double) $data['memory'];
+            $data['memory'] = (float) $data['memory'];
         }
         if (\array_key_exists('cpu', $data) && \is_int($data['cpu'])) {
-            $data['cpu'] = (double) $data['cpu'];
+            $data['cpu'] = (float) $data['cpu'];
         }
         if (\array_key_exists('memory', $data)) {
             $object->setMemory($data['memory']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletImageNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletImageNormalizer.php
@@ -38,7 +38,7 @@ class DropletImageNormalizer implements DenormalizerInterface, NormalizerInterfa
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('size_gigabytes', $data) && \is_int($data['size_gigabytes'])) {
-            $data['size_gigabytes'] = (double) $data['size_gigabytes'];
+            $data['size_gigabytes'] = (float) $data['size_gigabytes'];
         }
         if (\array_key_exists('public', $data) && \is_int($data['public'])) {
             $data['public'] = (bool) $data['public'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletSnapshotNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/DropletSnapshotNormalizer.php
@@ -38,7 +38,7 @@ class DropletSnapshotNormalizer implements DenormalizerInterface, NormalizerInte
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('size_gigabytes', $data) && \is_int($data['size_gigabytes'])) {
-            $data['size_gigabytes'] = (double) $data['size_gigabytes'];
+            $data['size_gigabytes'] = (float) $data['size_gigabytes'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ElasticsearchLogsinkNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ElasticsearchLogsinkNormalizer.php
@@ -38,7 +38,7 @@ class ElasticsearchLogsinkNormalizer implements DenormalizerInterface, Normalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('timeout', $data) && \is_int($data['timeout'])) {
-            $data['timeout'] = (double) $data['timeout'];
+            $data['timeout'] = (float) $data['timeout'];
         }
         if (\array_key_exists('url', $data)) {
             $object->setUrl($data['url']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ImageNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/ImageNormalizer.php
@@ -38,7 +38,7 @@ class ImageNormalizer implements DenormalizerInterface, NormalizerInterface, Den
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('size_gigabytes', $data) && \is_int($data['size_gigabytes'])) {
-            $data['size_gigabytes'] = (double) $data['size_gigabytes'];
+            $data['size_gigabytes'] = (float) $data['size_gigabytes'];
         }
         if (\array_key_exists('public', $data) && \is_int($data['public'])) {
             $data['public'] = (bool) $data['public'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/KafkaAdvancedConfigNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/KafkaAdvancedConfigNormalizer.php
@@ -38,7 +38,7 @@ class KafkaAdvancedConfigNormalizer implements DenormalizerInterface, Normalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('log_cleaner_min_cleanable_ratio', $data) && \is_int($data['log_cleaner_min_cleanable_ratio'])) {
-            $data['log_cleaner_min_cleanable_ratio'] = (double) $data['log_cleaner_min_cleanable_ratio'];
+            $data['log_cleaner_min_cleanable_ratio'] = (float) $data['log_cleaner_min_cleanable_ratio'];
         }
         if (\array_key_exists('log_message_downconversion_enable', $data) && \is_int($data['log_message_downconversion_enable'])) {
             $data['log_message_downconversion_enable'] = (bool) $data['log_message_downconversion_enable'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/KafkaTopicConfigNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/KafkaTopicConfigNormalizer.php
@@ -38,7 +38,7 @@ class KafkaTopicConfigNormalizer implements DenormalizerInterface, NormalizerInt
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('min_cleanable_dirty_ratio', $data) && \is_int($data['min_cleanable_dirty_ratio'])) {
-            $data['min_cleanable_dirty_ratio'] = (double) $data['min_cleanable_dirty_ratio'];
+            $data['min_cleanable_dirty_ratio'] = (float) $data['min_cleanable_dirty_ratio'];
         }
         if (\array_key_exists('message_down_conversion_enable', $data) && \is_int($data['message_down_conversion_enable'])) {
             $data['message_down_conversion_enable'] = (bool) $data['message_down_conversion_enable'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/MemberCurrentUtilizationNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/MemberCurrentUtilizationNormalizer.php
@@ -38,10 +38,10 @@ class MemberCurrentUtilizationNormalizer implements DenormalizerInterface, Norma
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('memory', $data) && \is_int($data['memory'])) {
-            $data['memory'] = (double) $data['memory'];
+            $data['memory'] = (float) $data['memory'];
         }
         if (\array_key_exists('cpu', $data) && \is_int($data['cpu'])) {
-            $data['cpu'] = (double) $data['cpu'];
+            $data['cpu'] = (float) $data['cpu'];
         }
         if (\array_key_exists('memory', $data)) {
             $object->setMemory($data['memory']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/MysqlAdvancedConfigNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/MysqlAdvancedConfigNormalizer.php
@@ -38,10 +38,10 @@ class MysqlAdvancedConfigNormalizer implements DenormalizerInterface, Normalizer
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('long_query_time', $data) && \is_int($data['long_query_time'])) {
-            $data['long_query_time'] = (double) $data['long_query_time'];
+            $data['long_query_time'] = (float) $data['long_query_time'];
         }
         if (\array_key_exists('binlog_retention_period', $data) && \is_int($data['binlog_retention_period'])) {
-            $data['binlog_retention_period'] = (double) $data['binlog_retention_period'];
+            $data['binlog_retention_period'] = (float) $data['binlog_retention_period'];
         }
         if (\array_key_exists('innodb_print_all_deadlocks', $data) && \is_int($data['innodb_print_all_deadlocks'])) {
             $data['innodb_print_all_deadlocks'] = (bool) $data['innodb_print_all_deadlocks'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/OpensearchLogsinkNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/OpensearchLogsinkNormalizer.php
@@ -38,7 +38,7 @@ class OpensearchLogsinkNormalizer implements DenormalizerInterface, NormalizerIn
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('timeout', $data) && \is_int($data['timeout'])) {
-            $data['timeout'] = (double) $data['timeout'];
+            $data['timeout'] = (float) $data['timeout'];
         }
         if (\array_key_exists('url', $data)) {
             $object->setUrl($data['url']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/PostgresAdvancedConfigNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/PostgresAdvancedConfigNormalizer.php
@@ -38,16 +38,16 @@ class PostgresAdvancedConfigNormalizer implements DenormalizerInterface, Normali
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('autovacuum_vacuum_scale_factor', $data) && \is_int($data['autovacuum_vacuum_scale_factor'])) {
-            $data['autovacuum_vacuum_scale_factor'] = (double) $data['autovacuum_vacuum_scale_factor'];
+            $data['autovacuum_vacuum_scale_factor'] = (float) $data['autovacuum_vacuum_scale_factor'];
         }
         if (\array_key_exists('autovacuum_analyze_scale_factor', $data) && \is_int($data['autovacuum_analyze_scale_factor'])) {
-            $data['autovacuum_analyze_scale_factor'] = (double) $data['autovacuum_analyze_scale_factor'];
+            $data['autovacuum_analyze_scale_factor'] = (float) $data['autovacuum_analyze_scale_factor'];
         }
         if (\array_key_exists('bgwriter_lru_multiplier', $data) && \is_int($data['bgwriter_lru_multiplier'])) {
-            $data['bgwriter_lru_multiplier'] = (double) $data['bgwriter_lru_multiplier'];
+            $data['bgwriter_lru_multiplier'] = (float) $data['bgwriter_lru_multiplier'];
         }
         if (\array_key_exists('shared_buffers_percentage', $data) && \is_int($data['shared_buffers_percentage'])) {
-            $data['shared_buffers_percentage'] = (double) $data['shared_buffers_percentage'];
+            $data['shared_buffers_percentage'] = (float) $data['shared_buffers_percentage'];
         }
         if (\array_key_exists('jit', $data) && \is_int($data['jit'])) {
             $data['jit'] = (bool) $data['jit'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/RegionStateNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/RegionStateNormalizer.php
@@ -38,7 +38,7 @@ class RegionStateNormalizer implements DenormalizerInterface, NormalizerInterfac
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('thirty_day_uptime_percentage', $data) && \is_int($data['thirty_day_uptime_percentage'])) {
-            $data['thirty_day_uptime_percentage'] = (double) $data['thirty_day_uptime_percentage'];
+            $data['thirty_day_uptime_percentage'] = (float) $data['thirty_day_uptime_percentage'];
         }
         if (\array_key_exists('status', $data)) {
             $object->setStatus($data['status']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/SizeNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/SizeNormalizer.php
@@ -38,13 +38,13 @@ class SizeNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('transfer', $data) && \is_int($data['transfer'])) {
-            $data['transfer'] = (double) $data['transfer'];
+            $data['transfer'] = (float) $data['transfer'];
         }
         if (\array_key_exists('price_monthly', $data) && \is_int($data['price_monthly'])) {
-            $data['price_monthly'] = (double) $data['price_monthly'];
+            $data['price_monthly'] = (float) $data['price_monthly'];
         }
         if (\array_key_exists('price_hourly', $data) && \is_int($data['price_hourly'])) {
-            $data['price_hourly'] = (double) $data['price_hourly'];
+            $data['price_hourly'] = (float) $data['price_hourly'];
         }
         if (\array_key_exists('available', $data) && \is_int($data['available'])) {
             $data['available'] = (bool) $data['available'];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/SnapshotsBaseNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/SnapshotsBaseNormalizer.php
@@ -38,7 +38,7 @@ class SnapshotsBaseNormalizer implements DenormalizerInterface, NormalizerInterf
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('size_gigabytes', $data) && \is_int($data['size_gigabytes'])) {
-            $data['size_gigabytes'] = (double) $data['size_gigabytes'];
+            $data['size_gigabytes'] = (float) $data['size_gigabytes'];
         }
         if (\array_key_exists('name', $data)) {
             $object->setName($data['name']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/SnapshotsNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Normalizer/SnapshotsNormalizer.php
@@ -38,7 +38,7 @@ class SnapshotsNormalizer implements DenormalizerInterface, NormalizerInterface,
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('size_gigabytes', $data) && \is_int($data['size_gigabytes'])) {
-            $data['size_gigabytes'] = (double) $data['size_gigabytes'];
+            $data['size_gigabytes'] = (float) $data['size_gigabytes'];
         }
         if (\array_key_exists('id', $data)) {
             $object->setId($data['id']);

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Normalizer/SchemaNormalizer.php
@@ -38,7 +38,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
-            $data['floatProperty'] = (double) $data['floatProperty'];
+            $data['floatProperty'] = (float) $data['floatProperty'];
         }
         if (\array_key_exists('stringProperty', $data)) {
             $object->setStringProperty($data['stringProperty']);

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Normalizer/SchemaNormalizer.php
@@ -38,7 +38,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
-            $data['floatProperty'] = (double) $data['floatProperty'];
+            $data['floatProperty'] = (float) $data['floatProperty'];
         }
         if (\array_key_exists('stringProperty', $data)) {
             $object->setStringProperty($data['stringProperty']);

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Normalizer/TestFormPostBodyNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Normalizer/TestFormPostBodyNormalizer.php
@@ -38,7 +38,7 @@ class TestFormPostBodyNormalizer implements DenormalizerInterface, NormalizerInt
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('testFloat', $data) && \is_int($data['testFloat'])) {
-            $data['testFloat'] = (double) $data['testFloat'];
+            $data['testFloat'] = (float) $data['testFloat'];
         }
         if (\array_key_exists('testString', $data)) {
             $object->setTestString($data['testString']);

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Normalizer/FullTextEntitiesAnnotationsItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Normalizer/FullTextEntitiesAnnotationsItemNormalizer.php
@@ -38,7 +38,7 @@ class FullTextEntitiesAnnotationsItemNormalizer implements DenormalizerInterface
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('probability', $data) && \is_int($data['probability'])) {
-            $data['probability'] = (double) $data['probability'];
+            $data['probability'] = (float) $data['probability'];
         }
         if (\array_key_exists('start', $data)) {
             $object->setStart($data['start']);

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Normalizer/SchemaNormalizer.php
@@ -39,7 +39,7 @@ class SchemaNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('floatProperty', $data) && \is_int($data['floatProperty'])) {
-            $data['floatProperty'] = (double) $data['floatProperty'];
+            $data['floatProperty'] = (float) $data['floatProperty'];
         }
         if (\array_key_exists('stringProperty', $data)) {
             $object->setStringProperty($data['stringProperty']);

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/SpecialEventFieldsNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/SpecialEventFieldsNormalizer.php
@@ -38,7 +38,7 @@ class SpecialEventFieldsNormalizer implements DenormalizerInterface, NormalizerI
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('price', $data) && \is_int($data['price'])) {
-            $data['price'] = (double) $data['price'];
+            $data['price'] = (float) $data['price'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\SpecialEventFieldsConstraint());

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/SpecialEventNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/SpecialEventNormalizer.php
@@ -38,7 +38,7 @@ class SpecialEventNormalizer implements DenormalizerInterface, NormalizerInterfa
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('price', $data) && \is_int($data['price'])) {
-            $data['price'] = (double) $data['price'];
+            $data['price'] = (float) $data['price'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\SpecialEventConstraint());

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetAtmosphereItemNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetAtmosphereItemNormalizer.php
@@ -38,7 +38,7 @@ class PlanetAtmosphereItemNormalizer implements DenormalizerInterface, Normalize
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('percentage', $data) && \is_int($data['percentage'])) {
-            $data['percentage'] = (double) $data['percentage'];
+            $data['percentage'] = (float) $data['percentage'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\PlanetAtmosphereItemConstraint());

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetNormalizer.php
@@ -38,7 +38,7 @@ class PlanetNormalizer implements DenormalizerInterface, NormalizerInterface, De
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('habitabilityIndex', $data) && \is_int($data['habitabilityIndex'])) {
-            $data['habitabilityIndex'] = (double) $data['habitabilityIndex'];
+            $data['habitabilityIndex'] = (float) $data['habitabilityIndex'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\PlanetConstraint());

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetPhysicalPropertiesNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetPhysicalPropertiesNormalizer.php
@@ -38,13 +38,13 @@ class PlanetPhysicalPropertiesNormalizer implements DenormalizerInterface, Norma
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('mass', $data) && \is_int($data['mass'])) {
-            $data['mass'] = (double) $data['mass'];
+            $data['mass'] = (float) $data['mass'];
         }
         if (\array_key_exists('radius', $data) && \is_int($data['radius'])) {
-            $data['radius'] = (double) $data['radius'];
+            $data['radius'] = (float) $data['radius'];
         }
         if (\array_key_exists('gravity', $data) && \is_int($data['gravity'])) {
-            $data['gravity'] = (double) $data['gravity'];
+            $data['gravity'] = (float) $data['gravity'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\PlanetPhysicalPropertiesConstraint());

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetPhysicalPropertiesTemperatureNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetPhysicalPropertiesTemperatureNormalizer.php
@@ -38,13 +38,13 @@ class PlanetPhysicalPropertiesTemperatureNormalizer implements DenormalizerInter
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('min', $data) && \is_int($data['min'])) {
-            $data['min'] = (double) $data['min'];
+            $data['min'] = (float) $data['min'];
         }
         if (\array_key_exists('max', $data) && \is_int($data['max'])) {
-            $data['max'] = (double) $data['max'];
+            $data['max'] = (float) $data['max'];
         }
         if (\array_key_exists('average', $data) && \is_int($data['average'])) {
-            $data['average'] = (double) $data['average'];
+            $data['average'] = (float) $data['average'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\PlanetPhysicalPropertiesTemperatureConstraint());

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/SatelliteNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/SatelliteNormalizer.php
@@ -38,7 +38,7 @@ class SatelliteNormalizer implements DenormalizerInterface, NormalizerInterface,
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('diameter', $data) && \is_int($data['diameter'])) {
-            $data['diameter'] = (double) $data['diameter'];
+            $data['diameter'] = (float) $data['diameter'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\SatelliteConstraint());

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/SatelliteOrbitNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/SatelliteOrbitNormalizer.php
@@ -38,10 +38,10 @@ class SatelliteOrbitNormalizer implements DenormalizerInterface, NormalizerInter
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('orbitalPeriod', $data) && \is_int($data['orbitalPeriod'])) {
-            $data['orbitalPeriod'] = (double) $data['orbitalPeriod'];
+            $data['orbitalPeriod'] = (float) $data['orbitalPeriod'];
         }
         if (\array_key_exists('distance', $data) && \is_int($data['distance'])) {
-            $data['distance'] = (double) $data['distance'];
+            $data['distance'] = (float) $data['distance'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\SatelliteOrbitConstraint());

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Normalizer/BookingPaymentNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Normalizer/BookingPaymentNormalizer.php
@@ -38,7 +38,7 @@ class BookingPaymentNormalizer implements DenormalizerInterface, NormalizerInter
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('amount', $data) && \is_int($data['amount'])) {
-            $data['amount'] = (double) $data['amount'];
+            $data['amount'] = (float) $data['amount'];
         }
         if (!($context['skip_validation'] ?? false)) {
             $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\BookingPaymentConstraint());

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Normalizer/TripNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Normalizer/TripNormalizer.php
@@ -38,7 +38,7 @@ class TripNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             return new Reference($data['$recursiveRef'], $context['document-origin']);
         }
         if (\array_key_exists('price', $data) && \is_int($data['price'])) {
-            $data['price'] = (double) $data['price'];
+            $data['price'] = (float) $data['price'];
         }
         if (\array_key_exists('bicycles_allowed', $data) && \is_int($data['bicycles_allowed'])) {
             $data['bicycles_allowed'] = (bool) $data['bicycles_allowed'];


### PR DESCRIPTION
`DenormalizerGenerator` builds the int-to-float cast as `Expr\Cast\Double` without a `kind`, and php-parser prints that as `(double)` — a cast syntax deprecated in PHP 8.5 along with `(real)`. Every generated client with float properties emits deprecation warnings at runtime.

Before / after in generated code:

```diff
 if (\array_key_exists('price', $data) && \is_int($data['price'])) {
-    $data['price'] = (double) $data['price'];
+    $data['price'] = (float) $data['price'];
 }
```

The fix is one line: `new Expr\Cast\Double($arrayElement, ['kind' => Expr\Cast\Double::KIND_FLOAT])`. It is the only `Cast\Double` construction site in the codebase.

The rest of the diff is mechanical: regenerated `expected/` fixtures and the same `(double)` → `(float)` substitution in the package's own committed normalizers (9 files), which were generated by this same code.

Full suite, php-cs-fixer and PHPStan pass.

Fixes #972