### PR TITLE
feat(open-api-common): clean generation errors for unsupported schema features

### DIFF
--- a/docs/guides/compatibility.md
+++ b/docs/guides/compatibility.md
@@ -29,3 +29,31 @@ Use this mapping when choosing which OpenAPI package/component to install.
 
 > [!TIP]
 > If you handle mixed OpenAPI versions across projects, you can keep both `jane-php/open-api-2` and `jane-php/open-api-3` as dev dependencies. Jane will select the matching parser/component from the schema version.
+
+## Unsupported syntax across versions
+
+Jane validates your document against the features supported by the selected
+component before generating anything. When it finds something unsupported,
+generation stops with an error listing every violation and its location in
+your document (as a [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901)),
+along with how to fix it.
+
+The most common case is using OpenAPI 3.1 type arrays in a 3.0.x document:
+
+```yaml
+# Valid in OpenAPI 3.1.x, rejected by jane-php/open-api-3:
+type:
+  - string
+  - 'null'
+```
+
+```text
+Unsupported feature(s) found in your schema:
+`type` must be a string in OpenAPI 3.0.x, array given ("string", "null") at "/components/schemas/Pet/properties/status/type". Type arrays are an OpenAPI 3.1 feature: generate your client with jane-php/open-api-3-1 instead, or rewrite this schema using `nullable: true` / `oneOf`.
+```
+
+Depending on your situation, either generate with the matching package
+(`jane-php/open-api-3-1`) or rewrite the schema with the 3.0.x equivalents
+(`nullable: true`, or a `oneOf` with a `'null'` entry). See the
+[Nullability guide](nullable.md) for the correct syntax per spec version.
+

--- a/src/Bundle/JsonSchemaBundle/Command/JsonSchemaGenerateCommand.php
+++ b/src/Bundle/JsonSchemaBundle/Command/JsonSchemaGenerateCommand.php
@@ -41,7 +41,11 @@ final class JsonSchemaGenerateCommand extends Command
         }
 
         $inputArray = new ArrayInput(['--config-file' => $configFile], $this->generateCommand->getDefinition());
-        $this->generateCommand->execute($inputArray, $output);
+        $returnCode = $this->generateCommand->execute($inputArray, $output);
+
+        if (Command::SUCCESS !== $returnCode) {
+            return $returnCode;
+        }
 
         $sfStyle = new SymfonyStyle($input, $output);
         $sfStyle->success('Generation done.');

--- a/src/Bundle/OpenApiBundle/Command/OpenApiGenerateCommand.php
+++ b/src/Bundle/OpenApiBundle/Command/OpenApiGenerateCommand.php
@@ -42,7 +42,11 @@ final class OpenApiGenerateCommand extends Command
         }
 
         $inputArray = new ArrayInput(['--config-file' => $configFile], $this->generateCommand->getDefinition());
-        $this->generateCommand->execute($inputArray, $output);
+        $returnCode = $this->generateCommand->execute($inputArray, $output);
+
+        if (Command::SUCCESS !== $returnCode) {
+            return $returnCode;
+        }
 
         $sfStyle = new SymfonyStyle($input, $output);
         $sfStyle->success('Generation done.');

--- a/src/Component/JsonSchema/Console/Command/GenerateCommand.php
+++ b/src/Component/JsonSchema/Console/Command/GenerateCommand.php
@@ -4,6 +4,7 @@ namespace Jane\Component\JsonSchema\Console\Command;
 
 use Jane\Component\JsonSchema\Console\Loader\ConfigLoaderInterface;
 use Jane\Component\JsonSchema\Console\Loader\SchemaLoaderInterface;
