### PR TITLE
docs: add CHANGELOG entries for unreleased 2026 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [JsonSchema] [GH#971](https://github.com/janephp/janephp/pull/971) Allow registering additional validators via configuration
+- [OpenApi] [GH#975](https://github.com/janephp/janephp/pull/975) [GH#978](https://github.com/janephp/janephp/pull/978) Make error response exception generation optional (via configuration)
+
 ### Fixed
+- [Jane] [GH#952](https://github.com/janephp/janephp/pull/952) Fix PHP 8.5 deprecation warnings
+- [Jane] [GH#977](https://github.com/janephp/janephp/pull/977) Add `jane-php/open-api-3-1` to composer replace list
+- [JsonSchema] [GH#933](https://github.com/janephp/janephp/pull/933) Fix Denormalizers using `$data` before typechecking
+- [JsonSchema] [GH#943](https://github.com/janephp/janephp/pull/943) Fix array items validation follow-up
+- [JsonSchema] [GH#953](https://github.com/janephp/janephp/pull/953) Skip array items validation for non-object items schemas
+- [JsonSchema] [GH#957](https://github.com/janephp/janephp/pull/957) Support nullable required properties
+- [JsonSchema] [GH#964](https://github.com/janephp/janephp/pull/964) TypeValidator never supports union types due to misplaced parenthesis
+- [JsonSchema] [GH#967](https://github.com/janephp/janephp/pull/967) Match property class by reference segment, not substring
+- [JsonSchema] [GH#969](https://github.com/janephp/janephp/pull/969) Always generate the Constraint class so references never dangle
+- [JsonSchema] [GH#973](https://github.com/janephp/janephp/pull/973) Emit `(float)` cast instead of deprecated `(double)`
+- [OpenApi] [GH#934](https://github.com/janephp/janephp/pull/934) Allow number query parameters to accept int or float
 - [OpenApi3] Encode boolean multipart/form-data request values as `'true'`/`'false'` strings in generated endpoints
+- [OpenApi3] [GH#935](https://github.com/janephp/janephp/pull/935) Fix invalid PHP generation for path parameters with dashes
+- [OpenApi31] [GH#951](https://github.com/janephp/janephp/pull/951) Support allOf-wrapped refs in oneOf/anyOf guessers
+- [OpenApi31] [GH#980](https://github.com/janephp/janephp/pull/980) Scope oneOf/anyOf supportObject to allOf-wrapped refs
+
+### Removed
+- [Jane] [GH#931](https://github.com/janephp/janephp/pull/931) Remove all `ext-json` from composer.json
 
 ## [7.12.0] - 2026-07-09
 ### Fixed


### PR DESCRIPTION
## Description

Adds CHANGELOG.md entries for the unreleased functional changes merged in 2026 that were not yet documented.

## Changes

- **Added**: custom validator registration via configuration (GH#971) and optional error-response exception generation (GH#975/GH#978)
- **Fixed**: OpenApi31 allOf-wrapped refs in oneOf/anyOf guessers (GH#951, GH#980), JsonSchema fixes (GH#933, GH#943, GH#953, GH#957, GH#964, GH#967, GH#969, GH#973), OpenApi number query params (GH#934), OpenApi3 path params with dashes (GH#935), Jane PHP 8.5 deprecations (GH#952) and composer replace entry (GH#977)
- **Removed**: ext-json from composer.json (GH#931)

Docs/CI/tooling-only changes were intentionally excluded.

## How to test

- Review the added entries under `## [Unreleased]` in `CHANGELOG.md`
- No code changes; documentation only

## Notes

Entries reference their corresponding pull requests with links, matching the existing changelog format.
