### PR TITLE
fix(composer): add jane-php/open-api-3-1 to the replace list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "jane-php/open-api": "self.version",
         "jane-php/open-api-2": "self.version",
         "jane-php/open-api-3": "self.version",
+        "jane-php/open-api-3-1": "self.version",
         "jane-php/open-api-runtime": "self.version"
     },
     "require-dev": {


### PR DESCRIPTION
The monorepo `replace` block lists every split package it publishes — except `jane-php/open-api-3-1`, although the split exists and is published on Packagist (`.github/gitsplit/7-plus/.gitsplit.yml` targets `janephp/open-api-3-1`). The OpenAPI 3.1 component PR (#904) simply did not update the block.

Without the entry, a project that requires `jane-php/open-api-3-1` and installs the monorepo (e.g. through a `vcs` repository) gets both copies of the OpenApi31 code side by side, which leads to class collisions.

One line, consistent with the nine existing entries.

Fixes #976