### PR TITLE
fix(json-schema): reference external normalizers for cross-schema models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [OpenApi3] [GH#771](https://github.com/janephp/janephp/issues/771) Report clean generation errors for non-body parameters using an unsupported `schema.type` (or no `type`/`enum`) instead of crashing
 
 ### Fixed
+- [JsonSchema] [GH#585](https://github.com/janephp/janephp/issues/585) Reference normalizers of models from other mapped schemas (transitively) used by a schema's models in its generated `JaneObjectNormalizer`, so multi-namespace mappings no longer fail at runtime with "no supporting normalizer found"
 - [OpenApi] [GH#963](https://github.com/janephp/janephp/issues/963) Support JSON content types with parameters (e.g. `application/json;schema=...`) when generating response transformations and operation/model relations
 - [OpenApi] [GH#963](https://github.com/janephp/janephp/issues/963) Generate models for `allOf` schemas whose members omit an explicit `type: object`
 - [OpenApi31] [GH#946](https://github.com/janephp/janephp/issues/946) Generate response models and correct `transformResponseBody` return types for inline response schemas (array responses are typed as `Model[]` again)

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
     },
     "autoload-dev": {
         "classmap": [
+            "src/Component/JsonSchema/Tests/",
             "src/Component/OpenApi2/Tests/",
             "src/Component/OpenApi3/Tests/"
         ],

--- a/src/Component/JsonSchema/Generator/Normalizer/ExternalNormalizersResolver.php
+++ b/src/Component/JsonSchema/Generator/Normalizer/ExternalNormalizersResolver.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Generator\Normalizer;
+
+use Jane\Component\JsonSchema\Guesser\Guess\ArrayType;
+use Jane\Component\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\Component\JsonSchema\Guesser\Guess\MultipleType;
+use Jane\Component\JsonSchema\Guesser\Guess\NonObjectGuessInterface;
+use Jane\Component\JsonSchema\Guesser\Guess\ObjectType;
+use Jane\Component\JsonSchema\Guesser\Guess\Type;
+use Jane\Component\JsonSchema\Registry\Registry;
+use Jane\Component\JsonSchema\Registry\Schema;
+
+/**
+ * Collects the normalizers of models belonging to other schemas (namespaces) that are
+ * transitively used by the models of a given schema.
+ *
+ * A generated JaneObjectNormalizer only knows how to handle the models of its own schema.
+ * When a model references a model from another mapped schema, the generated normalizers
+ * delegate that property to the Symfony serializer at runtime. Without a mapping entry
+ * pointing to the foreign model's normalizer, no supporting normalizer can be found.
+ */
+class ExternalNormalizersResolver
+{
+    /**
+     * @return array<string, string> Model FQCN => normalizer FQCN, sorted by model FQCN
+     */
+    public function resolve(Schema $schema, Registry $registry): array
+    {
+        $owners = [];
+
+        foreach ($registry->getSchemas() as $registeredSchema) {
+            foreach ($registeredSchema->getClasses() as $class) {
+                if ($class instanceof NonObjectGuessInterface) {
+                    continue;
+                }
+
+                $owners[$this->getModelFqcn($registeredSchema, $class)] = [$registeredSchema, $class];
+            }
+        }
+
+        $mappings = [];
+        $visited = [];
+        $queue = [];
+
+        foreach ($schema->getClasses() as $class) {
+            if ($class instanceof NonObjectGuessInterface) {
+                continue;
+            }
+
+            $modelFqcn = $this->getModelFqcn($schema, $class);
+
+            if (!isset($visited[$modelFqcn])) {
+                $visited[$modelFqcn] = true;
+                $queue[] = $modelFqcn;
+            }
+        }
+
+        while ([] !== $queue) {
+            $modelFqcn = array_shift($queue);
+
+            if (!isset($owners[$modelFqcn])) {
+                continue;
+            }
+
+            /** @var ClassGuess $ownerClass */
+            [$ownerSchema, $ownerClass] = $owners[$modelFqcn];
+
+            foreach ($ownerClass->getProperties() as $property) {
+                foreach ($this->getObjectTypes($property->getType()) as $objectType) {
+                    $dependencyFqcn = ltrim($objectType->getFqdn(false), '\\');
+
+                    if (!isset($owners[$dependencyFqcn]) || isset($visited[$dependencyFqcn])) {
+                        continue;
+                    }
+
+                    $visited[$dependencyFqcn] = true;
+                    $queue[] = $dependencyFqcn;
+
+                    /** @var Schema $dependencySchema */
+                    [$dependencySchema, $dependencyClass] = $owners[$dependencyFqcn];
+
+                    if ($dependencySchema !== $schema) {
+                        $mappings[$dependencyFqcn] = \sprintf(
+                            '%s\\Normalizer\\%sNormalizer',
+                            $dependencySchema->getNamespace(),
+                            $dependencyClass->getName()
+                        );
+                    }
+                }
+            }
+        }
+
+        ksort($mappings);
+
+        return $mappings;
+    }
+
+    /**
+     * @return array<ObjectType>
+     */
+    private function getObjectTypes(Type $type): array
+    {
+        if ($type instanceof ObjectType) {
+            return [$type];
+        }
+
+        if ($type instanceof ArrayType) {
+            return $this->getObjectTypes($type->getItemType());
+        }
+
+        if ($type instanceof MultipleType) {
+            $objectTypes = [];
+
+            foreach ($type->getTypes() as $subType) {
+                foreach ($this->getObjectTypes($subType) as $objectType) {
+                    $objectTypes[] = $objectType;
+                }
+            }
+
+            return $objectTypes;
+        }
+
+        return [];
+    }
+
+    private function getModelFqcn(Schema $schema, ClassGuess $class): string
+    {
+        return \sprintf('%s\\Model\\%s', $schema->getNamespace(), $class->getName());
+    }
+}

--- a/src/Component/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/NormalizerGenerator.php
@@ -4,6 +4,7 @@ namespace Jane\Component\JsonSchema\Generator;
 
 use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\JsonSchema\Generator\Normalizer\DenormalizerGenerator;
+use Jane\Component\JsonSchema\Generator\Normalizer\ExternalNormalizersResolver;
 use Jane\Component\JsonSchema\Generator\Normalizer\JaneObjectNormalizerGenerator;
 use Jane\Component\JsonSchema\Generator\Normalizer\NormalizerGenerator as NormalizerGeneratorTrait;
 use Jane\Component\JsonSchema\Guesser\Guess\NonObjectGuessInterface;
@@ -107,6 +108,10 @@ class NormalizerGenerator implements GeneratorInterface
             $normalizers[$modelFqdn] = $schema->getNamespace() . '\\Normalizer\\' . $symfony7NormalizerClass->name;
             $schema->addFile(new File($schema->getDirectory() . '/Normalizer/' . $symfony7NormalizerClass->name . '.php', $namespace, self::FILE_TYPE_NORMALIZER));
         }
+
+        // Add normalizers of models from other schemas transitively used by this schema's models,
+        // so the generated JaneObjectNormalizer can handle them at runtime.
+        $normalizers += (new ExternalNormalizersResolver())->resolve($schema, $context->getRegistry());
 
         $schema->addFile(new File(
             $schema->getDirectory() . '/Normalizer/JaneObjectNormalizer.php',

--- a/src/Component/JsonSchema/Guesser/Guess/ObjectType.php
+++ b/src/Component/JsonSchema/Guesser/Guess/ObjectType.php
@@ -120,12 +120,17 @@ class ObjectType extends Type
         return $this->className;
     }
 
-    private function getFqdn(bool $withRoot = true): string
+    public function getFqdn(bool $withRoot = true): string
     {
         if ($withRoot) {
             return '\\' . $this->namespace . '\\Model\\' . $this->className;
         }
 
         return $this->namespace . '\\Model\\' . $this->className;
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
     }
 }

--- a/src/Component/JsonSchema/Tests/MultiNamespaceDenormalizationTest.php
+++ b/src/Component/JsonSchema/Tests/MultiNamespaceDenormalizationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests;
+
+use Jane\Component\JsonSchema\Tests\Expected\Schema1\Model\Test;
+use Jane\Component\JsonSchema\Tests\Expected\Schema1\Normalizer\JaneObjectNormalizer;
+use Jane\Component\JsonSchema\Tests\Expected\Schema2\Model\Foo;
+use Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Only the Schema1 proxy normalizer is registered in the serializer: it must be able to
+ * handle models from other schemas (directly and transitively) on its own.
+ *
+ * @see https://github.com/janephp/janephp/issues/585
+ */
+class MultiNamespaceDenormalizationTest extends TestCase
+{
+    public function testDenormalizeModelsFromOtherSchemasWithASingleProxyNormalizer(): void
+    {
+        $serializer = new Serializer([new JaneObjectNormalizer()], [new JsonEncoder()]);
+
+        /** @var Test $test */
+        $test = $serializer->deserialize('{"foo":{"foo":"foo-value","bar":{"bar":"bar-value"}}}', Test::class, 'json');
+
+        self::assertInstanceOf(Test::class, $test);
+        self::assertInstanceOf(Foo::class, $test->getFoo());
+        self::assertSame('foo-value', $test->getFoo()->getFoo());
+        self::assertInstanceOf(Bar::class, $test->getFoo()->getBar());
+        self::assertSame('bar-value', $test->getFoo()->getBar()->getBar());
+    }
+
+    public function testNormalizeModelsFromOtherSchemasWithASingleProxyNormalizer(): void
+    {
+        $serializer = new Serializer([new JaneObjectNormalizer()], [new JsonEncoder()]);
+
+        $bar = new Bar();
+        $bar->setBar('bar-value');
+        $foo = new Foo();
+        $foo->setFoo('foo-value');
+        $foo->setBar($bar);
+        $test = new Test();
+        $test->setFoo($foo);
+
+        self::assertSame('{"foo":{"foo":"foo-value","bar":{"bar":"bar-value"}}}', $serializer->serialize($test, 'json'));
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/.jane
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/.jane
@@ -3,6 +3,11 @@
 return [
     'mapping' => [
         // Order of schema matters for naming
+        __DIR__ . '/schema3.json' => [
+            'root-class' => 'Test',
+            'namespace' => 'Jane\Component\JsonSchema\Tests\Expected\Schema3',
+            'directory' => __DIR__ . '/generated/Schema3',
+        ],
         __DIR__ . '/schema2.json' => [
             'root-class' => 'Test',
             'namespace' => 'Jane\Component\JsonSchema\Tests\Expected\Schema2',

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema1/Normalizer/JaneObjectNormalizer.php
@@ -19,6 +19,10 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     protected $normalizers = [
         
         \Jane\Component\JsonSchema\Tests\Expected\Schema1\Model\Test::class => \Jane\Component\JsonSchema\Tests\Expected\Schema1\Normalizer\TestNormalizer::class,
+        
+        \Jane\Component\JsonSchema\Tests\Expected\Schema2\Model\Foo::class => \Jane\Component\JsonSchema\Tests\Expected\Schema2\Normalizer\FooNormalizer::class,
+        
+        \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar::class => \Jane\Component\JsonSchema\Tests\Expected\Schema3\Normalizer\BarNormalizer::class,
     ], $normalizersCache = [];
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
@@ -57,6 +61,8 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
         return [
             
             \Jane\Component\JsonSchema\Tests\Expected\Schema1\Model\Test::class => false,
+            \Jane\Component\JsonSchema\Tests\Expected\Schema2\Model\Foo::class => false,
+            \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar::class => false,
         ];
     }
 }

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema2/Model/Foo.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema2/Model/Foo.php
@@ -17,6 +17,10 @@ class Foo
      */
     protected $foo;
     /**
+     * @var \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar
+     */
+    protected $bar;
+    /**
      * @return string
      */
     public function getFoo(): string
@@ -32,6 +36,24 @@ class Foo
     {
         $this->initialized['foo'] = true;
         $this->foo = $foo;
+        return $this;
+    }
+    /**
+     * @return \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar
+     */
+    public function getBar(): \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar
+    {
+        return $this->bar;
+    }
+    /**
+     * @param \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar $bar
+     *
+     * @return self
+     */
+    public function setBar(\Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar $bar): self
+    {
+        $this->initialized['bar'] = true;
+        $this->bar = $bar;
         return $this;
     }
 }

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Model/Bar.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Model/Bar.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests\Expected\Schema3\Model;
+
+class Bar
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $bar;
+    /**
+     * @return string
+     */
+    public function getBar(): string
+    {
+        return $this->bar;
+    }
+    /**
+     * @param string $bar
+     *
+     * @return self
+     */
+    public function setBar(string $bar): self
+    {
+        $this->initialized['bar'] = true;
+        $this->bar = $bar;
+        return $this;
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Normalizer/BarNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Normalizer/BarNormalizer.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Jane\Component\JsonSchema\Tests\Expected\Schema2\Normalizer;
+namespace Jane\Component\JsonSchema\Tests\Expected\Schema3\Normalizer;
 
 use Jane\Component\JsonSchemaRuntime\Reference;
-use Jane\Component\JsonSchema\Tests\Expected\Schema2\Runtime\Normalizer\CheckArray;
-use Jane\Component\JsonSchema\Tests\Expected\Schema2\Runtime\Normalizer\ValidatorTrait;
+use Jane\Component\JsonSchema\Tests\Expected\Schema3\Runtime\Normalizer\CheckArray;
+use Jane\Component\JsonSchema\Tests\Expected\Schema3\Runtime\Normalizer\ValidatorTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-class FooNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+class BarNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
 {
     use DenormalizerAwareTrait;
     use NormalizerAwareTrait;
@@ -19,39 +19,33 @@ class FooNormalizer implements DenormalizerInterface, NormalizerInterface, Denor
     use ValidatorTrait;
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return $type === \Jane\Component\JsonSchema\Tests\Expected\Schema2\Model\Foo::class;
+        return $type === \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar::class;
     }
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return $data instanceof \Jane\Component\JsonSchema\Tests\Expected\Schema2\Model\Foo;
+        return $data instanceof \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar;
     }
     public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
     {
-        $object = new \Jane\Component\JsonSchema\Tests\Expected\Schema2\Model\Foo();
+        $object = new \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar();
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
-        if (\array_key_exists('foo', $data)) {
-            $object->setFoo($data['foo']);
-        }
         if (\array_key_exists('bar', $data)) {
-            $object->setBar($this->denormalizer->denormalize($data['bar'], \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar::class, 'json', $context));
+            $object->setBar($data['bar']);
         }
         return $object;
     }
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        if ($data->isInitialized('foo') && null !== $data->getFoo()) {
-            $dataArray['foo'] = $data->getFoo();
-        }
         if ($data->isInitialized('bar') && null !== $data->getBar()) {
-            $dataArray['bar'] = $this->normalizer->normalize($data->getBar(), 'json', $context);
+            $dataArray['bar'] = $data->getBar();
         }
         return $dataArray;
     }
     public function getSupportedTypes(?string $format = null): array
     {
-        return [\Jane\Component\JsonSchema\Tests\Expected\Schema2\Model\Foo::class => false];
+        return [\Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar::class => false];
     }
 }

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Normalizer/JaneObjectNormalizer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Jane\Component\JsonSchema\Tests\Expected\Schema2\Normalizer;
+namespace Jane\Component\JsonSchema\Tests\Expected\Schema3\Normalizer;
 
-use Jane\Component\JsonSchema\Tests\Expected\Schema2\Runtime\Normalizer\CheckArray;
-use Jane\Component\JsonSchema\Tests\Expected\Schema2\Runtime\Normalizer\ValidatorTrait;
+use Jane\Component\JsonSchema\Tests\Expected\Schema3\Runtime\Normalizer\CheckArray;
+use Jane\Component\JsonSchema\Tests\Expected\Schema3\Runtime\Normalizer\ValidatorTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -17,8 +17,6 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     use CheckArray;
     use ValidatorTrait;
     protected $normalizers = [
-        
-        \Jane\Component\JsonSchema\Tests\Expected\Schema2\Model\Foo::class => \Jane\Component\JsonSchema\Tests\Expected\Schema2\Normalizer\FooNormalizer::class,
         
         \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar::class => \Jane\Component\JsonSchema\Tests\Expected\Schema3\Normalizer\BarNormalizer::class,
     ], $normalizersCache = [];
@@ -58,7 +56,6 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     {
         return [
             
-            \Jane\Component\JsonSchema\Tests\Expected\Schema2\Model\Foo::class => false,
             \Jane\Component\JsonSchema\Tests\Expected\Schema3\Model\Bar::class => false,
         ];
     }

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests\Expected\Schema3\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests\Expected\Schema3\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests\Expected\Schema3\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/expected/Schema3/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests\Expected\Schema3\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/schema2.json
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/schema2.json
@@ -5,6 +5,9 @@
             "properties": {
                 "foo": {
                     "type": "string"
+                },
+                "bar": {
+                    "$ref": "schema3.json#/definitions/Bar"
                 }
             }
         }

--- a/src/Component/JsonSchema/Tests/fixtures/multi-namespace/schema3.json
+++ b/src/Component/JsonSchema/Tests/fixtures/multi-namespace/schema3.json
@@ -1,0 +1,12 @@
+{
+    "definitions": {
+        "Bar": {
+            "type": "object",
+            "properties": {
+                "bar": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #585. When a Jane mapping contains several schemas and a model references a model from another mapped schema (cross-file `$ref`), the generated `JaneObjectNormalizer` of a schema only knew how to handle its own models. At runtime, nested denormalization of the foreign model failed with `Could not denormalize object of type "...", no supporting normalizer found.` unless every schema's proxy normalizer was registered.

Each generated proxy now also references the normalizers of external models **transitively** used by its own models: a chain like `Schema1\Test → Schema2\Foo → Schema3\Bar` works with only Schema1's proxy registered in the serializer.

## Changes

- New `ExternalNormalizersResolver`: walks all registry schemas' guessed properties (direct object refs, arrays/maps item types, union/nullable branches) and computes the transitive closure of foreign model dependencies per schema — cycle-safe and deterministically ordered
- `NormalizerGenerator::generate()` merges those mappings into the generated `$normalizers` map and `getSupportedTypes()`; no constructor change, so existing instantiations are unaffected
- `ObjectType::getFqdn()` is now public and a `getNamespace()` accessor was added
- `multi-namespace` fixture extended into a three-schema chain (`schema3.json`, `Foo → Bar` reference) with regenerated expected files proving both one-hop and two-hop mappings
- New runtime regression tests (`MultiNamespaceDenormalizationTest`) using only Schema1's proxy normalizer for denormalization and normalization round-trip
- `composer.json`: added `src/Component/JsonSchema/Tests/` to the dev classmap (mirrors the existing OpenApi2/OpenApi3 entries) so fixture-generated classes resolve for tests and PHPStan
- CHANGELOG entry under Unreleased

## How to test

1. `vendor/bin/phpunit --filter MultiNamespaceDenormalizationTest`
2. `vendor/bin/phpunit` (full suite, 371 tests)
3. `castor qa:phpstan && castor qa:cs:check`

## Notes

- Generated code changes for any configuration referencing models across schemas (the schema's `JaneObjectNormalizer` gains entries); single-schema output is byte-identical.
- In multi-schema configs the `$normalizers` entry order becomes own models → externals → `Reference`.
- The `composer.json` autoload-dev change requires a `composer install` / `composer dump-autoload` locally after pulling.
