### PR TITLE
fix(openapi): support object query parameters and OAS styles (#955)

### DIFF
--- a/docs/openapi/component.md
+++ b/docs/openapi/component.md
@@ -225,6 +225,33 @@ There are many ways to use it. You can either use the `__type` key to specify a 
  deserialized according to it's format option. It can be used to customize a date-time field, or to add non supported
 formats. More details in the dedicated section.
 
+## Query parameter serialization (OpenAPI 3.x)
+
+For `query` parameters, Jane reads the OpenAPI [`style`](https://spec.openapis.org/oas/v3.0.3#style-values) and
+`explode` fields and generates a `getQueryStyles()` method in each affected Endpoint class. The runtime then
+serializes values accordingly:
+
+| Style | `explode: true` | `explode: false` |
+|-------|-----------------|------------------|
+| `form` (default) | objects: each property becomes a top level pair (`?name=john&country=SE`); arrays repeat the parameter name (`?param=a&param=b`) | values joined with `,` (`?color=blue,black`; objects interleave keys and values: `?color=R,100,G,200`) |
+| `spaceDelimited` | like `form` exploded | values joined with a space (`?color=blue%20black`) |
+| `pipeDelimited` | like `form` exploded | values joined with `\|` (`?color=blue\|black`) |
+| `deepObject` | bracket notation at every level (`?filter[from]=a&filter[range][to]=b`) | not applicable |
+
+When neither `style` nor `explode` is set, OpenAPI defaults apply (`form` for query parameters, `explode: true`
+when style is `form`). These defaults are only materialized for parameters whose schema is an `object` or an
+`array`: scalar parameters keep their historical encoding.
+
+Additional rules:
+
+- Nesting beyond the first level uses PHP bracket notation with explicit indices, e.g.
+  `?search[address][city]=NY` or `?tags[0]=a&tags[1]=b`. The OpenAPI specification does not define deeper
+  nesting, so this is Jane's convention.
+- `spaceDelimited`, `pipeDelimited` and non-exploded `form` only support flat values; providing nested
+  arrays/objects throws an `\InvalidArgumentException` when building the query string.
+- Parameters declaring a `content` field are serialized from their content and ignore `style` / `explode`,
+  as specified by OpenAPI.
+
 ## Using a generated client
 
 Generating a client will produce same classes as the [JSON Schema](../json_schema/component.md) library:

--- a/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/nullable-check/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Generator/Endpoint/GetGetQueryStylesTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetGetQueryStylesTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Generator\Endpoint;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Generator\EndpointGenerator;
+use Jane\Component\OpenApi3\Guesser\GuessClass;
+use Jane\Component\OpenApi3\JsonSchema\Model\Parameter;
+use Jane\Component\OpenApi3\JsonSchema\Model\Schema;
+use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
+use PhpParser\Modifiers;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt;
+
+trait GetGetQueryStylesTrait
+{
+    public function getQueryStylesMethod(OperationGuess $operation, string $methodName, GuessClass $guessClass): ?Stmt\ClassMethod
+    {
+        $styles = [];
+        foreach ($operation->getParameters() as $parameter) {
+            if ($parameter instanceof Reference) {
+                $parameter = $guessClass->resolveParameter($parameter);
+            }
+
+            if (!$parameter instanceof Parameter || EndpointGenerator::IN_QUERY !== $parameter->getIn()) {
+                continue;
+            }
+
+            // Content based serialization takes precedence over styles.
+            if (null !== $parameter->getContent()) {
+                continue;
+            }
+
+            $schema = $parameter->getSchema();
+            if ($schema instanceof Reference) {
+                [, $schema] = $guessClass->resolve($schema, Schema::class);
+            }
+
+            // OpenAPI defaults: style is guessed from the `in` field, explode defaults to true when style is form.
+            $style = $parameter->getStyle() ?? 'form';
+            $explode = $parameter->getExplode() ?? ('form' === $style);
+
+            $isCollectionType = $schema instanceof Schema && \in_array($schema->getType(), ['object', 'array'], true);
+
+            // Only emit a style declaration when it changes the legacy runtime behavior.
+            if (null === $parameter->getStyle() && null === $parameter->getExplode() && !$isCollectionType) {
+                continue;
+            }
+
+            // Keep option resolver keys consistent: `[]` suffixes are stripped there too.
+            $parameterName = $parameter->getName();
+            if (str_contains($parameterName, '[]')) {
+                $parameterName = substr($parameterName, 0, -2);
+            }
+
+            $items = [
+                new Expr\ArrayItem(new Scalar\String_($style), new Scalar\String_('style')),
+                new Expr\ArrayItem(new Expr\ConstFetch(new Name($explode ? 'true' : 'false')), new Scalar\String_('explode')),
+            ];
+            $styles[$parameterName] = new Expr\Array_($items);
+        }
+
+        if (\count($styles) === 0) {
+            return null;
+        }
+
+        $arrayItems = [];
+        foreach ($styles as $parameterName => $styleArray) {
+            $arrayItems[] = new Expr\ArrayItem($styleArray, new Scalar\String_($parameterName));
+        }
+
+        return new Stmt\ClassMethod($methodName, [
+            'flags' => Modifiers::PROTECTED,
+            'stmts' => [
+                new Stmt\Return_(new Expr\Array_($arrayItems)),
+            ],
+            'returnType' => new Name('array'),
+        ]);
+    }
+}

--- a/src/Component/OpenApi3/Generator/EndpointGenerator.php
+++ b/src/Component/OpenApi3/Generator/EndpointGenerator.php
@@ -10,6 +10,7 @@ use Jane\Component\OpenApi3\Generator\Endpoint\GetGetBodyTrait;
 use Jane\Component\OpenApi3\Generator\Endpoint\GetGetExtraHeadersTrait;
 use Jane\Component\OpenApi3\Generator\Endpoint\GetGetOptionsResolverTrait;
 use Jane\Component\OpenApi3\Generator\Endpoint\GetGetQueryAllowReservedTrait;
+use Jane\Component\OpenApi3\Generator\Endpoint\GetGetQueryStylesTrait;
 use Jane\Component\OpenApi3\Generator\Endpoint\GetGetUriTrait;
 use Jane\Component\OpenApi3\Generator\Endpoint\GetTransformResponseBodyTrait;
 use Jane\Component\OpenApi3\Generator\Parameter\NonBodyParameterGenerator;
@@ -35,6 +36,7 @@ class EndpointGenerator implements EndpointGeneratorInterface
     use GetGetMethodTrait;
     use GetGetOptionsResolverTrait;
     use GetGetQueryAllowReservedTrait;
+    use GetGetQueryStylesTrait;
     use GetGetUriTrait;
     use GetTransformResponseBodyTrait;
     use OptionResolverNormalizationTrait;
@@ -79,6 +81,7 @@ class EndpointGenerator implements EndpointGeneratorInterface
         $queryResolverMethod = $this->getOptionsResolverMethod($operation, self::IN_QUERY, 'getQueryOptionsResolver', $this->guessClass, $this->nonBodyParameterGenerator, $operationCustomQueryResolver, $genericCustomQueryResolver);
         $headerResolverMethod = $this->getOptionsResolverMethod($operation, self::IN_HEADER, 'getHeadersOptionsResolver', $this->guessClass, $this->nonBodyParameterGenerator);
         $queryAllowReservedMethod = $this->getQueryAllowReservedMethod($operation, 'getQueryAllowReserved', $this->guessClass);
+        $queryStylesMethod = $this->getQueryStylesMethod($operation, 'getQueryStyles', $this->guessClass);
 
         if ($extraHeadersMethod) {
             $class->stmts[] = $extraHeadersMethod;
@@ -94,6 +97,10 @@ class EndpointGenerator implements EndpointGeneratorInterface
 
         if ($queryAllowReservedMethod) {
             $class->stmts[] = $queryAllowReservedMethod;
+        }
+
+        if ($queryStylesMethod) {
+            $class->stmts[] = $queryStylesMethod;
         }
 
         $class->stmts[] = $transformBodyMethod;

--- a/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
@@ -190,16 +190,9 @@ class NonBodyParameterGenerator extends ParameterGenerator
     private function convertParameterType(Schema $schema): array
     {
         $type = $schema->getType();
-        $additionalProperties = $schema->getAdditionalProperties();
 
         if (null === $type && null !== $schema->getEnum() && \count($schema->getEnum()) > 0) {
             $type = 'string';
-        }
-
-        if ($additionalProperties instanceof Schema
-            && 'object' === $type
-            && 'string' === $additionalProperties->getType()) {
-            return ['string'];
         }
 
         $convertArray = [

--- a/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-merge/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-mixed-request-body-parameter-type/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiBooksBookIdreviewsGetCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiBooksBookIdreviewsGetCollection.php
@@ -57,6 +57,10 @@ class ApiBooksBookIdreviewsGetCollection extends \ApiPlatform\Demo\Runtime\Clien
         $optionsResolver->addAllowedTypes('book', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['page' => ['style' => 'form', 'explode' => false], 'order[id]' => ['style' => 'form', 'explode' => false], 'order[publicationDate]' => ['style' => 'form', 'explode' => false], 'book' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiBooksGetCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiBooksGetCollection.php
@@ -66,6 +66,10 @@ class ApiBooksGetCollection extends \ApiPlatform\Demo\Runtime\Client\BaseEndpoin
         $optionsResolver->addAllowedTypes('author', ['string']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['page' => ['style' => 'form', 'explode' => false], 'itemsPerPage' => ['style' => 'form', 'explode' => false], 'archived' => ['style' => 'form', 'explode' => false], 'order[id]' => ['style' => 'form', 'explode' => false], 'order[title]' => ['style' => 'form', 'explode' => false], 'order[author]' => ['style' => 'form', 'explode' => false], 'order[isbn]' => ['style' => 'form', 'explode' => false], 'order[publicationDate]' => ['style' => 'form', 'explode' => false], 'properties' => ['style' => 'form', 'explode' => true], 'title' => ['style' => 'form', 'explode' => false], 'author' => ['style' => 'form', 'explode' => false]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiParchmentsGetCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiParchmentsGetCollection.php
@@ -46,6 +46,10 @@ class ApiParchmentsGetCollection extends \ApiPlatform\Demo\Runtime\Client\BaseEn
         $optionsResolver->addAllowedTypes('page', ['int']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['page' => ['style' => 'form', 'explode' => false]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiReviewsGetCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiReviewsGetCollection.php
@@ -56,6 +56,10 @@ class ApiReviewsGetCollection extends \ApiPlatform\Demo\Runtime\Client\BaseEndpo
         $optionsResolver->addAllowedTypes('book', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['page' => ['style' => 'form', 'explode' => false], 'itemsPerPage' => ['style' => 'form', 'explode' => false], 'order[id]' => ['style' => 'form', 'explode' => false], 'order[publicationDate]' => ['style' => 'form', 'explode' => false], 'book' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiTopBooksGetCollection.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Endpoint/ApiTopBooksGetCollection.php
@@ -46,6 +46,10 @@ class ApiTopBooksGetCollection extends \ApiPlatform\Demo\Runtime\Client\BaseEndp
         $optionsResolver->addAllowedTypes('page', ['int']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['page' => ['style' => 'form', 'explode' => false]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-definition/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/body-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/boolean-query-resolver/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/content-type/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-endpoint-generator/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/custom-string-format-mapping/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/deprecated/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator-snake-case/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/discriminator/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsGetStatusForAuthenticatedUser.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/MigrationsGetStatusForAuthenticatedUser.php
@@ -50,6 +50,10 @@ class MigrationsGetStatusForAuthenticatedUser extends \Github\Runtime\Client\Bas
         $optionsResolver->addAllowedTypes('exclude', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['exclude' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/include-null-value/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/inheritance-using-discriminator-with-mapping/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/BusinessProcessWaitForLifeCycles.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/BusinessProcessWaitForLifeCycles.php
@@ -45,6 +45,10 @@ class BusinessProcessWaitForLifeCycles extends \PicturePark\API\Runtime\Client\B
         $optionsResolver->addAllowedTypes('timeout', ['string', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['lifeCycles' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/BusinessProcessWaitForStates.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/BusinessProcessWaitForStates.php
@@ -45,6 +45,10 @@ class BusinessProcessWaitForStates extends \PicturePark\API\Runtime\Client\BaseE
         $optionsResolver->addAllowedTypes('timeout', ['string', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['states' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentCreate.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentCreate.php
@@ -53,6 +53,10 @@ class ContentCreate extends \PicturePark\API\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->addAllowedTypes('waitSearchDocCreation', ['bool']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentGet.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentGet.php
@@ -43,6 +43,10 @@ class ContentGet extends \PicturePark\API\Runtime\Client\BaseEndpoint implements
         $optionsResolver->addAllowedTypes('resolveBehaviors', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentGetMany.php
@@ -43,6 +43,10 @@ class ContentGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint implem
         $optionsResolver->addAllowedTypes('resolveBehaviors', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true], 'resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentPermissionSetGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentPermissionSetGetMany.php
@@ -40,6 +40,10 @@ class ContentPermissionSetGetMany extends \PicturePark\API\Runtime\Client\BaseEn
         $optionsResolver->addAllowedTypes('ids', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentPermissionSetGetPermissionsMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentPermissionSetGetPermissionsMany.php
@@ -40,6 +40,10 @@ class ContentPermissionSetGetPermissionsMany extends \PicturePark\API\Runtime\Cl
         $optionsResolver->addAllowedTypes('ids', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentUpdateMetadata.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentUpdateMetadata.php
@@ -59,6 +59,10 @@ class ContentUpdateMetadata extends \PicturePark\API\Runtime\Client\BaseEndpoint
         $optionsResolver->addAllowedTypes('waitSearchDocCreation', ['bool']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentUpdatePermissions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentUpdatePermissions.php
@@ -54,6 +54,10 @@ class ContentUpdatePermissions extends \PicturePark\API\Runtime\Client\BaseEndpo
         $optionsResolver->addAllowedTypes('waitSearchDocCreation', ['bool']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemCreate.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemCreate.php
@@ -53,6 +53,10 @@ class ListItemCreate extends \PicturePark\API\Runtime\Client\BaseEndpoint implem
         $optionsResolver->addAllowedTypes('waitSearchDocCreation', ['bool']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemGet.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemGet.php
@@ -43,6 +43,10 @@ class ListItemGet extends \PicturePark\API\Runtime\Client\BaseEndpoint implement
         $optionsResolver->addAllowedTypes('resolveBehaviors', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemGetMany.php
@@ -43,6 +43,10 @@ class ListItemGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint imple
         $optionsResolver->addAllowedTypes('resolveBehaviors', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true], 'resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemUpdate.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ListItemUpdate.php
@@ -56,6 +56,10 @@ class ListItemUpdate extends \PicturePark\API\Runtime\Client\BaseEndpoint implem
         $optionsResolver->addAllowedTypes('waitSearchDocCreation', ['bool']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/OutputFormatGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/OutputFormatGetMany.php
@@ -40,6 +40,10 @@ class OutputFormatGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint i
         $optionsResolver->addAllowedTypes('ids', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaGetMany.php
@@ -41,6 +41,10 @@ class SchemaGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint impleme
         $optionsResolver->addAllowedTypes('ids', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaGetManyReferenced.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaGetManyReferenced.php
@@ -39,6 +39,10 @@ class SchemaGetManyReferenced extends \PicturePark\API\Runtime\Client\BaseEndpoi
         $optionsResolver->addAllowedTypes('ids', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaPermissionSetGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaPermissionSetGetMany.php
@@ -40,6 +40,10 @@ class SchemaPermissionSetGetMany extends \PicturePark\API\Runtime\Client\BaseEnd
         $optionsResolver->addAllowedTypes('ids', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaPermissionSetGetPermissionsMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaPermissionSetGetPermissionsMany.php
@@ -40,6 +40,10 @@ class SchemaPermissionSetGetPermissionsMany extends \PicturePark\API\Runtime\Cli
         $optionsResolver->addAllowedTypes('ids', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareGet.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareGet.php
@@ -43,6 +43,10 @@ class ShareGet extends \PicturePark\API\Runtime\Client\BaseEndpoint implements \
         $optionsResolver->addAllowedTypes('resolveBehaviors', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareGetShareJson.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ShareGetShareJson.php
@@ -44,6 +44,10 @@ class ShareGetShareJson extends \PicturePark\API\Runtime\Client\BaseEndpoint imp
         $optionsResolver->addAllowedTypes('resolveBehaviors', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['resolveBehaviors' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/UserGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/UserGetMany.php
@@ -40,6 +40,10 @@ class UserGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint implement
         $optionsResolver->addAllowedTypes('ids', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/UserRoleGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/UserRoleGetMany.php
@@ -40,6 +40,10 @@ class UserRoleGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint imple
         $optionsResolver->addAllowedTypes('ids', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/XmpMappingGetMany.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/XmpMappingGetMany.php
@@ -40,6 +40,10 @@ class XmpMappingGetMany extends \PicturePark\API\Runtime\Client\BaseEndpoint imp
         $optionsResolver->addAllowedTypes('ids', ['array', 'null']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-641/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-649/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Endpoint/AppsListDeployments.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Endpoint/AppsListDeployments.php
@@ -54,6 +54,10 @@ class AppsListDeployments extends \Jane\Generated\DigitalOcean\Runtime\Client\Ba
         $optionsResolver->addAllowedTypes('deployment_types', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['deployment_types' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Endpoint/AppsListJobInvocations.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Endpoint/AppsListJobInvocations.php
@@ -49,6 +49,10 @@ class AppsListJobInvocations extends \Jane\Generated\DigitalOcean\Runtime\Client
         $optionsResolver->addAllowedTypes('per_page', ['int']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['job_names' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Endpoint/GenaiListModels.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Endpoint/GenaiListModels.php
@@ -54,6 +54,10 @@ class GenaiListModels extends \Jane\Generated\DigitalOcean\Runtime\Client\BaseEn
         $optionsResolver->addAllowedTypes('per_page', ['int']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['usecases' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-670/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-672/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-675/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-787/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-828/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-type-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-resources/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api1/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multi-specs/expected/Api2/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-operation-id-with-dot-path/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-body/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/no-reference-response/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/operations/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameter-type-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Client.php
@@ -124,7 +124,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     }
     /**
      * @param array{
-     *    "input": string,
+     *    "input": array,
      * } $queryParameters
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
@@ -145,6 +145,31 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     public function testObjectQuery(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\TestObjectQuery($queryParameters), $fetch);
+    }
+    /**
+     * @param array{
+     *    "search": array,
+     * } $queryParameters
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     */
+    public function testObjectAdditionalProperties(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\TestObjectAdditionalProperties($queryParameters), $fetch);
+    }
+    /**
+     * @param array{
+     *    "columns"?: array,
+     *    "properties[]"?: array,
+     * } $queryParameters
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     */
+    public function testFormExplodeQuery(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\TestFormExplodeQuery($queryParameters), $fetch);
     }
     public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestDictionary.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestDictionary.php
@@ -6,7 +6,7 @@ class TestDictionary extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cli
 {
     /**
      * @param array{
-     *    "input": string,
+     *    "input": array,
      * } $queryParameters
      */
     public function __construct(array $queryParameters = [])
@@ -32,8 +32,12 @@ class TestDictionary extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cli
         $optionsResolver->setDefined(['input']);
         $optionsResolver->setRequired(['input']);
         $optionsResolver->setDefaults([]);
-        $optionsResolver->addAllowedTypes('input', ['string']);
+        $optionsResolver->addAllowedTypes('input', ['array']);
         return $optionsResolver;
+    }
+    protected function getQueryStyles(): array
+    {
+        return ['input' => ['style' => 'form', 'explode' => true]];
     }
     /**
      * {@inheritdoc}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestFormExplodeQuery.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestFormExplodeQuery.php
@@ -2,16 +2,12 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
 
-class TestQueryParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+class TestFormExplodeQuery extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
 {
     /**
      * @param array{
-     *    "testString"?: string,
-     *    "testInteger"?: int,
-     *    "testFloat"?: int,
-     *    "testArray"?: array,
-     *    "testRequired": string,
-     *    "testDefault"?: string,
+     *    "columns"?: array,
+     *    "properties[]"?: array,
      * } $queryParameters
      */
     public function __construct(array $queryParameters = [])
@@ -25,7 +21,7 @@ class TestQueryParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runtim
     }
     public function getUri(): string
     {
-        return '/test-query';
+        return '/test-form-explode-query';
     }
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
@@ -34,20 +30,16 @@ class TestQueryParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runtim
     protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
-        $optionsResolver->setDefined(['testString', 'testInteger', 'testFloat', 'testArray', 'testRequired', 'testDefault']);
-        $optionsResolver->setRequired(['testRequired']);
-        $optionsResolver->setDefaults(['testDefault' => 'test']);
-        $optionsResolver->addAllowedTypes('testString', ['string']);
-        $optionsResolver->addAllowedTypes('testInteger', ['int']);
-        $optionsResolver->addAllowedTypes('testFloat', ['int']);
-        $optionsResolver->addAllowedTypes('testArray', ['array']);
-        $optionsResolver->addAllowedTypes('testRequired', ['string']);
-        $optionsResolver->addAllowedTypes('testDefault', ['string']);
+        $optionsResolver->setDefined(['columns', 'properties']);
+        $optionsResolver->setRequired([]);
+        $optionsResolver->setDefaults([]);
+        $optionsResolver->addAllowedTypes('columns', ['array']);
+        $optionsResolver->addAllowedTypes('properties', ['array']);
         return $optionsResolver;
     }
     protected function getQueryStyles(): array
     {
-        return ['testArray' => ['style' => 'form', 'explode' => true]];
+        return ['columns' => ['style' => 'form', 'explode' => false], 'properties' => ['style' => 'form', 'explode' => true]];
     }
     /**
      * {@inheritdoc}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestObjectAdditionalProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestObjectAdditionalProperties.php
@@ -2,16 +2,11 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
 
-class TestQueryParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+class TestObjectAdditionalProperties extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
 {
     /**
      * @param array{
-     *    "testString"?: string,
-     *    "testInteger"?: int,
-     *    "testFloat"?: int,
-     *    "testArray"?: array,
-     *    "testRequired": string,
-     *    "testDefault"?: string,
+     *    "search": array,
      * } $queryParameters
      */
     public function __construct(array $queryParameters = [])
@@ -25,7 +20,7 @@ class TestQueryParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runtim
     }
     public function getUri(): string
     {
-        return '/test-query';
+        return '/test-object-additional-properties';
     }
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
@@ -34,20 +29,15 @@ class TestQueryParameters extends \Jane\Component\OpenApi3\Tests\Expected\Runtim
     protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
     {
         $optionsResolver = parent::getQueryOptionsResolver();
-        $optionsResolver->setDefined(['testString', 'testInteger', 'testFloat', 'testArray', 'testRequired', 'testDefault']);
-        $optionsResolver->setRequired(['testRequired']);
-        $optionsResolver->setDefaults(['testDefault' => 'test']);
-        $optionsResolver->addAllowedTypes('testString', ['string']);
-        $optionsResolver->addAllowedTypes('testInteger', ['int']);
-        $optionsResolver->addAllowedTypes('testFloat', ['int']);
-        $optionsResolver->addAllowedTypes('testArray', ['array']);
-        $optionsResolver->addAllowedTypes('testRequired', ['string']);
-        $optionsResolver->addAllowedTypes('testDefault', ['string']);
+        $optionsResolver->setDefined(['search']);
+        $optionsResolver->setRequired(['search']);
+        $optionsResolver->setDefaults([]);
+        $optionsResolver->addAllowedTypes('search', ['array']);
         return $optionsResolver;
     }
     protected function getQueryStyles(): array
     {
-        return ['testArray' => ['style' => 'form', 'explode' => true]];
+        return ['search' => ['style' => 'form', 'explode' => true]];
     }
     /**
      * {@inheritdoc}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestObjectQuery.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Endpoint/TestObjectQuery.php
@@ -35,6 +35,10 @@ class TestObjectQuery extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cl
         $optionsResolver->addAllowedTypes('filter', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['filter' => ['style' => 'deepObject', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/parameters/swagger.json
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters/swagger.json
@@ -377,6 +377,70 @@
                     }
                 }
             }
+        },
+        "/test-object-additional-properties": {
+            "get": {
+                "tags": [
+                    "example"
+                ],
+                "operationId": "testObjectAdditionalProperties",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                }
+            }
+        },
+        "/test-form-explode-query": {
+            "get": {
+                "tags": [
+                    "example"
+                ],
+                "operationId": "testFormExplodeQuery",
+                "parameters": [
+                    {
+                        "name": "columns",
+                        "in": "query",
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "properties[]",
+                        "in": "query",
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "no error"
+                    }
+                }
+            }
         }
     },
     "info": {

--- a/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/read-only-properties/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-type-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/simple-path-array-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-null-values/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/skip-parameter-check/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable-array/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/test-nullable/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindPrivateTweetMetricsById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindPrivateTweetMetricsById.php
@@ -46,6 +46,10 @@ class FindPrivateTweetMetricsById extends \Jane\Component\OpenApi3\Tests\Expecte
         $optionsResolver->addAllowedTypes('ids', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => false]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindTweetsById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindTweetsById.php
@@ -56,6 +56,10 @@ class FindTweetsById extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cli
         $optionsResolver->addAllowedTypes('expansions', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => false], 'expansions' => ['style' => 'form', 'explode' => false]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindUsersByIdOrUsername.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/FindUsersByIdOrUsername.php
@@ -58,6 +58,10 @@ class FindUsersByIdOrUsername extends \Jane\Component\OpenApi3\Tests\Expected\Ru
         $optionsResolver->addAllowedTypes('expansions', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => false], 'usernames' => ['style' => 'form', 'explode' => false], 'expansions' => ['style' => 'form', 'explode' => false]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/GetRules.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/GetRules.php
@@ -46,6 +46,10 @@ class GetRules extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Ba
         $optionsResolver->addAllowedTypes('ids', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamFilter.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamFilter.php
@@ -46,6 +46,10 @@ class StreamFilter extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Clien
         $optionsResolver->addAllowedTypes('expansions', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['expansions' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamSample.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/StreamSample.php
@@ -46,6 +46,10 @@ class StreamSample extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Clien
         $optionsResolver->addAllowedTypes('expansions', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['expansions' => ['style' => 'form', 'explode' => true]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/TweetsRecentSearch.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/TweetsRecentSearch.php
@@ -68,6 +68,10 @@ class TweetsRecentSearch extends \Jane\Component\OpenApi3\Tests\Expected\Runtime
         $optionsResolver->addAllowedTypes('expansions', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['expansions' => ['style' => 'form', 'explode' => false]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/uppercase-parameter/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/use-cacheable-supports-method/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/vnd-plus-json/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/FindTweetsById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Endpoint/FindTweetsById.php
@@ -56,6 +56,10 @@ class FindTweetsById extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\BaseEn
         $optionsResolver->addAllowedTypes('expansions', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => false], 'expansions' => ['style' => 'form', 'explode' => false]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-circular-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-request-body-reference/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/FindTweetsById.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Endpoint/FindTweetsById.php
@@ -56,6 +56,10 @@ class FindTweetsById extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cli
         $optionsResolver->addAllowedTypes('expansions', ['array']);
         return $optionsResolver;
     }
+    protected function getQueryStyles(): array
+    {
+        return ['ids' => ['style' => 'form', 'explode' => false], 'expansions' => ['style' => 'form', 'explode' => false]];
+    }
     /**
      * {@inheritdoc}
      *

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/yaml/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Generator/Endpoint/GetGetQueryStylesTrait.php
+++ b/src/Component/OpenApi31/Generator/Endpoint/GetGetQueryStylesTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Generator\Endpoint;
+
+use Jane\Component\JsonSchema\JsonSchema\Model\JsonSchema;
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Generator\EndpointGenerator;
+use Jane\Component\OpenApi31\Guesser\GuessClass;
+use Jane\Component\OpenApi31\JsonSchema\Model\Parameter;
+use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
+use PhpParser\Modifiers;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar;
+use PhpParser\Node\Stmt;
+
+trait GetGetQueryStylesTrait
+{
+    public function getQueryStylesMethod(OperationGuess $operation, string $methodName, GuessClass $guessClass): ?Stmt\ClassMethod
+    {
+        $styles = [];
+        foreach ($operation->getParameters() as $parameter) {
+            if ($parameter instanceof Reference) {
+                $parameter = $guessClass->resolveParameter($parameter);
+            }
+
+            if (!$parameter instanceof Parameter || EndpointGenerator::IN_QUERY !== $parameter->getIn()) {
+                continue;
+            }
+
+            // Content based serialization takes precedence over styles.
+            if (null !== $parameter->getContent()) {
+                continue;
+            }
+
+            $schema = $parameter->getSchema();
+            if ($schema instanceof Reference) {
+                [, $schema] = $guessClass->resolve($schema, JsonSchema::class);
+            }
+
+            // OpenAPI defaults: style is guessed from the `in` field, explode defaults to true when style is form.
+            $style = $parameter->getStyle() ?? 'form';
+            $explode = $parameter->getExplode() ?? ('form' === $style);
+
+            $isCollectionType = $schema instanceof JsonSchema && \in_array($schema->getType(), ['object', 'array'], true);
+
+            // Only emit a style declaration when it changes the legacy runtime behavior.
+            if (null === $parameter->getStyle() && null === $parameter->getExplode() && !$isCollectionType) {
+                continue;
+            }
+
+            // Keep option resolver keys consistent: `[]` suffixes are stripped there too.
+            $parameterName = $parameter->getName();
+            if (str_contains($parameterName, '[]')) {
+                $parameterName = substr($parameterName, 0, -2);
+            }
+
+            $items = [
+                new Expr\ArrayItem(new Scalar\String_($style), new Scalar\String_('style')),
+                new Expr\ArrayItem(new Expr\ConstFetch(new Name($explode ? 'true' : 'false')), new Scalar\String_('explode')),
+            ];
+            $styles[$parameterName] = new Expr\Array_($items);
+        }
+
+        if (\count($styles) === 0) {
+            return null;
+        }
+
+        $arrayItems = [];
+        foreach ($styles as $parameterName => $styleArray) {
+            $arrayItems[] = new Expr\ArrayItem($styleArray, new Scalar\String_($parameterName));
+        }
+
+        return new Stmt\ClassMethod($methodName, [
+            'flags' => Modifiers::PROTECTED,
+            'stmts' => [
+                new Stmt\Return_(new Expr\Array_($arrayItems)),
+            ],
+            'returnType' => new Name('array'),
+        ]);
+    }
+}

--- a/src/Component/OpenApi31/Generator/EndpointGenerator.php
+++ b/src/Component/OpenApi31/Generator/EndpointGenerator.php
@@ -11,6 +11,7 @@ use Jane\Component\OpenApi31\Generator\Endpoint\GetGetBodyTrait;
 use Jane\Component\OpenApi31\Generator\Endpoint\GetGetExtraHeadersTrait;
 use Jane\Component\OpenApi31\Generator\Endpoint\GetGetOptionsResolverTrait;
 use Jane\Component\OpenApi31\Generator\Endpoint\GetGetQueryAllowReservedTrait;
+use Jane\Component\OpenApi31\Generator\Endpoint\GetGetQueryStylesTrait;
 use Jane\Component\OpenApi31\Generator\Endpoint\GetGetUriTrait;
 use Jane\Component\OpenApi31\Generator\Endpoint\GetTransformResponseBodyTrait;
 use Jane\Component\OpenApi31\Generator\Parameter\NonBodyParameterGenerator;
@@ -35,6 +36,7 @@ class EndpointGenerator implements EndpointGeneratorInterface
     use GetGetMethodTrait;
     use GetGetOptionsResolverTrait;
     use GetGetQueryAllowReservedTrait;
+    use GetGetQueryStylesTrait;
     use GetGetUriTrait;
     use GetTransformResponseBodyTrait;
     use OptionResolverNormalizationTrait;
@@ -79,6 +81,7 @@ class EndpointGenerator implements EndpointGeneratorInterface
         $queryResolverMethod = $this->getOptionsResolverMethod($operation, self::IN_QUERY, 'getQueryOptionsResolver', $this->guessClass, $this->nonBodyParameterGenerator, $operationCustomQueryResolver, $genericCustomQueryResolver);
         $headerResolverMethod = $this->getOptionsResolverMethod($operation, self::IN_HEADER, 'getHeadersOptionsResolver', $this->guessClass, $this->nonBodyParameterGenerator);
         $queryAllowReservedMethod = $this->getQueryAllowReservedMethod($operation, 'getQueryAllowReserved', $this->guessClass);
+        $queryStylesMethod = $this->getQueryStylesMethod($operation, 'getQueryStyles', $this->guessClass);
 
         if ($extraHeadersMethod) {
             $class->stmts[] = $extraHeadersMethod;
@@ -94,6 +97,10 @@ class EndpointGenerator implements EndpointGeneratorInterface
 
         if ($queryAllowReservedMethod) {
             $class->stmts[] = $queryAllowReservedMethod;
+        }
+
+        if ($queryStylesMethod) {
+            $class->stmts[] = $queryStylesMethod;
         }
 
         $class->stmts[] = $transformBodyMethod;

--- a/src/Component/OpenApi31/JsonSchema/Model/Parameter.php
+++ b/src/Component/OpenApi31/JsonSchema/Model/Parameter.php
@@ -41,6 +41,18 @@ class Parameter
      * @var array<string, MediaType>|null
      */
     protected $content;
+    /**
+     * @var string|null
+     */
+    protected $style;
+    /**
+     * @var bool|null
+     */
+    protected $explode;
+    /**
+     * @var bool|null
+     */
+    protected $allowReserved = false;
 
     public function getName(): ?string
     {
@@ -135,6 +147,45 @@ class Parameter
     {
         $this->initialized['content'] = true;
         $this->content = $content;
+
+        return $this;
+    }
+
+    public function getStyle(): ?string
+    {
+        return $this->style;
+    }
+
+    public function setStyle(?string $style): self
+    {
+        $this->initialized['style'] = true;
+        $this->style = $style;
+
+        return $this;
+    }
+
+    public function getExplode(): ?bool
+    {
+        return $this->explode;
+    }
+
+    public function setExplode(?bool $explode): self
+    {
+        $this->initialized['explode'] = true;
+        $this->explode = $explode;
+
+        return $this;
+    }
+
+    public function getAllowReserved(): ?bool
+    {
+        return $this->allowReserved;
+    }
+
+    public function setAllowReserved(?bool $allowReserved): self
+    {
+        $this->initialized['allowReserved'] = true;
+        $this->allowReserved = $allowReserved;
 
         return $this;
     }

--- a/src/Component/OpenApi31/JsonSchema/Normalizer/ParameterNormalizer.php
+++ b/src/Component/OpenApi31/JsonSchema/Normalizer/ParameterNormalizer.php
@@ -44,6 +44,12 @@ class ParameterNormalizer implements DenormalizerInterface, NormalizerInterface,
         if (\array_key_exists('deprecated', $data) && \is_int($data['deprecated'])) {
             $data['deprecated'] = (bool) $data['deprecated'];
         }
+        if (\array_key_exists('explode', $data) && \is_int($data['explode'])) {
+            $data['explode'] = (bool) $data['explode'];
+        }
+        if (\array_key_exists('allowReserved', $data) && \is_int($data['allowReserved'])) {
+            $data['allowReserved'] = (bool) $data['allowReserved'];
+        }
         if (null === $data || false === \is_array($data)) {
             return $object;
         }
@@ -86,6 +92,21 @@ class ParameterNormalizer implements DenormalizerInterface, NormalizerInterface,
         } elseif (\array_key_exists('content', $data) && $data['content'] === null) {
             $object->setContent(null);
         }
+        if (\array_key_exists('style', $data) && $data['style'] !== null) {
+            $object->setStyle($data['style']);
+        } elseif (\array_key_exists('style', $data) && $data['style'] === null) {
+            $object->setStyle(null);
+        }
+        if (\array_key_exists('explode', $data) && $data['explode'] !== null) {
+            $object->setExplode($data['explode']);
+        } elseif (\array_key_exists('explode', $data) && $data['explode'] === null) {
+            $object->setExplode(null);
+        }
+        if (\array_key_exists('allowReserved', $data) && $data['allowReserved'] !== null) {
+            $object->setAllowReserved($data['allowReserved']);
+        } elseif (\array_key_exists('allowReserved', $data) && $data['allowReserved'] === null) {
+            $object->setAllowReserved(null);
+        }
 
         return $object;
     }
@@ -113,6 +134,15 @@ class ParameterNormalizer implements DenormalizerInterface, NormalizerInterface,
                 $values[$key] = $this->normalizer->normalize($value, 'json', $context);
             }
             $dataArray['content'] = $values;
+        }
+        if ($data->isInitialized('style') && null !== $data->getStyle()) {
+            $dataArray['style'] = $data->getStyle();
+        }
+        if ($data->isInitialized('explode') && null !== $data->getExplode()) {
+            $dataArray['explode'] = $data->getExplode();
+        }
+        if ($data->isInitialized('allowReserved') && null !== $data->getAllowReserved()) {
+            $dataArray['allowReserved'] = $data->getAllowReserved();
         }
 
         return $dataArray;

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/enum-as-objects/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/generate-error-exceptions/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-946/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-allof-in-oneof/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Runtime/Client/BaseEndpoint.php
@@ -24,13 +24,21 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
         return implode('&', $queryParameters);
@@ -56,6 +64,20 @@ abstract class BaseEndpoint implements Endpoint
         return new OptionsResolver();
     }
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -115,5 +137,145 @@ abstract class BaseEndpoint implements Endpoint
             $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
         }
         return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApiCommon/Generator/Runtime/data/Client/BaseEndpoint.php
+++ b/src/Component/OpenApiCommon/Generator/Runtime/data/Client/BaseEndpoint.php
@@ -30,14 +30,25 @@ abstract class BaseEndpoint implements Endpoint
     public function getQueryString(): string
     {
         $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
-        $optionsResolved = array_map(static function ($value) {
-            return $value ?? '';
-        }, $optionsResolved);
 
+        $styles = $this->getQueryStyles();
         $allowReserved = $this->getQueryAllowReserved();
         $queryParameters = [];
         foreach ($optionsResolved as $key => $value) {
-            $allowReservedKey = in_array($key, $allowReserved, true);
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+
+                continue;
+            }
+
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
             $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
         }
 
@@ -68,6 +79,21 @@ abstract class BaseEndpoint implements Endpoint
     }
 
     protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
     {
         return [];
     }
@@ -152,5 +178,181 @@ abstract class BaseEndpoint implements Endpoint
         }
 
         return implode('&', $params);
+    }
+
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+
+        if ([] === $value) {
+            return [];
+        }
+
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+
+                    continue;
+                }
+
+                if (null === $item) {
+                    continue;
+                }
+
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+
+            return $pairs;
+        }
+
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+
+                continue;
+            }
+
+            if (null === $subValue) {
+                continue;
+            }
+
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+
+        if ([] === $value) {
+            return [];
+        }
+
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+
+        if ([] === $value) {
+            return [];
+        }
+
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs(
+                $prefix . '[' . rawurlencode((string) $subKey) . ']',
+                $subValue,
+                $allowReserved
+            ));
+        }
+
+        return $pairs;
+    }
+
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+
+            if (null === $subValue) {
+                continue;
+            }
+
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
     }
 }

--- a/src/Component/OpenApiCommon/Tests/Generator/Runtime/data/Client/BaseEndpointTest.php
+++ b/src/Component/OpenApiCommon/Tests/Generator/Runtime/data/Client/BaseEndpointTest.php
@@ -34,6 +34,113 @@ final class BaseEndpointTest extends TestCase
         yield 'array' => [['queryParam' => ['te?st', 'tes*&']], ['queryParam'], 'queryParam%5B0%5D=te?st&queryParam%5B1%5D=tes*&'];
     }
 
+    public static function styledQueryParamsProvider(): iterable
+    {
+        $form = ['style' => 'form'];
+        yield 'form exploded object drops parent key' => [
+            ['search' => ['name' => 'john', 'country' => 'SE']],
+            ['search' => ['style' => 'form', 'explode' => true]],
+            'name=john&country=SE',
+        ];
+        yield 'form exploded array repeats parameter name' => [
+            ['param' => ['a', 'b']],
+            ['param' => ['style' => 'form', 'explode' => true]],
+            'param=a&param=b',
+        ];
+        yield 'form exploded object with nested array uses bracket notation' => [
+            ['search' => ['name' => 'john', 'tags' => ['a', 'b']]],
+            ['search' => ['style' => 'form', 'explode' => true]],
+            'name=john&tags%5B0%5D=a&tags%5B1%5D=b',
+        ];
+        yield 'form exploded object with nested object uses bracket notation' => [
+            ['search' => ['name' => 'john', 'address' => ['city' => 'NY']]],
+            ['search' => ['style' => 'form', 'explode' => true]],
+            'name=john&address%5Bcity%5D=NY',
+        ];
+        yield 'form exploded array of objects uses bracket notation' => [
+            ['points' => [['x' => 1], ['x' => 2]]],
+            ['points' => ['style' => 'form', 'explode' => true]],
+            'points%5B0%5D%5Bx%5D=1&points%5B1%5D%5Bx%5D=2',
+        ];
+        yield 'form non exploded array is comma separated' => [
+            ['color' => ['blue', 'black']],
+            ['color' => ['style' => 'form', 'explode' => false]],
+            'color=blue,black',
+        ];
+        yield 'form non exploded object interleaves keys and values' => [
+            ['color' => ['R' => '100', 'G' => '200']],
+            ['color' => ['style' => 'form', 'explode' => false]],
+            'color=R,100,G,200',
+        ];
+        yield 'space delimited array' => [
+            ['color' => ['blue', 'black']],
+            ['color' => ['style' => 'spaceDelimited', 'explode' => false]],
+            'color=blue%20black',
+        ];
+        yield 'pipe delimited array' => [
+            ['color' => ['blue', 'black']],
+            ['color' => ['style' => 'pipeDelimited', 'explode' => false]],
+            'color=blue|black',
+        ];
+        yield 'deep object flat' => [
+            ['filter' => ['from' => 'a', 'to' => 'b']],
+            ['filter' => ['style' => 'deepObject', 'explode' => true]],
+            'filter%5Bfrom%5D=a&filter%5Bto%5D=b',
+        ];
+        yield 'deep object nested' => [
+            ['filter' => ['range' => ['from' => 'a']]],
+            ['filter' => ['style' => 'deepObject', 'explode' => true]],
+            'filter%5Brange%5D%5Bfrom%5D=a',
+        ];
+        yield 'null value is omitted' => [
+            ['search' => null, 'other' => 'kept'],
+            ['search' => ['style' => 'form', 'explode' => true]],
+            'other=kept',
+        ];
+        yield 'empty object is omitted' => [
+            ['search' => []],
+            ['search' => ['style' => 'form', 'explode' => true]],
+            '',
+        ];
+        yield 'exploded scalar values are encoded' => [
+            ['search' => ['name' => 'jo hn?']],
+            ['search' => ['style' => 'form', 'explode' => true]],
+            'name=jo%20hn%3F',
+        ];
+    }
+
+    public static function styledQueryParamsWithAllowingReservedCharactersProvider(): iterable
+    {
+        yield 'form exploded reserved characters' => [
+            ['search' => ['name' => 'jo?hn&']],
+            ['search'],
+            ['search' => ['style' => 'form', 'explode' => true]],
+            'name=jo?hn&',
+        ];
+        yield 'pipe delimited reserved characters' => [
+            ['color' => ['bl|ue', 'bla*ck']],
+            ['color'],
+            ['color' => ['style' => 'pipeDelimited', 'explode' => false]],
+            'color=bl|ue|bla*ck',
+        ];
+    }
+
+    public static function invalidStyledQueryParamsProvider(): iterable
+    {
+        yield 'nested value with space delimited style' => [
+            ['color' => [['nested']]],
+            ['color' => ['style' => 'spaceDelimited']],
+        ];
+        yield 'nested value with form non exploded style' => [
+            ['color' => [['nested']]],
+            ['color' => ['style' => 'form', 'explode' => false]],
+        ];
+        yield 'unknown style' => [
+            ['color' => ['blue']],
+            ['color' => ['style' => 'matrix']],
+        ];
+    }
+
     /**
      * @dataProvider queryParamsProvider
      */
@@ -241,15 +348,52 @@ final class BaseEndpointTest extends TestCase
         $endpoint->getHeaders();
     }
 
-    private function getEndpoint(array $queryParams, array $allowReserved = []): object
+    /**
+     * @dataProvider styledQueryParamsProvider
+     */
+    public function testStyledQueryParamsWillBeProperlyEncoded(array $queryParams, array $styles, string $expectedQueryString): void
     {
-        return new class($queryParams, $allowReserved) extends \BaseEndpoint {
-            private array $allowReserved;
+        $endpoint = $this->getEndpoint($queryParams, [], $styles);
 
-            public function __construct(array $queryParams, array $allowReserved)
+        self::assertEquals($expectedQueryString, $endpoint->getQueryString());
+    }
+
+    /**
+     * @dataProvider styledQueryParamsWithAllowingReservedCharactersProvider
+     */
+    public function testStyledQueryParamsWillBeProperlyEncodedWithReservedCharacters(
+        array $queryParams,
+        array $allowedQueryParams,
+        array $styles,
+        string $expectedQueryString,
+    ): void {
+        $endpoint = $this->getEndpoint($queryParams, $allowedQueryParams, $styles);
+
+        self::assertEquals($expectedQueryString, $endpoint->getQueryString());
+    }
+
+    /**
+     * @dataProvider invalidStyledQueryParamsProvider
+     */
+    public function testInvalidStyledQueryParamsThrowException(array $queryParams, array $styles): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $endpoint = $this->getEndpoint($queryParams, [], $styles);
+        $endpoint->getQueryString();
+    }
+
+    private function getEndpoint(array $queryParams, array $allowReserved = [], array $queryStyles = []): object
+    {
+        return new class($queryParams, $allowReserved, $queryStyles) extends \BaseEndpoint {
+            private array $allowReserved;
+            private array $queryStyles;
+
+            public function __construct(array $queryParams, array $allowReserved, array $queryStyles)
             {
                 $this->queryParameters = $queryParams;
                 $this->allowReserved = $allowReserved;
+                $this->queryStyles = $queryStyles;
             }
 
             public function getMethod(): string
@@ -299,6 +443,11 @@ final class BaseEndpointTest extends TestCase
             protected function getQueryAllowReserved(): array
             {
                 return $this->allowReserved;
+            }
+
+            protected function getQueryStyles(): array
+            {
+                return $this->queryStyles;
             }
         };
     }


### PR DESCRIPTION
## Description

Fixes #955 and covers the query-parameter part of #419: OpenAPI 3.x query parameters of type `object` were generated with PHP type `string` when their schema used `additionalProperties`, and the generated clients ignored the OpenAPI `style` and `explode` parameter fields entirely, falling back to PHP bracket notation (`param[key]=value`) for every collection value. This PR types object parameters as arrays and adds native, spec-compliant serialization styles to the runtime — no new dependency (the old uri-template approach from #427 is not revived).

## Changes

- Type every `type: object` non-body query parameter as PHP `array`: removed the `additionalProperties` → `string` special case in the OpenAPI 3 `NonBodyParameterGenerator`.
- Add a `getQueryStyles()` hook to the runtime `BaseEndpoint` plus native encoders for `form`, `spaceDelimited`, `pipeDelimited` and `deepObject` styles:
  - exploded objects drop the parent key (`?name=john&country=SE`), exploded arrays repeat the parameter name (`?param=a&param=b`);
  - non-exploded values are delimiter-joined (`?color=blue,black`, objects interleave keys and values);
  - `deepObject` uses bracket notation at every level;
  - nesting beyond the first level uses PHP bracket notation with explicit indices (documented convention);
  - flat-only styles throw an `InvalidArgumentException` on nested input; unknown styles throw; declared-style params with null values are omitted.
- Generate a `getQueryStyles()` method into endpoint classes for OpenAPI 3.0 and 3.1, following the existing `getQueryAllowReserved()` precedent; emitted only when behavior changes from the legacy path (collection-typed schemas or explicit `style`/`explode`). Parameters declaring `content` keep precedence over styles.
- Extend the OpenAPI 3.1 `Parameter` model + normalizer with `style`, `explode` and `allowReserved` (previously missing).
- Regenerate test fixtures for OpenAPI 2/3/3.1 components (runtime file copies + updated/new endpoints); add runtime unit tests for all styled encodings and failure cases; document the serialization rules in `docs/openapi/component.md`.

**Breaking change for regenerated clients:** dictionary query parameters (`type: object` + `additionalProperties`) now generate as `array` instead of `string`, and collection-typed query parameters follow the OpenAPI styles once regenerated. Existing already-generated clients are unaffected until they regenerate.

## How to test

1. `vendor/bin/phpunit` — full suite green (388 tests), including new `BaseEndpointTest` style cases and the refreshed `parameters` fixtures (`TestObjectAdditionalProperties`, `TestFormExplodeQuery`).
2. `castor qa:phpstan` and `castor qa:cs:check` — both clean.

## Notes

- The OpenAPI 3.1 `getQueryAllowReserved()` stub could now become a real implementation since the 3.1 model gained `allowReserved`; left out of this PR to keep the diff scoped.
- Fixture churn is mostly mechanical: the runtime `BaseEndpoint.php` is copied verbatim into every expected fixture directory.
