### PR TITLE
fix(open-api-3-1): scope oneOf/anyOf supportObject to allOf-wrapped refs

### DIFF
--- a/src/Component/OpenApi31/Guesser/OpenApiSchema/AnyOfReferencefGuesser.php
+++ b/src/Component/OpenApi31/Guesser/OpenApiSchema/AnyOfReferencefGuesser.php
@@ -36,12 +36,18 @@ class AnyOfReferencefGuesser implements ChainGuesserAwareInterface, GuesserInter
             return false;
         }
 
+        if ($object->getAnyOf()[0] instanceof Reference) {
+            return true;
+        }
+
         foreach ($object->getAnyOf() as $anyOf) {
-            if ($anyOf instanceof Reference) {
-                return true;
+            if (!$anyOf instanceof JsonSchema || !\is_array($anyOf->getAllOf())) {
+                continue;
             }
-            if ($anyOf instanceof JsonSchema && \is_array($anyOf->getAllOf()) && [] !== $anyOf->getAllOf()) {
-                return true;
+            foreach ($anyOf->getAllOf() as $allOf) {
+                if ($allOf instanceof Reference) {
+                    return true;
+                }
             }
         }
 

--- a/src/Component/OpenApi31/Guesser/OpenApiSchema/OneOfReferencefGuesser.php
+++ b/src/Component/OpenApi31/Guesser/OpenApiSchema/OneOfReferencefGuesser.php
@@ -36,12 +36,18 @@ class OneOfReferencefGuesser implements ChainGuesserAwareInterface, GuesserInter
             return false;
         }
 
+        if ($object->getOneOf()[0] instanceof Reference) {
+            return true;
+        }
+
         foreach ($object->getOneOf() as $oneOf) {
-            if ($oneOf instanceof Reference) {
-                return true;
+            if (!$oneOf instanceof JsonSchema || !\is_array($oneOf->getAllOf())) {
+                continue;
             }
-            if ($oneOf instanceof JsonSchema && \is_array($oneOf->getAllOf()) && [] !== $oneOf->getAllOf()) {
-                return true;
+            foreach ($oneOf->getAllOf() as $allOf) {
+                if ($allOf instanceof Reference) {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
Follow-up to #951.

## Context
#951 added support for OAS 3.1 nullable references expressed as:
```json
{
  "oneOf": [
    { "allOf": [{ "$ref": "#/components/schemas/Image" }] },
    { "type": "null" }
  ]
}
```

As part of that, supportObject() in both OneOfReferencefGuesser and AnyOfReferencefGuesser was broadened to return true whenever any element is a bare Reference or an allOf-wrapped schema.

## Problem
That broadening is a behavior change beyond the intended fix: a schema like oneOf: [{type: string}, {$ref: X}] (a Reference in a non-first position, no allOf) now routes through these guessers instead of falling through to mixed, silently changing the generated type for previously-unsupported schemas.

## Change
Scopes supportObject() back down to the exact allOf-wrapped pattern while preserving the original behavior:
- first element instanceof Reference → true (unchanged backward compatibility)
- otherwise, only match when an element is a JsonSchema whose allOf actually contains a Reference
- a bare Reference in a non-first position no longer matches
guessType()'s $hasContent change from #951 is kept, as it is required for the fix (allOf elements have type === null).

## Verification
- The nullable-allof-in-oneof fixture still generates Image|null / ?Image for both oneOf and anyOf.
- The de-broadened case oneOf: [{type: string}, {$ref: X}] now correctly returns false from supportObject().