### PR TITLE
docs: add documentation for the custom validators option

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -198,3 +198,103 @@ public function denormalize(mixed $data, string $type, string $format = null, ar
 This allows the validation to be done without having anything else than
 the configuration to do. Also you can use the Validator out of Jane
 normalization by doing exactly the same as in the Normalizer.
+
+## Custom validators
+
+Sometimes the built-in validators are not enough for your specific
+schemas. Since Jane, you can register additional validators through the
+`validators` configuration option.
+
+The `validators` option takes an array of
+`Jane\Component\JsonSchema\Guesser\Validator\ValidatorInterface`
+**instances** (not class names), which lets you inject constructor
+dependencies (like allowed values, configuration, or services).
+
+```php
+<?php
+
+return [
+    'json-schema-file' => __DIR__ . '/price.json',
+    'root-class' => 'Price',
+    'namespace' => 'App\Generated',
+    'directory' => __DIR__ . '/generated',
+    'validation' => true,
+    'validators' => [
+        new class implements ValidatorInterface {
+            public function supports($object): bool
+            {
+                return $object instanceof JsonSchema && 'decimal-two' === $object->getFormat();
+            }
+
+            public function guess($object, string $name, $guess): void
+            {
+                $guess->addValidatorGuess(new ValidatorGuess(Regex::class, [
+                    'pattern' => '#^\d+\.\d{2}$#',
+                    'message' => 'This value is not a valid decimal with two fraction digits.',
+                ]));
+            }
+        },
+    ],
+];
+```
+
+As you can see, each validator implements `ValidatorInterface` with two
+methods:
+
+- `supports($object)` returns whether this validator applies to the
+  given schema object (for example a `JsonSchema` with a specific
+  `format`).
+- `guess($object, string $name, $guess)` emits the Symfony validation
+  constraints for the guessed property, using
+  `$guess->addValidatorGuess(new ValidatorGuess(ConstraintClass::class, [
+  ...options ]))`.
+
+Because the option takes instances, you can build validators with
+constructor dependencies. For example a validator that restricts a
+custom string format to a fixed list of allowed codes:
+
+```php
+new class(['EUR', 'USD', 'GBP']) implements ValidatorInterface {
+    public function __construct(
+        private readonly array $allowedCodes,
+    ) {
+    }
+
+    public function supports($object): bool
+    {
+        return $object instanceof JsonSchema && 'currency-code' === $object->getFormat();
+    }
+
+    public function guess($object, string $name, $guess): void
+    {
+        $guess->addValidatorGuess(new ValidatorGuess(Choice::class, [
+            'choices' => $this->allowedCodes,
+            'message' => 'This value is not a supported currency code.',
+        ]));
+    }
+},
+```
+
+A single `guess()` can also emit several constraints. For instance a
+custom numeric format that becomes a range:
+
+```php
+new class implements ValidatorInterface {
+    public function supports($object): bool
+    {
+        return $object instanceof JsonSchema && 'percentage' === $object->getFormat();
+    }
+
+    public function guess($object, string $name, $guess): void
+    {
+        $guess->addValidatorGuess(new ValidatorGuess(GreaterThanOrEqual::class, ['value' => 0.0]));
+        $guess->addValidatorGuess(new ValidatorGuess(LessThanOrEqual::class, ['value' => 100.0]));
+    }
+},
+```
+
+Note that custom validators are checked **before** the generic `Type`
+and `NotNull` fallback validators, so they take precedence for the
+schemas they `supports()`. The `validators` option is only meaningful
+when `validation` is enabled, and it works for both JSON Schema and
+OpenAPI generation.

--- a/docs/json_schema/component.md
+++ b/docs/json_schema/component.md
@@ -153,6 +153,9 @@ Other options are available to customize the generated code:
  that forces them to be present during denormalization. By default it is disabled.
 - `validation`: Will enable validation following JSON Schema validation specification. By default it is disabled. You
   can read more about it in the dedicated [Validation guide](../guides/validation.md).
+- `validators`: An array of `Jane\Component\JsonSchema\Guesser\Validator\ValidatorInterface` instances to register
+  additional validators during generation. Only meaningful when `validation` is enabled. See the
+  [Custom validators](../guides/validation.md#custom-validators) section of the Validation guide.
 - `include-null-value`: Will enable a way to manage null values. By default it is enabled.
 
 ## Using a generated Model

--- a/docs/openapi/component.md
+++ b/docs/openapi/component.md
@@ -157,7 +157,10 @@ Other options are available to customize the generated code:
 - `skip-required-fields`: If your model has required fields, this option allows you to skip the required behavior
  that forces them to be present during denormalization. By default it is disabled
 - `validation`: Will enable validation following JSON Schema validation specification. By default it is disabled. You
- can read more about it on the dedicated guide: [Validation guide](../guides/validation.md).
+  can read more about it on the dedicated guide: [Validation guide](../guides/validation.md).
+- `validators`: An array of `Jane\Component\JsonSchema\Guesser\Validator\ValidatorInterface` instances to register
+  additional validators during generation. Only meaningful when `validation` is enabled. See the
+  [Custom validators](../guides/validation.md#custom-validators) section of the Validation guide.
 - `include-null-value`: Will enable a way to manage null values. By default it is enabled.
 - `whitelisted-paths`: This option allows you to generate only needed endpoints and related models. Be carefull,
  that option will filter models used by whitelisted endpoints and generate model & normalizer only for them. Here is


### PR DESCRIPTION
## Description

Documents the `validators` configuration option introduced by PR #971, which allows registering custom validators during JSON Schema / OpenAPI code generation.

## Changes

- `docs/guides/validation.md`: new **Custom validators** section covering the `validators` option, the `ValidatorInterface` contract (`supports` / `guess`), instance-based registration (with constructor dependency injection), emitting one or more `ValidatorGuess`, and the priority of custom validators over the generic `Type` / `NotNull` fallbacks.
- `docs/json_schema/component.md`: added the `validators` option bullet (after `validation`), linking to the guide.
- `docs/openapi/component.md`: added the `validators` option bullet (after `validation`), linking to the guide.

## How to test

1. Open `docs/guides/validation.md` and check the rendering of the new **Custom validators** section.
2. Check the links to `../guides/validation.md#custom-validators` from `docs/json_schema/component.md` and `docs/openapi/component.md`.

## Notes

No functional change: documentation only. No configuration, dependency, or migration changes.
