### PR TITLE
feat(open-api-3): clean generation errors for non-body parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - [JsonSchema] [GH#865](https://github.com/janephp/janephp/issues/865) New `enums-as-objects` option to generate native PHP backed enums for schemas with an `enum` keyword (`string` / `integer` types)
+- [OpenApi3] [GH#771](https://github.com/janephp/janephp/issues/771) Report clean generation errors for non-body parameters using an unsupported `schema.type` (or no `type`/`enum`) instead of crashing
+
 
 ### Fixed
 - [OpenApi] [GH#963](https://github.com/janephp/janephp/issues/963) Support JSON content types with parameters (e.g. `application/json;schema=...`) when generating response transformations and operation/model relations

--- a/docs/guides/compatibility.md
+++ b/docs/guides/compatibility.md
@@ -57,3 +57,32 @@ Depending on your situation, either generate with the matching package
 (`nullable: true`, or a `oneOf` with a `'null'` entry). See the
 [Nullability guide](nullable.md) for the correct syntax per spec version.
 
+### Unsupported `type` for non-body parameters
+
+Query, header, path and cookie parameters map their `schema.type` to a PHP
+type. In a 3.0.x document only `string`, `number`, `boolean`, `integer`,
+`array`, `object` and `file` are accepted: anything else — or a parameter
+schema with neither `type` nor `enum` — stops generation with the offending
+location instead of crashing midway:
+
+```yaml
+# Rejected by jane-php/open-api-3:
+paths:
+  /pets:
+    get:
+      parameters:
+        - name: since
+          in: query
+          schema:
+            type: 'null'
+```
+
+```text
+Unsupported feature(s) found in your schema:
+`type` "null" is not supported for non-body parameters, expected one of "string", "number", "boolean", "integer", "array", "object" or "file" at "/paths/~1pets/get/parameters/0/schema/type".
+```
+
+Object-typed parameters (e.g. `deepObject` style) and schemas relying on an
+`enum` alone remain fully supported.
+
+

--- a/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Generator\Parameter;
 
+use Jane\Component\JsonSchema\Exception\InvalidSchemaException;
 use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi3\Guesser\GuessClass;
@@ -215,6 +216,15 @@ class NonBodyParameterGenerator extends ParameterGenerator
             'object' => ['array'],
             'file' => ['string', 'resource', '\\' . StreamInterface::class],
         ];
+
+        if (!isset($convertArray[$type])) {
+            $message = \sprintf(
+                'Unsupported `type` %s for non-body parameter: expected one of "string", "number", "boolean", "integer", "array", "object" or "file".',
+                null === $type ? 'missing' : \sprintf('"%s"', $type)
+            );
+
+            throw new InvalidSchemaException([$message]);
+        }
 
         return $convertArray[$type];
     }

--- a/src/Component/OpenApi3/SchemaParser/NonBodyParameterTypeValidator.php
+++ b/src/Component/OpenApi3/SchemaParser/NonBodyParameterTypeValidator.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Jane\Component\OpenApi3\SchemaParser;
+
+/**
+ * Detects non-body parameters whose `schema.type` cannot be mapped to a PHP
+ * type by the NonBodyParameterGenerator.
+ *
+ * OpenAPI 3.0.x only allows a fixed set of types for such parameters: feeding
+ * anything else (or omitting `type` without providing an `enum`) used to make
+ * generation crash with an opaque error deep inside the generator instead of
+ * a readable message pointing at the offending parameter.
+ */
+final class NonBodyParameterTypeValidator
+{
+    /** @var array<string> */
+    private const SUPPORTED_TYPES = [
+        'string',
+        'number',
+        'boolean',
+        'integer',
+        'array',
+        'object',
+        'file',
+    ];
+
+    /** @var array<string> */
+    private const HTTP_METHODS = [
+        'get',
+        'put',
+        'post',
+        'delete',
+        'options',
+        'head',
+        'patch',
+        'trace',
+    ];
+
+    /**
+     * Returns one human readable error per invalid non-body parameter, each
+     * pointing at the offending location as a JSON pointer (RFC 6901).
+     *
+     * @param array<mixed> $document
+     *
+     * @return array<string>
+     */
+    public static function validate(array $document): array
+    {
+        $errors = [];
+
+        if (!isset($document['paths']) || !\is_array($document['paths'])) {
+            return $errors;
+        }
+
+        foreach ($document['paths'] as $path => $pathItem) {
+            if (!\is_array($pathItem)) {
+                continue;
+            }
+
+            $pathPointer = '/paths/' . self::escapePointerToken((string) $path);
+
+            if (isset($pathItem['parameters']) && \is_array($pathItem['parameters'])) {
+                foreach ($pathItem['parameters'] as $index => $parameter) {
+                    self::validateParameter($parameter, $pathPointer . '/parameters/' . $index, $errors);
+                }
+            }
+
+            foreach (self::HTTP_METHODS as $method) {
+                if (!isset($pathItem[$method]['parameters']) || !\is_array($pathItem[$method]['parameters'])) {
+                    continue;
+                }
+
+                foreach ($pathItem[$method]['parameters'] as $index => $parameter) {
+                    self::validateParameter($parameter, $pathPointer . '/' . $method . '/parameters/' . $index, $errors);
+                }
+            }
+        }
+
+        if (isset($document['components']['parameters']) && \is_array($document['components']['parameters'])) {
+            foreach ($document['components']['parameters'] as $name => $parameter) {
+                self::validateParameter($parameter, '/components/parameters/' . self::escapePointerToken((string) $name), $errors);
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string> $errors
+     */
+    private static function validateParameter($parameter, string $pointer, array &$errors): void
+    {
+        if (!\is_array($parameter) || isset($parameter['$ref']) || isset($parameter['content'])) {
+            return;
+        }
+
+        $schema = $parameter['schema'] ?? null;
+
+        if (!\is_array($schema) || isset($schema['$ref'])) {
+            return;
+        }
+
+        // anyOf parameters are short-circuited by the generator, they never
+        // reach a single PHP type mapping
+        if (\array_key_exists('anyOf', $schema)) {
+            return;
+        }
+
+        $type = $schema['type'] ?? null;
+        $typePointer = $pointer . '/schema/type';
+
+        if (\is_string($type)) {
+            if (!\in_array($type, self::SUPPORTED_TYPES, true)) {
+                $errors[] = \sprintf(
+                    '`type` "%s" is not supported for non-body parameters, expected one of "string", "number", "boolean", "integer", "array", "object" or "file" at "%s".',
+                    $type,
+                    $typePointer
+                );
+            }
+
+            return;
+        }
+
+        if (null !== $type) {
+            // type arrays are already reported by TypeArrayValidator
+            if (\is_array($type) && array_is_list($type)) {
+                return;
+            }
+
+            $errors[] = \sprintf(
+                '`type` %s is not supported for non-body parameters, expected one of "string", "number", "boolean", "integer", "array", "object" or "file" at "%s".',
+                \gettype($type),
+                $typePointer
+            );
+
+            return;
+        }
+
+        $enum = $schema['enum'] ?? null;
+
+        if (!\is_array($enum) || [] === $enum) {
+            $errors[] = \sprintf(
+                'Missing `type` for non-body parameter, expected one of "string", "number", "boolean", "integer", "array", "object" or "file", or an `enum` at "%s".',
+                $pointer . '/schema'
+            );
+        }
+    }
+
+    private static function escapePointerToken(string $token): string
+    {
+        return str_replace(['~', '/'], ['~0', '~1'], $token);
+    }
+}

--- a/src/Component/OpenApi3/SchemaParser/SchemaParser.php
+++ b/src/Component/OpenApi3/SchemaParser/SchemaParser.php
@@ -26,6 +26,9 @@ class SchemaParser extends CommonSchemaParser
      */
     protected function validateSchema(array $openApiSpecData): array
     {
-        return TypeArrayValidator::validate($openApiSpecData);
+        return array_merge(
+            TypeArrayValidator::validate($openApiSpecData),
+            NonBodyParameterTypeValidator::validate($openApiSpecData)
+        );
     }
 }

--- a/src/Component/OpenApi3/Tests/Issue771UnsupportedParameterTypeErrorTest.php
+++ b/src/Component/OpenApi3/Tests/Issue771UnsupportedParameterTypeErrorTest.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Jane\Component\OpenApiCommon\Console\Command\GenerateCommand;
+use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
+use Jane\Component\OpenApiCommon\Console\Loader\OpenApiMatcher;
+use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @see https://github.com/janephp/janephp/issues/771
+ */
+class Issue771UnsupportedParameterTypeErrorTest extends TestCase
+{
+    public function testUnsupportedNonBodyParameterTypeFailsWithCleanError(): void
+    {
+        $fixtureDirectory = sys_get_temp_dir() . '/jane-openapi3-issue771-error-' . bin2hex(random_bytes(8));
+        mkdir($fixtureDirectory . '/generated', 0777, true);
+
+        $openApiFile = $fixtureDirectory . '/openapi.json';
+        file_put_contents($openApiFile, json_encode([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test',
+                'version' => '1.0.0',
+            ],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'operationId' => 'listPets',
+                        'parameters' => [
+                            [
+                                'name' => 'since',
+                                'in' => 'query',
+                                'schema' => [
+                                    'type' => 'null',
+                                ],
+                            ],
+                        ],
+                        'responses' => [
+                            '200' => ['description' => 'Ok'],
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'parameters' => [
+                    'Limit' => [
+                        'name' => 'limit',
+                        'in' => 'query',
+                        'schema' => [
+                            'type' => 'float64',
+                        ],
+                    ],
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $configFile = $this->createConfigFile($fixtureDirectory);
+
+        try {
+            $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+            $input = new ArrayInput(['--config-file' => $configFile], $command->getDefinition());
+            $output = new BufferedOutput();
+
+            $returnCode = $command->execute($input, $output);
+            $rendered = $output->fetch();
+
+            $this->assertSame(Command::FAILURE, $returnCode);
+            // every violation is reported, not only the first one
+            $this->assertStringContainsString('/paths/~1pets/get/parameters/0/schema/type', $rendered);
+            $this->assertStringContainsString('/components/parameters/Limit/schema/type', $rendered);
+            $this->assertStringContainsString('is not supported for non-body parameters', $rendered);
+            $this->assertStringNotContainsString('TypeError', $rendered);
+            $this->assertStringNotContainsString('Undefined array key', $rendered);
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    public function testObjectTypedQueryParameterStillGenerates(): void
+    {
+        $fixtureDirectory = sys_get_temp_dir() . '/jane-openapi3-issue771-ok-' . bin2hex(random_bytes(8));
+        mkdir($fixtureDirectory . '/generated', 0777, true);
+
+        $openApiFile = $fixtureDirectory . '/openapi.json';
+        file_put_contents($openApiFile, json_encode([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test',
+                'version' => '1.0.0',
+            ],
+            'paths' => [
+                '/things' => [
+                    'get' => [
+                        'operationId' => 'listThings',
+                        'parameters' => [
+                            [
+                                'name' => 'filter',
+                                'in' => 'query',
+                                'style' => 'deepObject',
+                                'explode' => true,
+                                'schema' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'from' => ['type' => 'string'],
+                                        'to' => ['type' => 'string'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'responses' => [
+                            '200' => ['description' => 'Ok'],
+                        ],
+                    ],
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $configFile = $this->createConfigFile($fixtureDirectory);
+
+        try {
+            $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+            $input = new ArrayInput(['--config-file' => $configFile], $command->getDefinition());
+            $output = new BufferedOutput();
+
+            $returnCode = $command->execute($input, $output);
+            $rendered = $output->fetch();
+
+            $this->assertSame(Command::SUCCESS, $returnCode, $rendered);
+            $this->assertFileExists($fixtureDirectory . '/generated/Endpoint/ListThings.php');
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    public function testMissingTypeWithoutEnumFailsWithCleanError(): void
+    {
+        $fixtureDirectory = sys_get_temp_dir() . '/jane-openapi3-issue771-missing-' . bin2hex(random_bytes(8));
+        mkdir($fixtureDirectory . '/generated', 0777, true);
+
+        $openApiFile = $fixtureDirectory . '/openapi.json';
+        file_put_contents($openApiFile, json_encode([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test',
+                'version' => '1.0.0',
+            ],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'operationId' => 'listPets',
+                        'parameters' => [
+                            [
+                                'name' => 'since',
+                                'in' => 'query',
+                                'schema' => new \stdClass(),
+                            ],
+                        ],
+                        'responses' => [
+                            '200' => ['description' => 'Ok'],
+                        ],
+                    ],
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $configFile = $this->createConfigFile($fixtureDirectory);
+
+        try {
+            $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+            $input = new ArrayInput(['--config-file' => $configFile], $command->getDefinition());
+            $output = new BufferedOutput();
+
+            $returnCode = $command->execute($input, $output);
+            $rendered = $output->fetch();
+
+            $this->assertSame(Command::FAILURE, $returnCode);
+            $this->assertStringContainsString('/paths/~1pets/get/parameters/0/schema', $rendered);
+            $this->assertStringContainsString('Missing `type` for non-body parameter', $rendered);
+            $this->assertStringNotContainsString('TypeError', $rendered);
+            $this->assertStringNotContainsString('Undefined array key', $rendered);
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    private function createConfigFile(string $fixtureDirectory): string
+    {
+        $configFile = $fixtureDirectory . '/.jane-openapi';
+        file_put_contents($configFile, \sprintf(
+            "<?php\n\nreturn [\n    'openapi-file' => %s,\n    'namespace' => 'Jane\\\\Component\\\\OpenApi3\\\\Tests\\\\Issue771Generated',\n    'directory' => %s,\n];\n",
+            var_export($fixtureDirectory . '/openapi.json', true),
+            var_export($fixtureDirectory . '/generated', true)
+        ));
+
+        return $configFile;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $entries = scandir($path);
+        if (false === $entries) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+
+            $entryPath = $path . '/' . $entry;
+            if (is_dir($entryPath)) {
+                $this->removeDirectory($entryPath);
+                continue;
+            }
+
+            unlink($entryPath);
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Description

Adds clean generation errors for OpenAPI 3 non-body parameters whose `schema.type` cannot be mapped to a PHP type (issue #771), building on the validation mechanism introduced in #983.

Feeding such a document used to crash generation with an opaque error deep inside `NonBodyParameterGenerator`. The document is now validated before parsing and generation stops with an explicit error listing every violation and its JSON pointer.

## Changes

- Add `NonBodyParameterTypeValidator`: walks path-level, operation-level and `components.parameters` entries in the raw document; skips `$ref` and `content`-style parameters as well as schema-level `$ref`; flags a `schema.type` outside `string`, `number`, `boolean`, `integer`, `array`, `object`, `file`, or a missing type without `enum`; reports RFC 6901 JSON pointers
- Merge its errors into the OpenApi3 `SchemaParser::validateSchema()` hook alongside `TypeArrayValidator`
- Throw `InvalidSchemaException` from `NonBodyParameterGenerator::convertParameterType()` as a safety net for schemas that bypass raw-document validation
- `anyOf`-only parameter schemas keep generating (the generator short-circuits them before type conversion)
- Tests: `Issue771UnsupportedParameterTypeErrorTest` covers failure output (exit code 1, both JSON pointers, no `TypeError`/`Undefined array key`), a missing-type case, and successful generation of an object-typed (`deepObject`) query parameter
- Document the unsupported parameter types in `docs/guides/compatibility.md` and add a CHANGELOG entry

## How to test

1. `vendor/bin/phpunit --filter Issue771`
2. Full suite: `vendor/bin/phpunit` (no fixture changes required)
3. Static analysis: `castor qa:phpstan`

## Notes

- Stacked on #983 (branch contains its commit f288993b1); only the second commit is new.
- No fixture regeneration: existing fixtures were scanned and none use an invalid non-body parameter type.
