### PR TITLE
feat(openapi-common): make error response exception generation optional

### DIFF
--- a/docs/openapi/component.md
+++ b/docs/openapi/component.md
@@ -211,6 +211,10 @@ There are many ways to use it. You can either use the `__type` key to specify a 
  given type (`bool`, `int`, `string`, ...) and give it your class that contains the custom normalizer by
  extending the generated runtime `CustomQueryResolver` class. You can also filter the usage of your custom
  normalizer by giving the exact path, method and parameter name where you want to apply it.
+- `generate-error-exceptions`: Will generate a dedicated exception class for every declared error response (status >= 400)
+ and throw it with the deserialized typed error model. When disabled, declared error responses are denormalized into
+ their typed model and returned like any other response. Undeclared statuses remain governed by
+ `throw-unexpected-status-code`. By default, it's enabled.
 - `throw-unexpected-status-code`: Will return a `UnexpectedStatusCodeException` if nothing has been matched during
  the transformation of the Endpoint body (including described exceptions). By default, it's disabled.
 - `custom-string-format-mapping`: This option allows you to specify in which class a string property will be


### PR DESCRIPTION
## Description

Makes the generation of dedicated exception classes for declared error responses (status >= 400) optional in the OpenAPI spec. Until now, every declared error response unconditionally produced a dedicated exception class plus a throw branch in the endpoint. For APIs that declare errors uniformly on every operation and handle them centrally, this generated hundreds of unused classes (~1200 for ~400 operations), with no other way out than pre-processing the document to strip non-2xx responses.

Adds the `generate-error-exceptions` option (default `true`, current behavior), which travels the same way `throw-unexpected-status-code` does: `GenerateCommand` puts it on the `Registry`, and the endpoint generators read it from the context. Also documents the option in `docs/openapi/component.md`.

## Changes

- Adds the `generate-error-exceptions` option (default `true`) in `ConfigLoader`, `SchemaLoader`, `GenerateCommand` and `Registry`.
- `OpenApi2`, `OpenApi3`, `OpenApi31`: the `GetTransformResponseBodyTrait` generators only emit an exception class + throw branch when the option is enabled. When disabled, declared error responses are denormalized into their typed model and returned like any other response; undeclared statuses remain governed by `throw-unexpected-status-code`.
- Documents the `generate-error-exceptions` option in `docs/openapi/component.md` (next to `throw-unexpected-status-code`).
- Adds OpenApi3 and OpenApi31 fixtures (`generate-error-exceptions`) with the option disabled.

## How to test

1. Generate a client with `generate-error-exceptions` disabled against a spec declaring error responses (see the `generate-error-exceptions` fixtures in `OpenApi3` / `OpenApi31`): verify no `Exception` directory is generated and error responses return the typed model.
2. Verify all existing fixtures (option enabled by default) remain byte-identical: `vendor/bin/phpunit`.

## Notes

- No default compatibility change: the default behavior (`true`) is unchanged.
