### PR TITLE
fix(open-api-3): resolve parameter schema refs before reading defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [JsonSchema] [GH#865](https://github.com/janephp/janephp/issues/865) New `enums-as-objects` option to generate native PHP backed enums for schemas with an `enum` keyword (`string` / `integer` types)
 - [OpenApi3] [GH#771](https://github.com/janephp/janephp/issues/771) Report clean generation errors for non-body parameters using an unsupported `schema.type` (or no `type`/`enum`) instead of crashing
 
-
 ### Fixed
 - [OpenApi] [GH#963](https://github.com/janephp/janephp/issues/963) Support JSON content types with parameters (e.g. `application/json;schema=...`) when generating response transformations and operation/model relations
 - [OpenApi] [GH#963](https://github.com/janephp/janephp/issues/963) Generate models for `allOf` schemas whose members omit an explicit `type: object`
 - [OpenApi31] [GH#946](https://github.com/janephp/janephp/issues/946) Generate response models and correct `transformResponseBody` return types for inline response schemas (array responses are typed as `Model[]` again)
 - [OpenApi31] Keep endpoint names plural for operations returning an array response
 - [OpenApi] Support union types (e.g. `type: ["array", "null"]`) when detecting array schemas
+- [OpenApi3] [GH#803](https://github.com/janephp/janephp/issues/803) Fix fatal error when a non-required query/header parameter references a schema defining a `default` (the default is now applied to the generated options resolver)
+- [Jane] Wrap unexpected generation-phase errors in a clean `GenerationFailedException` instead of letting raw PHP errors reach the console
 
 ## [7.13.0] - 2026-08-17
 ### Added

--- a/src/Component/JsonSchema/Exception/GenerationFailedException.php
+++ b/src/Component/JsonSchema/Exception/GenerationFailedException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Exception;
+
+/**
+ * Safety net for unexpected errors raised during the generation phase.
+ *
+ * Raw PHP errors (TypeError, Error, ...) are wrapped so console and bundle
+ * commands can render a clean message instead of a stack trace, while the
+ * original error class and message stay visible for debugging.
+ */
+class GenerationFailedException extends \RuntimeException implements JaneExceptionInterface
+{
+    public function __construct(
+        string $schemaOrigin,
+        \Throwable $previous,
+    ) {
+        parent::__construct(\sprintf(
+            'An unexpected error occurred while generating "%s": [%s] %s',
+            $schemaOrigin,
+            \get_class($previous),
+            $previous->getMessage()
+        ), 0, $previous);
+    }
+}

--- a/src/Component/JsonSchema/Generator/ChainGenerator.php
+++ b/src/Component/JsonSchema/Generator/ChainGenerator.php
@@ -2,6 +2,8 @@
 
 namespace Jane\Component\JsonSchema\Generator;
 
+use Jane\Component\JsonSchema\Exception\GenerationFailedException;
+use Jane\Component\JsonSchema\Exception\JaneExceptionInterface;
 use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\JsonSchema\Registry\Registry;
 
@@ -25,7 +27,13 @@ abstract class ChainGenerator
             $context->setCurrentSchema($schema);
 
             foreach ($this->generators as $generator) {
-                $generator->generate($schema, $schema->getRootName(), $context);
+                try {
+                    $generator->generate($schema, $schema->getRootName(), $context);
+                } catch (JaneExceptionInterface $exception) {
+                    throw $exception;
+                } catch (\Throwable $exception) {
+                    throw new GenerationFailedException($context->getCurrentSchema()->getOrigin(), $exception);
+                }
             }
         }
     }

--- a/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
@@ -40,19 +40,20 @@ class NonBodyParameterGenerator extends ParameterGenerator
         $name = $this->getInflector()->camelize($parameter->getName());
         $methodParameter = new Node\Param(new Expr\Variable($name));
 
-        if (!$parameter->getSchema()) {
+        $schema = $parameter->getSchema();
+        if (!$schema instanceof Schema) {
             return $methodParameter;
         }
 
-        if (!$parameter->getRequired() || null !== $parameter->getSchema()->getDefault()) {
-            $methodParameter->default = $this->getDefaultAsExpr($parameter);
+        if (!$parameter->getRequired() || null !== $schema->getDefault()) {
+            $methodParameter->default = $this->getDefaultAsExpr($schema);
         }
 
-        if (null !== $parameter->getSchema()->getAnyOf() && \count($parameter->getSchema()->getAnyOf()) > 0) {
+        if (null !== $schema->getAnyOf() && \count($schema->getAnyOf()) > 0) {
             return $methodParameter;
         }
 
-        $types = $this->convertParameterType($parameter->getSchema());
+        $types = $this->convertParameterType($schema);
 
         if (\count($types) === 1) {
             $methodParameter->type = new Node\Name($types[0]);
@@ -112,7 +113,7 @@ class NonBodyParameterGenerator extends ParameterGenerator
             }
 
             if (!$parameter->getRequired() && null !== $schema && null !== $schema->getDefault()) {
-                $defaults[] = new Expr\ArrayItem($this->getDefaultAsExpr($parameter), new Scalar\String_($parameterName));
+                $defaults[] = new Expr\ArrayItem($this->getDefaultAsExpr($schema), new Scalar\String_($parameterName));
             }
 
             if (null !== $matchGenericResolver) {
@@ -141,9 +142,10 @@ class NonBodyParameterGenerator extends ParameterGenerator
     public function generateMethodDocParameter($parameter, Context $context, string $reference): string
     {
         $type = 'mixed';
+        $schema = $parameter->getSchema();
 
-        if ($parameter->getSchema() && (null === $parameter->getSchema()->getAnyOf() || \count($parameter->getSchema()->getAnyOf()) === 0)) {
-            $type = implode('|', $this->convertParameterType($parameter->getSchema()));
+        if ($schema instanceof Schema && (null === $schema->getAnyOf() || \count($schema->getAnyOf()) === 0)) {
+            $type = implode('|', $this->convertParameterType($schema));
         }
 
         return rtrim(\sprintf(' * @param %s $%s %s', $type, str_replace('*/', '*\\/', $this->getInflector()->camelize($parameter->getName())), str_replace('*/', '*\\/', $parameter->getDescription() ?: '')));
@@ -173,10 +175,10 @@ class NonBodyParameterGenerator extends ParameterGenerator
     /**
      * Generate a default value as an Expr.
      */
-    private function getDefaultAsExpr(Parameter $parameter): Expr
+    private function getDefaultAsExpr(Schema $schema): Expr
     {
         /** @var Expr|Stmt\Expression $expr */
-        $expr = $this->parser->parse('<?php ' . var_export($parameter->getSchema()->getDefault(), true) . ';')[0];
+        $expr = $this->parser->parse('<?php ' . var_export($schema->getDefault(), true) . ';')[0];
 
         if ($expr instanceof Stmt\Expression) {
             return $expr->expr;

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.yaml',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Client.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * Foo bar
+     *
+     * @param array{
+     *    "mode"?: string, //File listing mode
+     * } $queryParameters
+     * @param array{
+     *    "X-Sort-Order"?: string, //Sort order
+     * } $headerParameters
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Expected\Model\File[] : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getFiles(array $queryParameters = [], array $headerParameters = [], string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetFiles($queryParameters, $headerParameters), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://example.com/rest/v1');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Endpoint/GetFiles.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Endpoint/GetFiles.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetFiles extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    /**
+     * Foo bar
+     *
+     * @param array{
+     *    "mode"?: string, //File listing mode
+     * } $queryParameters
+     * @param array{
+     *    "X-Sort-Order"?: string, //Sort order
+     * } $headerParameters
+     */
+    public function __construct(array $queryParameters = [], array $headerParameters = [])
+    {
+        $this->queryParameters = $queryParameters;
+        $this->headerParameters = $headerParameters;
+    }
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/files';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(['mode']);
+        $optionsResolver->setRequired([]);
+        $optionsResolver->setDefaults(['mode' => 'auto']);
+        $optionsResolver->addAllowedTypes('mode', ['string']);
+        return $optionsResolver;
+    }
+    protected function getHeadersOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getHeadersOptionsResolver();
+        $optionsResolver->setDefined(['X-Sort-Order']);
+        $optionsResolver->setRequired([]);
+        $optionsResolver->setDefaults(['X-Sort-Order' => 'asc']);
+        $optionsResolver->addAllowedTypes('X-Sort-Order', ['string']);
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\File[]
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Expected\Model\File[]', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Model/File.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Model/File.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class File extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * File identifier
+     *
+     * @var string
+     */
+    protected $id;
+    /**
+     * File identifier
+     *
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+    /**
+     * File identifier
+     *
+     * @param string $id
+     *
+     * @return self
+     */
+    public function setId(string $id): self
+    {
+        $this->initialized['id'] = true;
+        $this->id = $id;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Normalizer/FileNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Normalizer/FileNormalizer.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FileNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\File::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\File::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\File();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('id', $data)) {
+            $object->setId($data['id']);
+            unset($data['id']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('id') && null !== $data->getId()) {
+            $dataArray['id'] = $data->getId();
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\File::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi3\Tests\Expected\Model\File::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\FileNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            
+            \Jane\Component\OpenApi3\Tests\Expected\Model\File::class => false,
+            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+        ];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(static function ($value) {
+            return $value ?? '';
+        }, $optionsResolved);
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            $allowReservedKey = in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/openapi.yaml
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/openapi.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.2
+info:
+  title: Test
+  version: 0.0.0
+servers:
+  - url: https://example.com/rest/v1
+paths:
+  /files:
+    get:
+      operationId: getFiles
+      summary: List all files
+      description: |
+        Foo bar
+      tags:
+        - Files
+      parameters:
+        - $ref: '#/components/parameters/fileMode'
+        - $ref: '#/components/parameters/fileSort'
+      responses:
+        '200':
+          $ref: '#/components/responses/FileList'
+components:
+  parameters:
+    fileMode:
+      in: query
+      name: mode
+      required: false
+      description: "File listing mode"
+      schema:
+        $ref: "#/components/schemas/mode"
+    fileSort:
+      in: header
+      name: X-Sort-Order
+      required: false
+      description: "Sort order"
+      schema:
+        $ref: "#/components/schemas/sortOrder"
+  schemas:
+    file:
+      type: object
+      properties:
+        id:
+          type: string
+          description: File identifier
+    mode:
+      type: string
+      default: auto
+      description: File listing mode
+    sortOrder:
+      type: string
+      default: asc
+      description: Sort order
+  responses:
+    FileList:
+      description: Return the list of files.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/file'


### PR DESCRIPTION
## Description

Fixes GH-803: `jane-openapi generate` crashed with a raw PHP error when a **non-required** query/header parameter's `schema` was a `$ref` to a schema defining a `default` (e.g. VRChat, Bitly specs). The options resolver generator read the default from the raw schema (a `Reference` object) instead of the resolved one. These documents are valid OpenAPI 3.0 and now generate correctly.

As a safety net, any unexpected error raised during the generation phase is now wrapped in a `JaneExceptionInterface` exception, so console and bundle commands render a clean message instead of a stack trace.

## Changes

- `OpenApi3/NonBodyParameterGenerator`: `getDefaultAsExpr()` now takes the resolved `Schema` and reads its default; the options resolver call site passes the schema already resolved through `GuessClass::resolve()` — this alone closes GH-803
- `OpenApi3/NonBodyParameterGenerator`: `generateMethodParameter()` and `generateMethodDocParameter()` are guarded with `instanceof Schema` checks, mirroring the existing `OpenApi31` implementation
- `JsonSchema/ChainGenerator`: rethrows `JaneExceptionInterface` untouched and wraps any other `\Throwable` in the new `GenerationFailedException`, carrying the schema origin plus the original error class and message
- New regression fixture `OpenApi3/Tests/fixtures/issue-803/`: non-required query + header parameters whose `$ref`'d schemas define defaults; generated endpoints contain `$optionsResolver->setDefaults(['mode' => 'auto'])`
- CHANGELOG entries under Unreleased

## How to test

1. `vendor/bin/phpunit` — full suite passes (355 tests), including the new `issue-803` resource fixture and untouched `issue-299` / `parameter-type-reference` fixtures
2. `castor qa:phpstan` — no errors
3. Manual: run generation on an OpenAPI 3.0 document with a non-required `$ref`'d query parameter whose target has a `default`; the endpoint now applies it via `setDefaults()`

## Notes

- Based on top of the janephp-759 branch work (`f288993b1`); that commit is included in this PR until #759 merges
- A *required* parameter whose `$ref`'d schema has a `default` still lands in `setRequired()` with its default silently dropped (pre-existing, same in OpenApi31) — deliberately left out of scope
