### PR TITLE
fix(open-api): generate default response models when whitelisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [OpenApi3] [GH#771](https://github.com/janephp/janephp/issues/771) Report clean generation errors for non-body parameters using an unsupported `schema.type` (or no `type`/`enum`) instead of crashing
 
 ### Fixed
+- [OpenApi] [GH#763](https://github.com/janephp/janephp/issues/763) Generate models referenced by the `default` response when using `whitelisted-paths` (the default response is not part of the iterated status codes, so its models were filtered out)
 - [JsonSchema] [GH#585](https://github.com/janephp/janephp/issues/585) Reference normalizers of models from other mapped schemas (transitively) used by a schema's models in its generated `JaneObjectNormalizer`, so multi-namespace mappings no longer fail at runtime with "no supporting normalizer found"
 - [OpenApi] [GH#963](https://github.com/janephp/janephp/issues/963) Support JSON content types with parameters (e.g. `application/json;schema=...`) when generating response transformations and operation/model relations
 - [OpenApi] [GH#963](https://github.com/janephp/janephp/issues/963) Generate models for `allOf` schemas whose members omit an explicit `type: object`

--- a/src/Component/OpenApi3/Tests/Issue763WhitelistDefaultResponseTest.php
+++ b/src/Component/OpenApi3/Tests/Issue763WhitelistDefaultResponseTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Jane\Component\OpenApiCommon\Console\Command\GenerateCommand;
+use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
+use Jane\Component\OpenApiCommon\Console\Loader\OpenApiMatcher;
+use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @see https://github.com/janephp/janephp/issues/763
+ */
+class Issue763WhitelistDefaultResponseTest extends TestCase
+{
+    public function testDefaultResponseModelIsGeneratedWithWhitelistedPaths(): void
+    {
+        [$fixtureDirectory, $generatedDirectory] = $this->generateClient(true);
+
+        try {
+            self::assertFileExists($generatedDirectory . '/Model/Error.php');
+
+            $endpointContent = file_get_contents($generatedDirectory . '/Endpoint/CreateToken.php');
+            self::assertIsString($endpointContent);
+            self::assertStringContainsString(
+                "deserialize(\$body, 'Jane\\Component\\OpenApi3\\Tests\\Issue763Expected\\Model\\Error', 'json')",
+                $endpointContent
+            );
+            self::assertStringContainsString(
+                '@return null|\Jane\Component\OpenApi3\Tests\Issue763Expected\Model\PostDataPostResponse200|\Jane\Component\OpenApi3\Tests\Issue763Expected\Model\Error',
+                $endpointContent
+            );
+            self::assertStringNotContainsString('return json_decode($body);', $endpointContent);
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    public function testDefaultResponseModelIsGeneratedWithoutWhitelistedPaths(): void
+    {
+        [$fixtureDirectory, $generatedDirectory] = $this->generateClient(false);
+
+        try {
+            self::assertFileExists($generatedDirectory . '/Model/Error.php');
+
+            $endpointContent = file_get_contents($generatedDirectory . '/Endpoint/CreateToken.php');
+            self::assertIsString($endpointContent);
+            self::assertStringContainsString(
+                "deserialize(\$body, 'Jane\\Component\\OpenApi3\\Tests\\Issue763Expected\\Model\\Error', 'json')",
+                $endpointContent
+            );
+            self::assertStringNotContainsString('return json_decode($body);', $endpointContent);
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    /**
+     * @return array{0: string, 1: string} The fixture directory and the generated directory
+     */
+    private function generateClient(bool $whitelistedPaths): array
+    {
+        $fixtureDirectory = sys_get_temp_dir() . '/jane-openapi3-issue-763-' . bin2hex(random_bytes(8));
+        $generatedDirectory = $fixtureDirectory . '/generated';
+        mkdir($generatedDirectory, 0777, true);
+
+        $openApiFile = $fixtureDirectory . '/openapi.json';
+        file_put_contents($openApiFile, json_encode([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Issue 763',
+                'version' => '1.0.0',
+            ],
+            'paths' => [
+                '/post/data' => [
+                    'post' => [
+                        'operationId' => 'createToken',
+                        'tags' => ['token'],
+                        'requestBody' => [
+                            'content' => [
+                                'application/json' => [
+                                    'schema' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'property' => ['type' => 'string'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'responses' => [
+                            '200' => [
+                                'description' => 'successful operation',
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => [
+                                            'type' => 'object',
+                                            'properties' => [
+                                                'value' => ['type' => 'string'],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            'default' => [
+                                '$ref' => '#/components/responses/error',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'schemas' => [
+                    'error' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'error' => [
+                                'type' => 'string',
+                                'nullable' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                'responses' => [
+                    'error' => [
+                        'description' => 'an error response',
+                        'content' => [
+                            'application/json' => [
+                                'schema' => [
+                                    '$ref' => '#/components/schemas/error',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $config = [
+            'openapi-file' => $openApiFile,
+            'namespace' => 'Jane\Component\OpenApi3\Tests\Issue763Expected',
+            'directory' => $generatedDirectory,
+        ];
+
+        if ($whitelistedPaths) {
+            $config['whitelisted-paths'] = [['\/post\/data']];
+        }
+
+        $configFile = $fixtureDirectory . '/.jane-openapi';
+        file_put_contents($configFile, '<?php' . "\n\n" . 'return ' . var_export($config, true) . ';' . "\n");
+
+        $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+        $input = new ArrayInput(['--config-file' => $configFile], $command->getDefinition());
+        $output = new BufferedOutput();
+
+        $returnCode = $command->execute($input, $output);
+        $rendered = $output->fetch();
+
+        self::assertSame(Command::SUCCESS, $returnCode, $rendered);
+
+        return [$fixtureDirectory, $generatedDirectory];
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $entries = scandir($path);
+        if (false === $entries) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+
+            $entryPath = $path . '/' . $entry;
+            if (is_dir($entryPath)) {
+                $this->removeDirectory($entryPath);
+                continue;
+            }
+
+            unlink($entryPath);
+        }
+
+        rmdir($path);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/BaseEndpoint.php
@@ -37,7 +37,19 @@ abstract class BaseEndpoint implements Endpoint
     }
     public function getHeaders(array $baseHeaders = []): array
     {
-        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
     }
     protected function getQueryOptionsResolver(): OptionsResolver
     {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
@@ -17,7 +17,7 @@ class Client extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\Client
      * @param array $accept Accept content header application/json|application/problem+json
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null|\Jane\OpenApi3\Tests\Expected\Model\TweetLookupResponse : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|\Jane\OpenApi3\Tests\Expected\Model\TweetLookupResponse|\Jane\OpenApi3\Tests\Expected\Model\Error : \Psr\Http\Message\ResponseInterface)
      */
     public function findTweetsById(array $queryParameters = [], string $fetch = self::FETCH_OBJECT, array $accept = [])
     {
@@ -32,7 +32,7 @@ class Client extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\Client
      * @param array $accept Accept content header application/json|application/problem+json
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|\Jane\OpenApi3\Tests\Expected\Model\Error : \Psr\Http\Message\ResponseInterface)
      */
     public function addOrDeleteRules($requestBody, array $queryParameters = [], string $fetch = self::FETCH_OBJECT, array $accept = [])
     {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/AddOrDeleteRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/AddOrDeleteRules.php
@@ -55,7 +55,7 @@ class AddOrDeleteRules extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\Base
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|\Jane\OpenApi3\Tests\Expected\Model\Error
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
@@ -65,7 +65,7 @@ class AddOrDeleteRules extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\Base
             return json_decode($body);
         }
         if (mb_strpos(strtolower($contentType), 'application/json') !== false) {
-            return json_decode($body);
+            return $serializer->deserialize($body, 'Jane\OpenApi3\Tests\Expected\Model\Error', 'json');
         }
         if (mb_strpos(strtolower($contentType), 'application/problem+json') !== false) {
             return json_decode($body);

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/FindTweetsById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/FindTweetsById.php
@@ -60,7 +60,7 @@ class FindTweetsById extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\BaseEn
      * {@inheritdoc}
      *
      *
-     * @return null|\Jane\OpenApi3\Tests\Expected\Model\TweetLookupResponse
+     * @return null|\Jane\OpenApi3\Tests\Expected\Model\TweetLookupResponse|\Jane\OpenApi3\Tests\Expected\Model\Error
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
@@ -70,7 +70,7 @@ class FindTweetsById extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\BaseEn
             return $serializer->deserialize($body, 'Jane\OpenApi3\Tests\Expected\Model\TweetLookupResponse', 'json');
         }
         if (mb_strpos(strtolower($contentType), 'application/json') !== false) {
-            return json_decode($body);
+            return $serializer->deserialize($body, 'Jane\OpenApi3\Tests\Expected\Model\Error', 'json');
         }
         if (mb_strpos(strtolower($contentType), 'application/problem+json') !== false) {
             return json_decode($body);

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Model/Error.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Model/Error.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Model;
+
+class Error extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var int
+     */
+    protected $code;
+    /**
+     * @var string
+     */
+    protected $message;
+    /**
+     * @return int
+     */
+    public function getCode(): int
+    {
+        return $this->code;
+    }
+    /**
+     * @param int $code
+     *
+     * @return self
+     */
+    public function setCode(int $code): self
+    {
+        $this->initialized['code'] = true;
+        $this->code = $code;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+    /**
+     * @param string $message
+     *
+     * @return self
+     */
+    public function setMessage(string $message): self
+    {
+        $this->initialized['message'] = true;
+        $this->message = $message;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Normalizer/ErrorNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Normalizer/ErrorNormalizer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Jane\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\OpenApi3\Tests\Expected\Model\Error::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\OpenApi3\Tests\Expected\Model\Error::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\OpenApi3\Tests\Expected\Model\Error();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('code', $data)) {
+            $object->setCode($data['code']);
+            unset($data['code']);
+        }
+        if (\array_key_exists('message', $data)) {
+            $object->setMessage($data['message']);
+            unset($data['message']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['code'] = $data->getCode();
+        $dataArray['message'] = $data->getMessage();
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\OpenApi3\Tests\Expected\Model\Error::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Normalizer/JaneObjectNormalizer.php
@@ -18,6 +18,8 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     use ValidatorTrait;
     protected $normalizers = [
         
+        \Jane\OpenApi3\Tests\Expected\Model\Error::class => \Jane\OpenApi3\Tests\Expected\Normalizer\ErrorNormalizer::class,
+        
         \Jane\OpenApi3\Tests\Expected\Model\Expansions::class => \Jane\OpenApi3\Tests\Expected\Normalizer\ExpansionsNormalizer::class,
         
         \Jane\OpenApi3\Tests\Expected\Model\TweetLookupResponse::class => \Jane\OpenApi3\Tests\Expected\Normalizer\TweetLookupResponseNormalizer::class,
@@ -64,6 +66,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     {
         return [
             
+            \Jane\OpenApi3\Tests\Expected\Model\Error::class => false,
             \Jane\OpenApi3\Tests\Expected\Model\Expansions::class => false,
             \Jane\OpenApi3\Tests\Expected\Model\TweetLookupResponse::class => false,
             \Jane\OpenApi3\Tests\Expected\Model\Poll::class => false,

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php
@@ -17,7 +17,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * @param array $accept Accept content header application/json|application/problem+json
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Expected\Model\TweetLookupResponse : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Expected\Model\TweetLookupResponse|\Jane\Component\OpenApi3\Tests\Expected\Model\Error : \Psr\Http\Message\ResponseInterface)
      */
     public function findTweetsById(array $queryParameters = [], string $fetch = self::FETCH_OBJECT, array $accept = [])
     {
@@ -32,7 +32,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * @param array $accept Accept content header application/json|application/problem+json
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Expected\Model\Error : \Psr\Http\Message\ResponseInterface)
      */
     public function addOrDeleteRules($requestBody, array $queryParameters = [], string $fetch = self::FETCH_OBJECT, array $accept = [])
     {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/AddOrDeleteRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/AddOrDeleteRules.php
@@ -55,7 +55,7 @@ class AddOrDeleteRules extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\C
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\Error
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
@@ -65,7 +65,7 @@ class AddOrDeleteRules extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\C
             return json_decode($body);
         }
         if (mb_strpos(strtolower($contentType), 'application/json') !== false) {
-            return json_decode($body);
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Expected\Model\Error', 'json');
         }
         if (mb_strpos(strtolower($contentType), 'application/problem+json') !== false) {
             return json_decode($body);

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/FindTweetsById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/FindTweetsById.php
@@ -60,7 +60,7 @@ class FindTweetsById extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cli
      * {@inheritdoc}
      *
      *
-     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\TweetLookupResponse
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\TweetLookupResponse|\Jane\Component\OpenApi3\Tests\Expected\Model\Error
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {
@@ -70,7 +70,7 @@ class FindTweetsById extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cli
             return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Expected\Model\TweetLookupResponse', 'json');
         }
         if (mb_strpos(strtolower($contentType), 'application/json') !== false) {
-            return json_decode($body);
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Expected\Model\Error', 'json');
         }
         if (mb_strpos(strtolower($contentType), 'application/problem+json') !== false) {
             return json_decode($body);

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Model/Error.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Model/Error.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class Error extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var int
+     */
+    protected $code;
+    /**
+     * @var string
+     */
+    protected $message;
+    /**
+     * @return int
+     */
+    public function getCode(): int
+    {
+        return $this->code;
+    }
+    /**
+     * @param int $code
+     *
+     * @return self
+     */
+    public function setCode(int $code): self
+    {
+        $this->initialized['code'] = true;
+        $this->code = $code;
+        return $this;
+    }
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+    /**
+     * @param string $message
+     *
+     * @return self
+     */
+    public function setMessage(string $message): self
+    {
+        $this->initialized['message'] = true;
+        $this->message = $message;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Normalizer/ErrorNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Normalizer/ErrorNormalizer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ErrorNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\Error::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\Error::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Error();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('code', $data)) {
+            $object->setCode($data['code']);
+            unset($data['code']);
+        }
+        if (\array_key_exists('message', $data)) {
+            $object->setMessage($data['message']);
+            unset($data['message']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        $dataArray['code'] = $data->getCode();
+        $dataArray['message'] = $data->getMessage();
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\Error::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Normalizer/JaneObjectNormalizer.php
@@ -18,6 +18,8 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     use ValidatorTrait;
     protected $normalizers = [
         
+        \Jane\Component\OpenApi3\Tests\Expected\Model\Error::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ErrorNormalizer::class,
+        
         \Jane\Component\OpenApi3\Tests\Expected\Model\Expansions::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\ExpansionsNormalizer::class,
         
         \Jane\Component\OpenApi3\Tests\Expected\Model\TweetLookupResponse::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\TweetLookupResponseNormalizer::class,
@@ -64,6 +66,7 @@ class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface
     {
         return [
             
+            \Jane\Component\OpenApi3\Tests\Expected\Model\Error::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\Expansions::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\TweetLookupResponse::class => false,
             \Jane\Component\OpenApi3\Tests\Expected\Model\Poll::class => false,

--- a/src/Component/OpenApi3/WhitelistedSchema.php
+++ b/src/Component/OpenApi3/WhitelistedSchema.php
@@ -7,6 +7,7 @@ use Jane\Component\OpenApi3\JsonSchema\Model\MediaType;
 use Jane\Component\OpenApi3\JsonSchema\Model\Parameter;
 use Jane\Component\OpenApi3\JsonSchema\Model\RequestBody;
 use Jane\Component\OpenApi3\JsonSchema\Model\Response;
+use Jane\Component\OpenApi3\JsonSchema\Model\Responses;
 use Jane\Component\OpenApi3\JsonSchema\Model\Schema as SchemaModel;
 use Jane\Component\OpenApiCommon\Contracts\WhitelistFetchInterface;
 use Jane\Component\OpenApiCommon\Generator\ContentType;
@@ -63,40 +64,16 @@ class WhitelistedSchema implements WhitelistFetchInterface
             }
         }
 
-        /** @var Response[]|null $responses */
+        /** @var Responses|null $responses */
         $responses = $operationGuess->getOperation()->getResponses();
         if (null !== $responses && \count($responses) > 0) {
             foreach ($responses as $response) {
-                if ($response instanceof Reference) {
-                    [$_, $response] = $this->guessClass->resolve($response, Response::class);
-                }
-                if (!($response instanceof Response)) {
-                    continue;
-                }
+                $this->addResponseRelations($operationGuess, $baseOperation, $response, $registry);
+            }
 
-                if (null === $response->getContent()) {
-                    $schema = null;
-                    $classGuess = $this->guessClass->guessClass($schema, $operationGuess->getReference(), $registry);
-                    if (null !== $classGuess) {
-                        $this->schema->addOperationRelation($baseOperation, $classGuess->getName());
-                    }
-                }
-
-                if (null !== $response->getContent() && is_iterable($response->getContent())) {
-                    /** @var MediaType $content */
-                    foreach ($response->getContent() as $contentType => $content) {
-                        $baseContentType = ContentType::withoutParameters($contentType);
-
-                        if ('application/json' === $baseContentType || str_ends_with($baseContentType, '+json')) {
-                            $contentReference = $operationGuess->getReference() . '/content/' . $contentType . '/schema';
-                            $schema = $content->getSchema();
-                            $classGuess = $this->guessClass->guessClass($schema, $contentReference, $registry);
-                            if (null !== $classGuess) {
-                                $this->schema->addOperationRelation($baseOperation, $classGuess->getName());
-                            }
-                        }
-                    }
-                }
+            $defaultResponse = $responses->getDefault();
+            if (null !== $defaultResponse) {
+                $this->addResponseRelations($operationGuess, $baseOperation, $defaultResponse, $registry);
             }
         }
 
@@ -108,6 +85,40 @@ class WhitelistedSchema implements WhitelistFetchInterface
                     $reference = $operationGuess->getReference() . '/parameters/' . $key;
                     $schema = $parameter->getSchema();
                     $classGuess = $this->guessClass->guessClass($schema, $reference, $registry);
+                    if (null !== $classGuess) {
+                        $this->schema->addOperationRelation($baseOperation, $classGuess->getName());
+                    }
+                }
+            }
+        }
+    }
+
+    private function addResponseRelations(OperationGuess $operationGuess, string $baseOperation, mixed $response, Registry $registry): void
+    {
+        if ($response instanceof Reference) {
+            [$_, $response] = $this->guessClass->resolve($response, Response::class);
+        }
+        if (!($response instanceof Response)) {
+            return;
+        }
+
+        if (null === $response->getContent()) {
+            $schema = null;
+            $classGuess = $this->guessClass->guessClass($schema, $operationGuess->getReference(), $registry);
+            if (null !== $classGuess) {
+                $this->schema->addOperationRelation($baseOperation, $classGuess->getName());
+            }
+        }
+
+        if (null !== $response->getContent() && is_iterable($response->getContent())) {
+            /** @var MediaType $content */
+            foreach ($response->getContent() as $contentType => $content) {
+                $baseContentType = ContentType::withoutParameters($contentType);
+
+                if ('application/json' === $baseContentType || str_ends_with($baseContentType, '+json')) {
+                    $contentReference = $operationGuess->getReference() . '/content/' . $contentType . '/schema';
+                    $schema = $content->getSchema();
+                    $classGuess = $this->guessClass->guessClass($schema, $contentReference, $registry);
                     if (null !== $classGuess) {
                         $this->schema->addOperationRelation($baseOperation, $classGuess->getName());
                     }

--- a/src/Component/OpenApi31/Tests/Issue763WhitelistDefaultResponseTest.php
+++ b/src/Component/OpenApi31/Tests/Issue763WhitelistDefaultResponseTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests;
+
+use Jane\Component\OpenApiCommon\Console\Command\GenerateCommand;
+use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
+use Jane\Component\OpenApiCommon\Console\Loader\OpenApiMatcher;
+use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @see https://github.com/janephp/janephp/issues/763
+ */
+class Issue763WhitelistDefaultResponseTest extends TestCase
+{
+    public function testDefaultResponseModelIsGeneratedWithWhitelistedPaths(): void
+    {
+        [$fixtureDirectory, $generatedDirectory] = $this->generateClient(true);
+
+        try {
+            self::assertFileExists($generatedDirectory . '/Model/Error.php');
+
+            $endpointContent = file_get_contents($generatedDirectory . '/Endpoint/CreateToken.php');
+            self::assertIsString($endpointContent);
+            self::assertStringContainsString(
+                "deserialize(\$body, 'Jane\\Component\\OpenApi31\\Tests\\Issue763Expected\\Model\\Error', 'json')",
+                $endpointContent
+            );
+            self::assertStringContainsString(
+                '@return null|\Jane\Component\OpenApi31\Tests\Issue763Expected\Model\PostDataPostResponse200|\Jane\Component\OpenApi31\Tests\Issue763Expected\Model\Error',
+                $endpointContent
+            );
+            self::assertStringNotContainsString('return json_decode($body);', $endpointContent);
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    public function testDefaultResponseModelIsGeneratedWithoutWhitelistedPaths(): void
+    {
+        [$fixtureDirectory, $generatedDirectory] = $this->generateClient(false);
+
+        try {
+            self::assertFileExists($generatedDirectory . '/Model/Error.php');
+
+            $endpointContent = file_get_contents($generatedDirectory . '/Endpoint/CreateToken.php');
+            self::assertIsString($endpointContent);
+            self::assertStringContainsString(
+                "deserialize(\$body, 'Jane\\Component\\OpenApi31\\Tests\\Issue763Expected\\Model\\Error', 'json')",
+                $endpointContent
+            );
+            self::assertStringNotContainsString('return json_decode($body);', $endpointContent);
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    /**
+     * @return array{0: string, 1: string} The fixture directory and the generated directory
+     */
+    private function generateClient(bool $whitelistedPaths): array
+    {
+        $fixtureDirectory = sys_get_temp_dir() . '/jane-openapi31-issue-763-' . bin2hex(random_bytes(8));
+        $generatedDirectory = $fixtureDirectory . '/generated';
+        mkdir($generatedDirectory, 0777, true);
+
+        $openApiFile = $fixtureDirectory . '/openapi.json';
+        file_put_contents($openApiFile, json_encode([
+            'openapi' => '3.1.0',
+            'info' => [
+                'title' => 'Issue 763',
+                'version' => '1.0.0',
+            ],
+            'paths' => [
+                '/post/data' => [
+                    'post' => [
+                        'operationId' => 'createToken',
+                        'tags' => ['token'],
+                        'requestBody' => [
+                            'content' => [
+                                'application/json' => [
+                                    'schema' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'property' => ['type' => 'string'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'responses' => [
+                            '200' => [
+                                'description' => 'successful operation',
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => [
+                                            'type' => 'object',
+                                            'properties' => [
+                                                'value' => ['type' => 'string'],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            'default' => [
+                                '$ref' => '#/components/responses/error',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'schemas' => [
+                    'error' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'error' => ['type' => 'string'],
+                        ],
+                    ],
+                ],
+                'responses' => [
+                    'error' => [
+                        'description' => 'an error response',
+                        'content' => [
+                            'application/json' => [
+                                'schema' => [
+                                    '$ref' => '#/components/schemas/error',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $config = [
+            'openapi-file' => $openApiFile,
+            'namespace' => 'Jane\Component\OpenApi31\Tests\Issue763Expected',
+            'directory' => $generatedDirectory,
+        ];
+
+        if ($whitelistedPaths) {
+            $config['whitelisted-paths'] = [['\/post\/data']];
+        }
+
+        $configFile = $fixtureDirectory . '/.jane-openapi';
+        file_put_contents($configFile, '<?php' . "\n\n" . 'return ' . var_export($config, true) . ';' . "\n");
+
+        $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+        $input = new ArrayInput(['--config-file' => $configFile], $command->getDefinition());
+        $output = new BufferedOutput();
+
+        $returnCode = $command->execute($input, $output);
+        $rendered = $output->fetch();
+
+        self::assertSame(Command::SUCCESS, $returnCode, $rendered);
+
+        return [$fixtureDirectory, $generatedDirectory];
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $entries = scandir($path);
+        if (false === $entries) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+
+            $entryPath = $path . '/' . $entry;
+            if (is_dir($entryPath)) {
+                $this->removeDirectory($entryPath);
+                continue;
+            }
+
+            unlink($entryPath);
+        }
+
+        rmdir($path);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/BaseEndpoint.php
@@ -37,7 +37,19 @@ abstract class BaseEndpoint implements Endpoint
     }
     public function getHeaders(array $baseHeaders = []): array
     {
-        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
     }
     protected function getQueryOptionsResolver(): OptionsResolver
     {

--- a/src/Component/OpenApi31/WhitelistedSchema.php
+++ b/src/Component/OpenApi31/WhitelistedSchema.php
@@ -7,6 +7,7 @@ use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi31\JsonSchema\Model\MediaType;
 use Jane\Component\OpenApi31\JsonSchema\Model\RequestBody;
 use Jane\Component\OpenApi31\JsonSchema\Model\Response;
+use Jane\Component\OpenApi31\JsonSchema\Model\Responses;
 use Jane\Component\OpenApiCommon\Contracts\WhitelistFetchInterface;
 use Jane\Component\OpenApiCommon\Generator\ContentType;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
@@ -62,38 +63,48 @@ class WhitelistedSchema implements WhitelistFetchInterface
             }
         }
 
-        /** @var Response[]|null $responses */
+        /** @var Responses|null $responses */
         $responses = $operationGuess->getOperation()->getResponses();
         if (null !== $responses && \count($responses) > 0) {
             foreach ($responses as $response) {
-                if ($response instanceof Reference) {
-                    [$_, $response] = $this->guessClass->resolve($response, Response::class);
-                }
-                if (!($response instanceof Response)) {
-                    continue;
-                }
+                $this->addResponseRelations($operationGuess, $baseOperation, $response, $registry);
+            }
 
-                if (null === $response->getContent()) {
-                    $schema = null;
-                    $classGuess = $this->guessClass->guessClass($schema, $operationGuess->getReference(), $registry);
+            $defaultResponse = $responses->getDefault();
+            if (null !== $defaultResponse) {
+                $this->addResponseRelations($operationGuess, $baseOperation, $defaultResponse, $registry);
+            }
+        }
+    }
+
+    private function addResponseRelations(OperationGuess $operationGuess, string $baseOperation, mixed $response, Registry $registry): void
+    {
+        if ($response instanceof Reference) {
+            [$_, $response] = $this->guessClass->resolve($response, Response::class);
+        }
+        if (!($response instanceof Response)) {
+            return;
+        }
+
+        if (null === $response->getContent()) {
+            $schema = null;
+            $classGuess = $this->guessClass->guessClass($schema, $operationGuess->getReference(), $registry);
+            if (null !== $classGuess) {
+                $this->schema->addOperationRelation($baseOperation, $classGuess->getName());
+            }
+        }
+
+        if (null !== $response->getContent() && is_iterable($response->getContent())) {
+            /** @var MediaType $content */
+            foreach ($response->getContent() as $contentType => $content) {
+                $baseContentType = ContentType::withoutParameters($contentType);
+
+                if ('application/json' === $baseContentType || str_ends_with($baseContentType, '+json')) {
+                    $contentReference = $operationGuess->getReference() . '/content/' . $contentType . '/schema';
+                    $schema = $content->getSchema();
+                    $classGuess = $this->guessClass->guessClass($schema, $contentReference, $registry);
                     if (null !== $classGuess) {
                         $this->schema->addOperationRelation($baseOperation, $classGuess->getName());
-                    }
-                }
-
-                if (null !== $response->getContent() && is_iterable($response->getContent())) {
-                    /** @var MediaType $content */
-                    foreach ($response->getContent() as $contentType => $content) {
-                        $baseContentType = ContentType::withoutParameters($contentType);
-
-                        if ('application/json' === $baseContentType || str_ends_with($baseContentType, '+json')) {
-                            $contentReference = $operationGuess->getReference() . '/content/' . $contentType . '/schema';
-                            $schema = $content->getSchema();
-                            $classGuess = $this->guessClass->guessClass($schema, $contentReference, $registry);
-                            if (null !== $classGuess) {
-                                $this->schema->addOperationRelation($baseOperation, $classGuess->getName());
-                            }
-                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description

Fixes #763: with `whitelisted-paths` configured in a Jane OpenAPI config, models referenced only through an OpenAPI `default` response were silently dropped from generated clients (e.g. an `Error` schema reached via `$ref: '#/components/responses/error'`). Without `whitelisted-paths`, those models were generated as expected.

Root cause: the generated `Responses` model stores the `default` response in a dedicated property instead of an `\ArrayObject` offset, so iterating `$operation->getResponses()` never yields it. Neither the main guessing phase nor `WhitelistedSchema::addOperationRelations()` recorded an operation→model relation for the default response, and `Schema::filterRelations()` then removed every class not reachable from an operation.

## Changes

- [OpenApi3] Extract per-response handling into `WhitelistedSchema::addResponseRelations()`; after iterating explicit status codes, also process `$responses->getDefault()`, resolving `$ref` responses first.
- [OpenApi31] Same change to `WhitelistedSchema`.
- Corrected the `$responses` docblock type from `Response[]|null` to `Responses|null`.
- Added self-contained regression tests (`Issue763WhitelistDefaultResponseTest`) in both components: they generate the reporter's spec (POST + inline 200 + `default: {$ref}`) with and without `whitelisted-paths` and assert that `Model/Error.php` exists, the endpoint deserializes the default branch into `Model\Error`, the return docblock lists both response models, and no `return json_decode($body);` fallback remains.
- CHANGELOG entry under Unreleased → Fixed.

## How to test

1. `composer install`
2. `vendor/bin/phpunit --filter Issue763WhitelistDefaultResponseTest` (runs in both `OpenApi3/Tests` and `OpenApi31/Tests`)
3. Refresh expected fixtures: `castor jane:replace-all-expected-fixtures`
4. Full QA: `vendor/bin/phpunit`, `castor qa:phpstan`, `castor qa:cs:check`

## Notes

- Expected-fixture refresh is required: `src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/` currently encodes the buggy behavior (no `Error.php`/`Problem.php` although its operations reference them through the default response). That fixture test fails until step 3 is run; the expected folders were deliberately not hand-edited per contribution guidelines. The fixture diff should show new model/normalizer files plus updated endpoints and `JaneObjectNormalizer`.
- Downstream impact: regenerating an existing client that uses `whitelisted-paths` will now emit additional model classes previously dropped (this is the intended fix).
- Pre-existing issues intentionally left out of scope: the main-phase guesser still skips `$ref`/default responses when collecting relations (the whitelist pass compensates), and `WhitelistedSchema` computes lookup references for inline bodies/responses that can never match registration keys (harmless dead lookups).