+use Jane\Component\JsonSchema\Exception\JaneExceptionInterface;
 use Jane\Component\JsonSchema\Jane;
 use Jane\Component\JsonSchema\Printer;
 use Jane\Component\JsonSchema\Registry\Registry;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class GenerateCommand extends Command
 {
@@ -30,6 +32,18 @@ class GenerateCommand extends Command
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            return $this->executeGeneration($input, $output);
+        } catch (JaneExceptionInterface $exception) {
+            $io = new SymfonyStyle($input, $output);
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+    }
+
+    protected function executeGeneration(InputInterface $input, OutputInterface $output): int
     {
         $options = $this->configLoader->load($input->getOption('config-file'));
         $registries = $this->registries($options);

--- a/src/Component/JsonSchema/Exception/InvalidSchemaException.php
+++ b/src/Component/JsonSchema/Exception/InvalidSchemaException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Exception;
+
+/**
+ * Thrown when a schema uses features unsupported by the component handling it.
+ *
+ * Carries one human readable entry per violation, each pointing at the
+ * offending location in the document so users can fix every problem in a
+ * single pass instead of discovering them one crash at a time.
+ */
+class InvalidSchemaException extends \RuntimeException implements JaneExceptionInterface
+{
+    /** @param array<string> $errors */
+    public function __construct(
+        private readonly array $errors = [],
+    ) {
+        parent::__construct(\sprintf(
+            "Unsupported feature(s) found in your schema:\n%s",
+            implode("\n", $errors)
+        ));
+    }
+
+    /** @return array<string> */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Component/JsonSchema/Exception/JaneExceptionInterface.php
+++ b/src/Component/JsonSchema/Exception/JaneExceptionInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Exception;
+
+/**
+ * Marker interface for all user facing errors thrown by Jane components.
+ *
+ * Implementations must provide a message explaining the problem to the user
+ * and, when possible, how to fix it. Console commands can rely on this marker
+ * to render those errors cleanly instead of letting them bubble up as raw
+ * PHP errors.
+ */
+interface JaneExceptionInterface
+{
+}

--- a/src/Component/OpenApi3/SchemaParser/SchemaParser.php
+++ b/src/Component/OpenApi3/SchemaParser/SchemaParser.php
@@ -18,4 +18,14 @@ class SchemaParser extends CommonSchemaParser
     {
         return \is_array($openApiSpecData) && \array_key_exists('openapi', $openApiSpecData) && version_compare($openApiSpecData['openapi'], '3.0.0', '>=') && version_compare($openApiSpecData['openapi'], '3.1.0', '<');
     }
+
+    /**
+     * @param array<mixed> $openApiSpecData
+     *
+     * @return array<string>
+     */
+    protected function validateSchema(array $openApiSpecData): array
+    {
+        return TypeArrayValidator::validate($openApiSpecData);
+    }
 }

--- a/src/Component/OpenApi3/SchemaParser/TypeArrayValidator.php
+++ b/src/Component/OpenApi3/SchemaParser/TypeArrayValidator.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Jane\Component\OpenApi3\SchemaParser;
+
+/**
+ * Detects JSON Schema style type arrays (`type: [string, 'null']`) in a raw
+ * OpenAPI document.
+ *
+ * Those arrays are only valid since OpenAPI 3.1: in a 3.0.x document `type`
+ * must be a single string, and denormalizing such a document with the
+ * OpenApi3 models would otherwise fail with an opaque TypeError.
+ */
+final class TypeArrayValidator
+{
+    /** @var array<string> */
+    private const DATA_KEYS = [
+        'const',
+        'default',
+        'enum',
+        'example',
+        'examples',
+    ];
+
+    /**
+     * Keys whose children are property names instead of schema keywords: any
+     * collision between a property name and the keys above must still be
+     * traversed as a schema.
+     *
+     * @var array<string>
+     */
+    private const PROPERTY_MAP_KEYS = [
+        'properties',
+        'patternProperties',
+    ];
+
+    /**
+     * Returns one human readable error per `type` array found, each pointing
+     * at the offending location as a JSON pointer (RFC 6901).
+     *
+     * @param array<mixed> $document
+     *
+     * @return array<string>
+     */
+    public static function validate(array $document): array
+    {
+        $errors = [];
+
+        self::walk($document, '', $errors);
+
+        return $errors;
+    }
+
+    /**
+     * @param array<mixed>  $node
+     * @param array<string> $errors
+     */
+    private static function walk(array $node, string $pointer, array &$errors, bool $keysArePropertyNames = false): void
+    {
+        foreach ($node as $key => $value) {
+            if (!$keysArePropertyNames && \is_string($key)) {
+                if (str_starts_with($key, 'x-')) {
+                    // vendor extensions may contain arbitrary data, not schemas
+                    continue;
+                }
+
+                // plain data keys hold values, not sub schemas
+                if (\in_array($key, self::DATA_KEYS, true)) {
+                    continue;
+                }
+            }
+
+            $childPointer = $pointer . '/' . str_replace(['~', '/'], ['~0', '~1'], \is_int($key) ? (string) $key : $key);
+
+            // JSON objects are decoded as associative arrays: only lists are
+            // actual type arrays, everything else is a nested schema
+            // (e.g. a property named "type" holding its own schema object).
+            if ('type' === $key && \is_array($value) && array_is_list($value)) {
+                $types = implode(', ', array_map(
+                    static fn ($type): string => \is_string($type) ? \sprintf('"%s"', $type) : \gettype($type),
+                    $value
+                ));
+
+                $errors[] = \sprintf(
+                    '`type` must be a string in OpenAPI 3.0.x, array given (%s) at "%s". Type arrays are an OpenAPI 3.1 feature: generate your client with jane-php/open-api-3-1 instead, or rewrite this schema using `nullable: true` / `oneOf`.',
+                    $types,
+                    $childPointer
+                );
+
+                continue;
+            }
+
+            if (\is_array($value)) {
+                self::walk(
+                    $value,
+                    $childPointer,
+                    $errors,
+                    \is_string($key) && \in_array($key, self::PROPERTY_MAP_KEYS, true)
+                );
+            }
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/Issue759TypeArrayCleanErrorTest.php
+++ b/src/Component/OpenApi3/Tests/Issue759TypeArrayCleanErrorTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Jane\Component\OpenApiCommon\Console\Command\GenerateCommand;
+use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
+use Jane\Component\OpenApiCommon\Console\Loader\OpenApiMatcher;
+use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @see https://github.com/janephp/janephp/issues/759
+ */
+class Issue759TypeArrayCleanErrorTest extends TestCase
+{
+    public function testTypeArrayIn30SpecFailsWithCleanErrorInsteadOfTypeError(): void
+    {
+        $fixtureDirectory = sys_get_temp_dir() . '/jane-openapi3-issue759-error-' . bin2hex(random_bytes(8));
+        mkdir($fixtureDirectory . '/generated', 0777, true);
+
+        $openApiFile = $fixtureDirectory . '/openapi.json';
+        file_put_contents($openApiFile, json_encode([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test',
+                'version' => '1.0.0',
+            ],
+            'paths' => [],
+            'components' => [
+                'schemas' => [
+                    'Pet' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'status' => [
+                                'type' => ['string', 'null'],
+                            ],
+                            'name' => [
+                                'type' => ['string', 'null'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $configFile = $this->createConfigFile($fixtureDirectory);
+
+        try {
+            $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+            $input = new ArrayInput(['--config-file' => $configFile], $command->getDefinition());
+            $output = new BufferedOutput();
+
+            $returnCode = $command->execute($input, $output);
+            $rendered = $output->fetch();
+
+            $this->assertSame(Command::FAILURE, $returnCode);
+            // every violation is reported, not only the first one
+            $this->assertStringContainsString('/components/schemas/Pet/properties/status/type', $rendered);
+            $this->assertStringContainsString('/components/schemas/Pet/properties/name/type', $rendered);
+            $this->assertStringContainsString('jane-php/open-api-3-1', $rendered);
+            $this->assertStringNotContainsString('TypeError', $rendered);
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    public function testSameSpecWith30NullableSyntaxStillGenerates(): void
+    {
+        $fixtureDirectory = sys_get_temp_dir() . '/jane-openapi3-issue759-ok-' . bin2hex(random_bytes(8));
+        mkdir($fixtureDirectory . '/generated', 0777, true);
+
+        $openApiFile = $fixtureDirectory . '/openapi.json';
+        file_put_contents($openApiFile, json_encode([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test',
+                'version' => '1.0.0',
+            ],
+            'paths' => [],
+            'components' => [
+                'schemas' => [
+                    'Pet' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'status' => [
+                                'type' => 'string',
+                                'nullable' => true,
+                            ],
+                        ],
+                    ],
+                    // GeoJSON style schemas declare a "type" property whose
+                    // value is a regular schema object, not a type array
+                    'Point' => [
+                        'type' => 'object',
+                        'required' => ['type'],
+                        'properties' => [
+                            'type' => [
+                                'type' => 'string',
+                                'enum' => ['Point'],
+                            ],
+                            'coordinates' => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'number',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $configFile = $this->createConfigFile($fixtureDirectory);
+
+        try {
+            $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+            $input = new ArrayInput(['--config-file' => $configFile], $command->getDefinition());
+            $output = new BufferedOutput();
+
+            $returnCode = $command->execute($input, $output);
+            $rendered = $output->fetch();
+
+            $this->assertSame(Command::SUCCESS, $returnCode, $rendered);
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    private function createConfigFile(string $fixtureDirectory): string
+    {
+        $configFile = $fixtureDirectory . '/.jane-openapi';
+        file_put_contents($configFile, \sprintf(
+            "<?php\n\nreturn [\n    'openapi-file' => %s,\n    'namespace' => 'Jane\\\\Component\\\\OpenApi3\\\\Tests\\\\Issue759Generated',\n    'directory' => %s,\n];\n",
+            var_export($fixtureDirectory . '/openapi.json', true),
+            var_export($fixtureDirectory . '/generated', true)
+        ));
+
+        return $configFile;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $entries = scandir($path);
+        if (false === $entries) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+
+            $entryPath = $path . '/' . $entry;
+            if (is_dir($entryPath)) {
+                $this->removeDirectory($entryPath);
+                continue;
+            }
+
+            unlink($entryPath);
+        }
+
+        rmdir($path);
+    }
+}

--- a/src/Component/OpenApi3/Tests/TypeArrayValidatorTest.php
+++ b/src/Component/OpenApi3/Tests/TypeArrayValidatorTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Jane\Component\OpenApi3\SchemaParser\TypeArrayValidator;
+use PHPUnit\Framework\TestCase;
+
+class TypeArrayValidatorTest extends TestCase
+{
+    /**
+     * @dataProvider provideDocumentsWithTypeArray
+     *
+     * @param array<mixed>  $document
+     * @param array<string> $expectedPointers
+     */
+    public function testCollectsEveryTypeArrayOccurrence(array $document, array $expectedPointers): void
+    {
+        $errors = TypeArrayValidator::validate($document);
+
+        $this->assertCount(\count($expectedPointers), $errors);
+
+        foreach ($expectedPointers as $index => $expectedPointer) {
+            $this->assertStringContainsString(
+                \sprintf('at "%s"', $expectedPointer),
+                $errors[$index],
+                \sprintf('Error #%d does not point at "%s": %s', $index, $expectedPointer, $errors[$index])
+            );
+            $this->assertStringContainsString('jane-php/open-api-3-1', $errors[$index]);
+        }
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<mixed>, 1: array<string>}>
+     */
+    public function provideDocumentsWithTypeArray(): \Generator
+    {
+        yield 'root level schema' => [
+            [
+                'openapi' => '3.0.2',
+                'type' => ['string', 'null'],
+            ],
+            ['/type'],
+        ];
+
+        yield 'component property' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'schemas' => [
+                        'Planet' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'description' => [
+                                    'type' => ['string', 'null'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            ['/components/schemas/Planet/properties/description/type'],
+        ];
+
+        yield 'nested allOf and items use numeric pointers' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'schemas' => [
+                        'Foo' => [
+                            'allOf' => [
+                                [
+                                    'items' => [
+                                        'type' => ['integer', 'null'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            ['/components/schemas/Foo/allOf/0/items/type'],
+        ];
+
+        yield 'multiple occurrences are all reported' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'schemas' => [
+                        'A' => ['type' => ['string', 'null']],
+                        'B' => ['type' => ['integer', 'null']],
+                    ],
+                ],
+            ],
+            [
+                '/components/schemas/A/type',
+                '/components/schemas/B/type',
+            ],
+        ];
+
+        yield 'json pointer escaping' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'schemas' => [
+                        'Weird~Name/Sub' => [
+                            'properties' => [
+                                'a/b~c' => [
+                                    'type' => ['string', 'null'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            ['/components/schemas/Weird~0Name~1Sub/properties/a~1b~0c/type'],
+        ];
+
+        yield 'property named like a data or extension keyword is still a schema' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'schemas' => [
+                        'Config' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'default' => [
+                                    'type' => ['string', 'null'],
+                                ],
+                                'enum' => [
+                                    'type' => ['string', 'null'],
+                                ],
+                                'x-special' => [
+                                    'type' => ['string', 'null'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                '/components/schemas/Config/properties/default/type',
+                '/components/schemas/Config/properties/enum/type',
+                '/components/schemas/Config/properties/x-special/type',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDocumentsWithoutTypeArray
+     *
+     * @param array<mixed> $document
+     */
+    public function testValidDocumentsReportNoError(array $document): void
+    {
+        $this->assertSame([], TypeArrayValidator::validate($document));
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<mixed>}>
+     */
+    public function provideDocumentsWithoutTypeArray(): \Generator
+    {
+        yield 'property named type holding a schema object is not a violation' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'schemas' => [
+                        'Feature' => [
+                            'type' => 'object',
+                            'required' => ['type'],
+                            'properties' => [
+                                'type' => [
+                                    'type' => 'string',
+                                    'description' => 'Feature type.',
+                                ],
+                                'geometry' => [
+                                    'properties' => [
+                                        'type' => [
+                                            'type' => 'string',
+                                            'enum' => ['Point'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'classic nullable 3.0 syntax' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'schemas' => [
+                        'Planet' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'description' => [
+                                    'type' => 'string',
+                                    'nullable' => true,
+                                ],
+                                'tags' => [
+                                    'type' => 'array',
+                                    'items' => ['type' => 'string'],
+                                ],
+                                'meta' => [
+                                    'type' => 'object',
+                                    'additionalProperties' => ['type' => 'string'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'data keys holding arrays or objects are not traversed' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'schemas' => [
+                        'Planet' => [
+                            'enum' => [['type' => ['string']]],
+                            'examples' => [
+                                ['type' => ['string']],
+                            ],
+                            'default' => ['type' => ['string']],
+                            'const' => ['type' => ['string']],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'vendor extensions are ignored' => [
+            [
+                'openapi' => '3.0.2',
+                'x-vendor-data' => [
+                    'some-tool' => [
+                        'type' => ['string', 'null'],
+                    ],
+                ],
+                'paths' => [],
+            ],
+        ];
+    }
+}

--- a/src/Component/OpenApiCommon/Console/Command/GenerateCommand.php
+++ b/src/Component/OpenApiCommon/Console/Command/GenerateCommand.php
@@ -31,7 +31,7 @@ class GenerateCommand extends BaseGenerateCommand
         $this->addOption('config-file', 'c', InputOption::VALUE_REQUIRED, 'File to use for Jane OpenAPI configuration', '.jane-openapi');
     }
 
-    public function execute(InputInterface $input, OutputInterface $output): int
+    protected function executeGeneration(InputInterface $input, OutputInterface $output): int
     {
         $options = $this->configLoader->load($input->getOption('config-file'));
         $registries = $this->registries($options);

--- a/src/Component/OpenApiCommon/Exception/CouldNotParseException.php
+++ b/src/Component/OpenApiCommon/Exception/CouldNotParseException.php
@@ -2,6 +2,8 @@
 
 namespace Jane\Component\OpenApiCommon\Exception;
 
-class CouldNotParseException extends \LogicException
+use Jane\Component\JsonSchema\Exception\JaneExceptionInterface;
+
+class CouldNotParseException extends \LogicException implements JaneExceptionInterface
 {
 }

--- a/src/Component/OpenApiCommon/Exception/OpenApiVersionSupportException.php
+++ b/src/Component/OpenApiCommon/Exception/OpenApiVersionSupportException.php
@@ -2,6 +2,8 @@
 
 namespace Jane\Component\OpenApiCommon\Exception;
 
-class OpenApiVersionSupportException extends \BadMethodCallException
+use Jane\Component\JsonSchema\Exception\JaneExceptionInterface;
+
+class OpenApiVersionSupportException extends \BadMethodCallException implements JaneExceptionInterface
 {
 }

--- a/src/Component/OpenApiCommon/SchemaParser/SchemaParser.php
+++ b/src/Component/OpenApiCommon/SchemaParser/SchemaParser.php
@@ -2,6 +2,7 @@
 
 namespace Jane\Component\OpenApiCommon\SchemaParser;
 
+use Jane\Component\JsonSchema\Exception\InvalidSchemaException;
 use Jane\Component\OpenApiCommon\Exception\CouldNotParseException;
 use Jane\Component\OpenApiCommon\Exception\OpenApiVersionSupportException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -29,6 +30,12 @@ abstract class SchemaParser
 
             try {
                 return static::$parsed[$openApiSpecPath] = $this->deserialize($openApiSpecContents, $openApiSpecPath);
+            } catch (InvalidSchemaException $exception) {
+                // Structural violations do not depend on the serialization format,
+                // retrying as YAML would only report the same problem again.
+                throw $exception;
+            } catch (\TypeError $exception) {
+                throw new CouldNotParseException(\sprintf('Could not parse schema "%s": "%s"', $openApiSpecPath, $exception->getMessage()));
             } catch (\Exception $exception) {
                 $jsonException = $exception;
             }
@@ -40,6 +47,10 @@ abstract class SchemaParser
                 );
 
                 return static::$parsed[$openApiSpecPath] = $this->denormalize($content, $openApiSpecPath);
+            } catch (InvalidSchemaException $exception) {
+                throw $exception;
+            } catch (\TypeError $exception) {
+                throw new CouldNotParseException(\sprintf('Could not parse schema "%s": "%s"', $openApiSpecPath, $exception->getMessage()));
             } catch (YamlException $yamlException) {
                 throw new CouldNotParseException(\sprintf("Could not parse schema in JSON nor YAML format:\n- JSON error: \"%s\"\n- YAML error: \"%s\"\n", $jsonException->getMessage(), $yamlException->getMessage()));
             }
@@ -57,10 +68,29 @@ abstract class SchemaParser
 
     abstract protected function validSchema($openApiSpecData): bool;
 
+    /**
+     * Checks the raw decoded document for features unsupported by the target
+     * OpenAPI version, returning one human readable error per violation.
+     *
+     * @param array<mixed> $openApiSpecData
+     *
+     * @return array<string>
+     */
+    protected function validateSchema(array $openApiSpecData): array
+    {
+        return [];
+    }
+
     protected function denormalize($openApiSpecData, $openApiSpecPath)
     {
         if (!$this->validSchema($openApiSpecData)) {
             throw new OpenApiVersionSupportException(\sprintf('Only OpenAPI v%s specifications and up are supported, use an external tool to convert your api files', static::OPEN_API_VERSION_MAJOR));
+        }
+
+        $errors = $this->validateSchema($openApiSpecData);
+
+        if ([] !== $errors) {
+            throw new InvalidSchemaException($errors);
         }
 
         return $this->denormalizer->denormalize(


### PR DESCRIPTION
## Description

Fixes the raw `TypeError` crash reported in #759: feeding an OpenAPI document that uses JSON-Schema-style type arrays (`type: [string, 'null']`, valid since OAS 3.1) to `jane-php/open-api-3` aborted denormalization with an opaque PHP error pointing at generated model internals.

Generation now validates the decoded document against the selected component's supported feature set **before** parsing and stops with an explicit error listing every violation, its location as a JSON pointer (RFC 6901), and how to fix it (use `jane-php/open-api-3-1`, or rewrite with `nullable: true` / `oneOf`). The mechanism is generic: a new `validateSchema()` hook on the shared parser plus a marker interface for user-facing errors, ready to host future checks without a second error-reporting path.

## Changes

- Add `Jane\Component\JsonSchema\Exception\JaneExceptionInterface` (marker for all user-facing Jane errors) and `InvalidSchemaException` carrying one human-readable entry per violation; retrofit existing `CouldNotParseException` and `OpenApiVersionSupportException` with the marker.
- Add `SchemaParser::validateSchema()` hook called after the version guard in `OpenApiCommon`; default implementation is a no-op so other components are unaffected.
- Add `TypeArrayValidator` for OpenApi3: recursive walk collecting every `type` array occurrence with exact JSON pointers; skips vendor extensions (`x-*`) and data keys (`enum`, `examples`, ...), stays context-aware inside `properties` maps, and uses `array_is_list()` so GeoJSON-style schemas declaring a property literally named `type` are not flagged.
- Harden `SchemaParser::parseSchema()` so an escaping `\TypeError` is rethrown as `CouldNotParseException` instead of crashing, while structural violations short-circuit the JSON→YAML retry.
- Both `GenerateCommand`s catch `JaneExceptionInterface` and render a styled `[ERROR]` block with exit code `FAILURE` instead of letting errors bubble raw.
- Symfony bundle commands now propagate the inner command's return code instead of always printing "Generation done." and returning success.
- Document cross-version validation behavior in `docs/guides/compatibility.md`.
- Tests: unit tests for `TypeArrayValidator` (pointers, escaping, property-name collisions, positive controls) and an end-to-end regression test asserting clean failure output, exit code, absence of any `TypeError`, plus a generation-success control.

No breaking changes to supported syntax or generated code; behavior changes are limited to error reporting (clean failure where a raw crash previously occurred). No new dependencies.

## How to test

1. Run the full suite from a clean state: `vendor/bin/phpunit` — expect green including the new `TypeArrayValidatorTest` and `Issue759TypeArrayCleanErrorTest`.
2. Reproduce the original report: create a 3.0.x spec containing

   ```yaml
   example_property:
     type:
       - string
       - 'null'
   ```

   run `bin/jane-openapi generate` with a `jane-php/open-api-3` config — generation exits non-zero with an error naming `/…/example_property/type` and the fix options, instead of a `TypeError` stack trace.
3. Static analysis: `castor qa:phpstan` reports no errors.
