### PR TITLE
fix(json-schema): support nullable dates/datetimes for OpenAPI 3.1 (#848)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [OpenApi] [GH#963](https://github.com/janephp/janephp/issues/963) Support JSON content types with parameters (e.g. `application/json;schema=...`) when generating response transformations and operation/model relations
 - [OpenApi] [GH#963](https://github.com/janephp/janephp/issues/963) Generate models for `allOf` schemas whose members omit an explicit `type: object`
+- [OpenApi31] [GH#848](https://github.com/janephp/janephp/issues/848) Support nullable dates and datetimes expressed as `type: ["string", "null"]` with a `format: date` / `date-time` (OAS 3.1 style), generating the same null-safe normalization code as OpenAPI 3.0's `nullable: true`
 - [OpenApi31] [GH#946](https://github.com/janephp/janephp/issues/946) Generate response models and correct `transformResponseBody` return types for inline response schemas (array responses are typed as `Model[]` again)
 - [OpenApi31] Keep endpoint names plural for operations returning an array response
 - [OpenApi] Support union types (e.g. `type: ["array", "null"]`) when detecting array schemas

--- a/src/Component/JsonSchema/Guesser/Guess/CheckNullableTrait.php
+++ b/src/Component/JsonSchema/Guesser/Guess/CheckNullableTrait.php
@@ -9,7 +9,7 @@ trait CheckNullableTrait
     public function isNullable($schema): bool
     {
         if (\get_class($schema) === JsonSchema::class) {
-            return \is_array($schema->getType()) ? !\in_array('null', $schema->getType()) : 'null' !== $schema->getType();
+            return \is_array($schema->getType()) ? \in_array('null', $schema->getType()) : 'null' === $schema->getType();
         }
         if (\get_class($schema) === 'Jane\\Component\\OpenApi2\\JsonSchema\\Model\\Schema') {
             return $schema->offsetExists('x-nullable') && \is_bool($schema->offsetGet('x-nullable')) && $schema->offsetGet('x-nullable');

--- a/src/Component/JsonSchema/Guesser/JsonSchema/DateGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/DateGuesser.php
@@ -25,7 +25,24 @@ class DateGuesser implements GuesserInterface, TypeGuesserInterface
     {
         $class = $this->getSchemaClass();
 
-        return ($object instanceof $class) && 'string' === $object->getType() && 'date' === $object->getFormat();
+        if (!($object instanceof $class)) {
+            return false;
+        }
+
+        return $this->supportsType($object->getType()) && 'date' === $object->getFormat();
+    }
+
+    private function supportsType(mixed $type): bool
+    {
+        if (\is_string($type)) {
+            return 'string' === $type;
+        }
+
+        if (!\is_array($type)) {
+            return false;
+        }
+
+        return ['string'] === array_values(array_diff($type, ['null']));
     }
 
     public function guessType($object, string $name, string $reference, Registry $registry): Type

--- a/src/Component/JsonSchema/Guesser/JsonSchema/DateTimeGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/DateTimeGuesser.php
@@ -26,7 +26,24 @@ class DateTimeGuesser implements GuesserInterface, TypeGuesserInterface
     {
         $class = $this->getSchemaClass();
 
-        return ($object instanceof $class) && 'string' === $object->getType() && 'date-time' === $object->getFormat();
+        if (!($object instanceof $class)) {
+            return false;
+        }
+
+        return $this->supportsType($object->getType()) && 'date-time' === $object->getFormat();
+    }
+
+    private function supportsType(mixed $type): bool
+    {
+        if (\is_string($type)) {
+            return 'string' === $type;
+        }
+
+        if (!\is_array($type)) {
+            return false;
+        }
+
+        return ['string'] === array_values(array_diff($type, ['null']));
     }
 
     public function guessType($object, string $name, string $reference, Registry $registry): Type

--- a/src/Component/JsonSchema/Tests/Guesser/Guess/CheckNullableTraitTest.php
+++ b/src/Component/JsonSchema/Tests/Guesser/Guess/CheckNullableTraitTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests\Guesser\Guess;
+
+use Jane\Component\JsonSchema\Guesser\Guess\CheckNullableTrait;
+use Jane\Component\JsonSchema\JsonSchema\Model\JsonSchema;
+use Jane\Component\OpenApi2\JsonSchema\Model\Schema as OpenApi2Schema;
+use Jane\Component\OpenApi3\JsonSchema\Model\Schema as OpenApi3Schema;
+use PHPUnit\Framework\TestCase;
+
+class CheckNullableTraitTest extends TestCase
+{
+    private object $checker;
+
+    protected function setUp(): void
+    {
+        $this->checker = new class() {
+            use CheckNullableTrait;
+        };
+    }
+
+    /**
+     * @dataProvider jsonSchemaTypeProvider
+     */
+    public function testJsonSchemaNullable(mixed $type, bool $expectedNullable): void
+    {
+        $schema = new JsonSchema();
+        $schema->setType($type);
+
+        self::assertSame($expectedNullable, $this->checker->isNullable($schema));
+    }
+
+    public static function jsonSchemaTypeProvider(): iterable
+    {
+        yield 'array containing null' => [['string', 'null'], true];
+        yield 'array without null' => [['string', 'integer'], false];
+        yield 'null string type' => ['null', true];
+        yield 'string type' => ['string', false];
+        yield 'integer type' => ['integer', false];
+        yield 'no type' => [null, false];
+    }
+
+    public function testOpenApi2XNullable(): void
+    {
+        $nullableSchema = new OpenApi2Schema();
+        $nullableSchema->offsetSet('x-nullable', true);
+        self::assertTrue($this->checker->isNullable($nullableSchema));
+
+        $notNullableSchema = new OpenApi2Schema();
+        $notNullableSchema->offsetSet('x-nullable', false);
+        self::assertFalse($this->checker->isNullable($notNullableSchema));
+
+        $invalidFlagSchema = new OpenApi2Schema();
+        $invalidFlagSchema->offsetSet('x-nullable', 'yes');
+        self::assertFalse($this->checker->isNullable($invalidFlagSchema));
+
+        $missingFlagSchema = new OpenApi2Schema();
+        self::assertFalse($this->checker->isNullable($missingFlagSchema));
+    }
+
+    public function testOpenApi3Nullable(): void
+    {
+        $nullableSchema = new OpenApi3Schema();
+        $nullableSchema->setNullable(true);
+        self::assertTrue($this->checker->isNullable($nullableSchema));
+
+        $notNullableSchema = new OpenApi3Schema();
+        $notNullableSchema->setNullable(false);
+        self::assertFalse($this->checker->isNullable($notNullableSchema));
+
+        $unsetSchema = new OpenApi3Schema();
+        self::assertFalse($this->checker->isNullable($unsetSchema));
+    }
+
+    public function testUnsupportedObjectIsNeverNullable(): void
+    {
+        self::assertFalse($this->checker->isNullable(new \stdClass()));
+    }
+}

--- a/src/Component/JsonSchema/Tests/Guesser/JsonSchema/DateGuesserTest.php
+++ b/src/Component/JsonSchema/Tests/Guesser/JsonSchema/DateGuesserTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Jane\Component\JsonSchema\Tests\Guesser\JsonSchema;
+
+use Jane\Component\JsonSchema\Guesser\JsonSchema\DateGuesser;
+use Jane\Component\JsonSchema\Guesser\JsonSchema\DateTimeGuesser;
+use Jane\Component\JsonSchema\JsonSchema\Model\JsonSchema;
+use PHPUnit\Framework\TestCase;
+
+class DateGuesserTest extends TestCase
+{
+    private DateGuesser $dateGuesser;
+
+    private DateTimeGuesser $dateTimeGuesser;
+
+    protected function setUp(): void
+    {
+        $this->dateGuesser = new DateGuesser();
+        $this->dateTimeGuesser = new DateTimeGuesser();
+    }
+
+    /**
+     * @dataProvider dateSupportProvider
+     */
+    public function testDateSupportObject(mixed $type, ?string $format, bool $expected): void
+    {
+        $schema = new JsonSchema();
+        if (null !== $type) {
+            $schema->setType($type);
+        }
+        if (null !== $format) {
+            $schema->setFormat($format);
+        }
+
+        self::assertSame($expected, $this->dateGuesser->supportObject($schema));
+    }
+
+    public static function dateSupportProvider(): iterable
+    {
+        yield 'plain string' => ['string', 'date', true];
+        yield 'nullable array' => [['string', 'null'], 'date', true];
+        yield 'nullable array reversed order' => [['null', 'string'], 'date', true];
+        yield 'multiple real types rejected' => [['string', 'integer', 'null'], 'date', false];
+        yield 'null type only' => ['null', 'date', false];
+        yield 'no type' => [null, 'date', false];
+        yield 'wrong scalar type' => ['integer', 'date', false];
+        yield 'wrong format' => ['string', 'date-time', false];
+        yield 'missing format' => [['string', 'null'], null, false];
+    }
+
+    /**
+     * @dataProvider dateTimeSupportProvider
+     */
+    public function testDateTimeSupportObject(mixed $type, ?string $format, bool $expected): void
+    {
+        $schema = new JsonSchema();
+        if (null !== $type) {
+            $schema->setType($type);
+        }
+        if (null !== $format) {
+            $schema->setFormat($format);
+        }
+
+        self::assertSame($expected, $this->dateTimeGuesser->supportObject($schema));
+    }
+
+    public static function dateTimeSupportProvider(): iterable
+    {
+        yield 'plain string' => ['string', 'date-time', true];
+        yield 'nullable array' => [['string', 'null'], 'date-time', true];
+        yield 'nullable array reversed order' => [['null', 'string'], 'date-time', true];
+        yield 'multiple real types rejected' => [['string', 'integer', 'null'], 'date-time', false];
+        yield 'null type only' => ['null', 'date-time', false];
+        yield 'no type' => [null, 'date-time', false];
+        yield 'wrong scalar type' => ['integer', 'date-time', false];
+        yield 'wrong format' => ['string', 'date', false];
+        yield 'missing format' => [['string', 'null'], null, false];
+    }
+
+    public function testUnsupportedObjectClassIsRejected(): void
+    {
+        self::assertFalse($this->dateGuesser->supportObject(new \stdClass()));
+        self::assertFalse($this->dateTimeGuesser->supportObject(new \stdClass()));
+    }
+}

--- a/src/Component/JsonSchema/Tests/fixtures/date-format/expected/Normalizer/TestNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/date-format/expected/Normalizer/TestNormalizer.php
@@ -41,27 +41,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $object->setDate(\DateTime::createFromFormat('d.m.Y', $data['date'])->setTime(0, 0, 0));
         }
         if (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] !== null) {
-            $value = $data['dateOrNull'];
-            if (is_string($data['dateOrNull']) and false !== \DateTime::createFromFormat('d.m.Y', $data['dateOrNull'])->setTime(0, 0, 0)) {
-                $value = \DateTime::createFromFormat('d.m.Y', $data['dateOrNull'])->setTime(0, 0, 0);
-            } elseif (is_null($data['dateOrNull'])) {
-                $value = $data['dateOrNull'];
-            }
-            $object->setDateOrNull($value);
+            $object->setDateOrNull(\DateTime::createFromFormat('d.m.Y', $data['dateOrNull'])->setTime(0, 0, 0));
         }
         elseif (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] === null) {
             $object->setDateOrNull(null);
         }
         if (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] !== null) {
-            $value_1 = $data['dateOrNullOrInt'];
+            $value = $data['dateOrNullOrInt'];
             if (is_string($data['dateOrNullOrInt']) and false !== \DateTime::createFromFormat('d.m.Y', $data['dateOrNullOrInt'])->setTime(0, 0, 0)) {
-                $value_1 = \DateTime::createFromFormat('d.m.Y', $data['dateOrNullOrInt'])->setTime(0, 0, 0);
+                $value = \DateTime::createFromFormat('d.m.Y', $data['dateOrNullOrInt'])->setTime(0, 0, 0);
             } elseif (is_null($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             } elseif (is_int($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             }
-            $object->setDateOrNullOrInt($value_1);
+            $object->setDateOrNullOrInt($value);
         }
         elseif (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] === null) {
             $object->setDateOrNullOrInt(null);
@@ -72,27 +66,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $dataArray = [];
         if ($data->isInitialized('date') && null !== $data->getDate()) {
-            $dataArray['date'] = $data->getDate()?->format('d.m.Y');
+            $dataArray['date'] = $data->getDate()->format('d.m.Y');
         }
         if ($data->isInitialized('dateOrNull')) {
-            $value = $data->getDateOrNull();
-            if (is_object($data->getDateOrNull())) {
-                $value = $data->getDateOrNull()->format('d.m.Y');
-            } elseif (is_null($data->getDateOrNull())) {
-                $value = $data->getDateOrNull();
-            }
-            $dataArray['dateOrNull'] = $value;
+            $dataArray['dateOrNull'] = $data->getDateOrNull()?->format('d.m.Y');
         }
         if ($data->isInitialized('dateOrNullOrInt')) {
-            $value_1 = $data->getDateOrNullOrInt();
+            $value = $data->getDateOrNullOrInt();
             if (is_object($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt()?->format('d.m.Y');
+                $value = $data->getDateOrNullOrInt()->format('d.m.Y');
             } elseif (is_null($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             } elseif (is_int($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             }
-            $dataArray['dateOrNullOrInt'] = $value_1;
+            $dataArray['dateOrNullOrInt'] = $value;
         }
         return $dataArray;
     }

--- a/src/Component/JsonSchema/Tests/fixtures/date/expected/Normalizer/TestNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/date/expected/Normalizer/TestNormalizer.php
@@ -41,27 +41,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $object->setDate(\DateTime::createFromFormat('Y-m-d', $data['date'])->setTime(0, 0, 0));
         }
         if (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] !== null) {
-            $value = $data['dateOrNull'];
-            if (is_string($data['dateOrNull']) and false !== \DateTime::createFromFormat('Y-m-d', $data['dateOrNull'])->setTime(0, 0, 0)) {
-                $value = \DateTime::createFromFormat('Y-m-d', $data['dateOrNull'])->setTime(0, 0, 0);
-            } elseif (is_null($data['dateOrNull'])) {
-                $value = $data['dateOrNull'];
-            }
-            $object->setDateOrNull($value);
+            $object->setDateOrNull(\DateTime::createFromFormat('Y-m-d', $data['dateOrNull'])->setTime(0, 0, 0));
         }
         elseif (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] === null) {
             $object->setDateOrNull(null);
         }
         if (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] !== null) {
-            $value_1 = $data['dateOrNullOrInt'];
+            $value = $data['dateOrNullOrInt'];
             if (is_string($data['dateOrNullOrInt']) and false !== \DateTime::createFromFormat('Y-m-d', $data['dateOrNullOrInt'])->setTime(0, 0, 0)) {
-                $value_1 = \DateTime::createFromFormat('Y-m-d', $data['dateOrNullOrInt'])->setTime(0, 0, 0);
+                $value = \DateTime::createFromFormat('Y-m-d', $data['dateOrNullOrInt'])->setTime(0, 0, 0);
             } elseif (is_null($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             } elseif (is_int($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             }
-            $object->setDateOrNullOrInt($value_1);
+            $object->setDateOrNullOrInt($value);
         }
         elseif (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] === null) {
             $object->setDateOrNullOrInt(null);
@@ -72,27 +66,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $dataArray = [];
         if ($data->isInitialized('date') && null !== $data->getDate()) {
-            $dataArray['date'] = $data->getDate()?->format('Y-m-d');
+            $dataArray['date'] = $data->getDate()->format('Y-m-d');
         }
         if ($data->isInitialized('dateOrNull')) {
-            $value = $data->getDateOrNull();
-            if (is_object($data->getDateOrNull())) {
-                $value = $data->getDateOrNull()->format('Y-m-d');
-            } elseif (is_null($data->getDateOrNull())) {
-                $value = $data->getDateOrNull();
-            }
-            $dataArray['dateOrNull'] = $value;
+            $dataArray['dateOrNull'] = $data->getDateOrNull()?->format('Y-m-d');
         }
         if ($data->isInitialized('dateOrNullOrInt')) {
-            $value_1 = $data->getDateOrNullOrInt();
+            $value = $data->getDateOrNullOrInt();
             if (is_object($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt()?->format('Y-m-d');
+                $value = $data->getDateOrNullOrInt()->format('Y-m-d');
             } elseif (is_null($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             } elseif (is_int($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             }
-            $dataArray['dateOrNullOrInt'] = $value_1;
+            $dataArray['dateOrNullOrInt'] = $value;
         }
         return $dataArray;
     }

--- a/src/Component/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/datetime-format/expected/Normalizer/TestNormalizer.php
@@ -41,27 +41,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $object->setDate(\DateTime::createFromFormat('l, d-M-y H:i:s T', $data['date']));
         }
         if (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] !== null) {
-            $value = $data['dateOrNull'];
-            if (is_string($data['dateOrNull']) and false !== \DateTime::createFromFormat('l, d-M-y H:i:s T', $data['dateOrNull'])) {
-                $value = \DateTime::createFromFormat('l, d-M-y H:i:s T', $data['dateOrNull']);
-            } elseif (is_null($data['dateOrNull'])) {
-                $value = $data['dateOrNull'];
-            }
-            $object->setDateOrNull($value);
+            $object->setDateOrNull(\DateTime::createFromFormat('l, d-M-y H:i:s T', $data['dateOrNull']));
         }
         elseif (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] === null) {
             $object->setDateOrNull(null);
         }
         if (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] !== null) {
-            $value_1 = $data['dateOrNullOrInt'];
+            $value = $data['dateOrNullOrInt'];
             if (is_string($data['dateOrNullOrInt']) and false !== \DateTime::createFromFormat('l, d-M-y H:i:s T', $data['dateOrNullOrInt'])) {
-                $value_1 = \DateTime::createFromFormat('l, d-M-y H:i:s T', $data['dateOrNullOrInt']);
+                $value = \DateTime::createFromFormat('l, d-M-y H:i:s T', $data['dateOrNullOrInt']);
             } elseif (is_null($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             } elseif (is_int($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             }
-            $object->setDateOrNullOrInt($value_1);
+            $object->setDateOrNullOrInt($value);
         }
         elseif (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] === null) {
             $object->setDateOrNullOrInt(null);
@@ -72,27 +66,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $dataArray = [];
         if ($data->isInitialized('date') && null !== $data->getDate()) {
-            $dataArray['date'] = $data->getDate()?->format('l, d-M-y H:i:s T');
+            $dataArray['date'] = $data->getDate()->format('l, d-M-y H:i:s T');
         }
         if ($data->isInitialized('dateOrNull')) {
-            $value = $data->getDateOrNull();
-            if (is_object($data->getDateOrNull())) {
-                $value = $data->getDateOrNull()->format('l, d-M-y H:i:s T');
-            } elseif (is_null($data->getDateOrNull())) {
-                $value = $data->getDateOrNull();
-            }
-            $dataArray['dateOrNull'] = $value;
+            $dataArray['dateOrNull'] = $data->getDateOrNull()?->format('l, d-M-y H:i:s T');
         }
         if ($data->isInitialized('dateOrNullOrInt')) {
-            $value_1 = $data->getDateOrNullOrInt();
+            $value = $data->getDateOrNullOrInt();
             if (is_object($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt()?->format('l, d-M-y H:i:s T');
+                $value = $data->getDateOrNullOrInt()->format('l, d-M-y H:i:s T');
             } elseif (is_null($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             } elseif (is_int($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             }
-            $dataArray['dateOrNullOrInt'] = $value_1;
+            $dataArray['dateOrNullOrInt'] = $value;
         }
         return $dataArray;
     }

--- a/src/Component/JsonSchema/Tests/fixtures/datetime-interface/expected/Normalizer/TestNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/datetime-interface/expected/Normalizer/TestNormalizer.php
@@ -41,27 +41,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $object->setDate(\DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['date']));
         }
         if (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] !== null) {
-            $value = $data['dateOrNull'];
-            if (is_string($data['dateOrNull']) and false !== \DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNull'])) {
-                $value = \DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNull']);
-            } elseif (is_null($data['dateOrNull'])) {
-                $value = $data['dateOrNull'];
-            }
-            $object->setDateOrNull($value);
+            $object->setDateOrNull(\DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNull']));
         }
         elseif (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] === null) {
             $object->setDateOrNull(null);
         }
         if (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] !== null) {
-            $value_1 = $data['dateOrNullOrInt'];
+            $value = $data['dateOrNullOrInt'];
             if (is_string($data['dateOrNullOrInt']) and false !== \DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNullOrInt'])) {
-                $value_1 = \DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNullOrInt']);
+                $value = \DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNullOrInt']);
             } elseif (is_null($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             } elseif (is_int($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             }
-            $object->setDateOrNullOrInt($value_1);
+            $object->setDateOrNullOrInt($value);
         }
         elseif (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] === null) {
             $object->setDateOrNullOrInt(null);
@@ -72,27 +66,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $dataArray = [];
         if ($data->isInitialized('date') && null !== $data->getDate()) {
-            $dataArray['date'] = $data->getDate()?->format('Y-m-d\TH:i:sP');
+            $dataArray['date'] = $data->getDate()->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('dateOrNull')) {
-            $value = $data->getDateOrNull();
-            if (is_object($data->getDateOrNull())) {
-                $value = $data->getDateOrNull()->format('Y-m-d\TH:i:sP');
-            } elseif (is_null($data->getDateOrNull())) {
-                $value = $data->getDateOrNull();
-            }
-            $dataArray['dateOrNull'] = $value;
+            $dataArray['dateOrNull'] = $data->getDateOrNull()?->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('dateOrNullOrInt')) {
-            $value_1 = $data->getDateOrNullOrInt();
+            $value = $data->getDateOrNullOrInt();
             if (is_object($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt()?->format('Y-m-d\TH:i:sP');
+                $value = $data->getDateOrNullOrInt()->format('Y-m-d\TH:i:sP');
             } elseif (is_null($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             } elseif (is_int($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             }
-            $dataArray['dateOrNullOrInt'] = $value_1;
+            $dataArray['dateOrNullOrInt'] = $value;
         }
         return $dataArray;
     }

--- a/src/Component/JsonSchema/Tests/fixtures/datetime-no-format/expected/Normalizer/TestNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/datetime-no-format/expected/Normalizer/TestNormalizer.php
@@ -41,27 +41,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $object->setDate((new \DateTime($data['date']))->getTimezone()->getName() == 'Z' ? (new \DateTime($data['date']))->setTimezone(new \DateTimeZone('GMT')) : new \DateTime($data['date']));
         }
         if (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] !== null) {
-            $value = $data['dateOrNull'];
-            if (is_string($data['dateOrNull']) and false !== ((new \DateTime($data['dateOrNull']))->getTimezone()->getName() == 'Z' ? (new \DateTime($data['dateOrNull']))->setTimezone(new \DateTimeZone('GMT')) : new \DateTime($data['dateOrNull']))) {
-                $value = (new \DateTime($data['dateOrNull']))->getTimezone()->getName() == 'Z' ? (new \DateTime($data['dateOrNull']))->setTimezone(new \DateTimeZone('GMT')) : new \DateTime($data['dateOrNull']);
-            } elseif (is_null($data['dateOrNull'])) {
-                $value = $data['dateOrNull'];
-            }
-            $object->setDateOrNull($value);
+            $object->setDateOrNull((new \DateTime($data['dateOrNull']))->getTimezone()->getName() == 'Z' ? (new \DateTime($data['dateOrNull']))->setTimezone(new \DateTimeZone('GMT')) : new \DateTime($data['dateOrNull']));
         }
         elseif (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] === null) {
             $object->setDateOrNull(null);
         }
         if (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] !== null) {
-            $value_1 = $data['dateOrNullOrInt'];
+            $value = $data['dateOrNullOrInt'];
             if (is_string($data['dateOrNullOrInt']) and false !== ((new \DateTime($data['dateOrNullOrInt']))->getTimezone()->getName() == 'Z' ? (new \DateTime($data['dateOrNullOrInt']))->setTimezone(new \DateTimeZone('GMT')) : new \DateTime($data['dateOrNullOrInt']))) {
-                $value_1 = (new \DateTime($data['dateOrNullOrInt']))->getTimezone()->getName() == 'Z' ? (new \DateTime($data['dateOrNullOrInt']))->setTimezone(new \DateTimeZone('GMT')) : new \DateTime($data['dateOrNullOrInt']);
+                $value = (new \DateTime($data['dateOrNullOrInt']))->getTimezone()->getName() == 'Z' ? (new \DateTime($data['dateOrNullOrInt']))->setTimezone(new \DateTimeZone('GMT')) : new \DateTime($data['dateOrNullOrInt']);
             } elseif (is_null($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             } elseif (is_int($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             }
-            $object->setDateOrNullOrInt($value_1);
+            $object->setDateOrNullOrInt($value);
         }
         elseif (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] === null) {
             $object->setDateOrNullOrInt(null);
@@ -72,27 +66,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $dataArray = [];
         if ($data->isInitialized('date') && null !== $data->getDate()) {
-            $dataArray['date'] = $data->getDate()?->format('Y-m-d\TH:i:sP');
+            $dataArray['date'] = $data->getDate()->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('dateOrNull')) {
-            $value = $data->getDateOrNull();
-            if (is_object($data->getDateOrNull())) {
-                $value = $data->getDateOrNull()->format('Y-m-d\TH:i:sP');
-            } elseif (is_null($data->getDateOrNull())) {
-                $value = $data->getDateOrNull();
-            }
-            $dataArray['dateOrNull'] = $value;
+            $dataArray['dateOrNull'] = $data->getDateOrNull()?->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('dateOrNullOrInt')) {
-            $value_1 = $data->getDateOrNullOrInt();
+            $value = $data->getDateOrNullOrInt();
             if (is_object($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt()?->format('Y-m-d\TH:i:sP');
+                $value = $data->getDateOrNullOrInt()->format('Y-m-d\TH:i:sP');
             } elseif (is_null($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             } elseif (is_int($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             }
-            $dataArray['dateOrNullOrInt'] = $value_1;
+            $dataArray['dateOrNullOrInt'] = $value;
         }
         return $dataArray;
     }

--- a/src/Component/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
+++ b/src/Component/JsonSchema/Tests/fixtures/datetime/expected/Normalizer/TestNormalizer.php
@@ -41,27 +41,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $object->setDate(\DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['date']));
         }
         if (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] !== null) {
-            $value = $data['dateOrNull'];
-            if (is_string($data['dateOrNull']) and false !== \DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNull'])) {
-                $value = \DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNull']);
-            } elseif (is_null($data['dateOrNull'])) {
-                $value = $data['dateOrNull'];
-            }
-            $object->setDateOrNull($value);
+            $object->setDateOrNull(\DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNull']));
         }
         elseif (\array_key_exists('dateOrNull', $data) && $data['dateOrNull'] === null) {
             $object->setDateOrNull(null);
         }
         if (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] !== null) {
-            $value_1 = $data['dateOrNullOrInt'];
+            $value = $data['dateOrNullOrInt'];
             if (is_string($data['dateOrNullOrInt']) and false !== \DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNullOrInt'])) {
-                $value_1 = \DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNullOrInt']);
+                $value = \DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['dateOrNullOrInt']);
             } elseif (is_null($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             } elseif (is_int($data['dateOrNullOrInt'])) {
-                $value_1 = $data['dateOrNullOrInt'];
+                $value = $data['dateOrNullOrInt'];
             }
-            $object->setDateOrNullOrInt($value_1);
+            $object->setDateOrNullOrInt($value);
         }
         elseif (\array_key_exists('dateOrNullOrInt', $data) && $data['dateOrNullOrInt'] === null) {
             $object->setDateOrNullOrInt(null);
@@ -72,27 +66,21 @@ class TestNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
     {
         $dataArray = [];
         if ($data->isInitialized('date') && null !== $data->getDate()) {
-            $dataArray['date'] = $data->getDate()?->format('Y-m-d\TH:i:sP');
+            $dataArray['date'] = $data->getDate()->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('dateOrNull')) {
-            $value = $data->getDateOrNull();
-            if (is_object($data->getDateOrNull())) {
-                $value = $data->getDateOrNull()->format('Y-m-d\TH:i:sP');
-            } elseif (is_null($data->getDateOrNull())) {
-                $value = $data->getDateOrNull();
-            }
-            $dataArray['dateOrNull'] = $value;
+            $dataArray['dateOrNull'] = $data->getDateOrNull()?->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('dateOrNullOrInt')) {
-            $value_1 = $data->getDateOrNullOrInt();
+            $value = $data->getDateOrNullOrInt();
             if (is_object($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt()?->format('Y-m-d\TH:i:sP');
+                $value = $data->getDateOrNullOrInt()->format('Y-m-d\TH:i:sP');
             } elseif (is_null($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             } elseif (is_int($data->getDateOrNullOrInt())) {
-                $value_1 = $data->getDateOrNullOrInt();
+                $value = $data->getDateOrNullOrInt();
             }
-            $dataArray['dateOrNullOrInt'] = $value_1;
+            $dataArray['dateOrNullOrInt'] = $value;
         }
         return $dataArray;
     }

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/BuyMuseumTicketsNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/BuyMuseumTicketsNormalizer.php
@@ -66,7 +66,7 @@ class BuyMuseumTicketsNormalizer implements DenormalizerInterface, NormalizerInt
         if ($data->isInitialized('ticketId') && null !== $data->getTicketId()) {
             $dataArray['ticketId'] = $data->getTicketId();
         }
-        $dataArray['ticketDate'] = $data->getTicketDate()?->format('Y-m-d');
+        $dataArray['ticketDate'] = $data->getTicketDate()->format('Y-m-d');
         $dataArray['ticketType'] = $data->getTicketType();
         if ($data->isInitialized('eventId') && null !== $data->getEventId()) {
             $dataArray['eventId'] = $data->getEventId();

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/MuseumDailyHoursNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/MuseumDailyHoursNormalizer.php
@@ -54,7 +54,7 @@ class MuseumDailyHoursNormalizer implements DenormalizerInterface, NormalizerInt
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         $dataArray = [];
-        $dataArray['date'] = $data->getDate()?->format('Y-m-d');
+        $dataArray['date'] = $data->getDate()->format('Y-m-d');
         $dataArray['timeOpen'] = $data->getTimeOpen();
         $dataArray['timeClose'] = $data->getTimeClose();
         if (!($context['skip_validation'] ?? false)) {

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/MuseumTicketsConfirmationNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/MuseumTicketsConfirmationNormalizer.php
@@ -66,7 +66,7 @@ class MuseumTicketsConfirmationNormalizer implements DenormalizerInterface, Norm
         if ($data->isInitialized('ticketId') && null !== $data->getTicketId()) {
             $dataArray['ticketId'] = $data->getTicketId();
         }
-        $dataArray['ticketDate'] = $data->getTicketDate()?->format('Y-m-d');
+        $dataArray['ticketDate'] = $data->getTicketDate()->format('Y-m-d');
         $dataArray['ticketType'] = $data->getTicketType();
         if ($data->isInitialized('eventId') && null !== $data->getEventId()) {
             $dataArray['eventId'] = $data->getEventId();

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/SpecialEventFieldsNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/SpecialEventFieldsNormalizer.php
@@ -79,7 +79,7 @@ class SpecialEventFieldsNormalizer implements DenormalizerInterface, NormalizerI
         if ($data->isInitialized('dates') && null !== $data->getDates()) {
             $values = [];
             foreach ($data->getDates() as $value) {
-                $values[] = $value?->format('Y-m-d');
+                $values[] = $value->format('Y-m-d');
             }
             $dataArray['dates'] = $values;
         }

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/SpecialEventNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/SpecialEventNormalizer.php
@@ -78,7 +78,7 @@ class SpecialEventNormalizer implements DenormalizerInterface, NormalizerInterfa
         $dataArray['eventDescription'] = $data->getEventDescription();
         $values = [];
         foreach ($data->getDates() as $value) {
-            $values[] = $value?->format('Y-m-d');
+            $values[] = $value->format('Y-m-d');
         }
         $dataArray['dates'] = $values;
         $dataArray['price'] = $data->getPrice();

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/TicketNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Normalizer/TicketNormalizer.php
@@ -60,7 +60,7 @@ class TicketNormalizer implements DenormalizerInterface, NormalizerInterface, De
         if ($data->isInitialized('ticketId') && null !== $data->getTicketId()) {
             $dataArray['ticketId'] = $data->getTicketId();
         }
-        $dataArray['ticketDate'] = $data->getTicketDate()?->format('Y-m-d');
+        $dataArray['ticketDate'] = $data->getTicketDate()->format('Y-m-d');
         $dataArray['ticketType'] = $data->getTicketType();
         if ($data->isInitialized('eventId') && null !== $data->getEventId()) {
             $dataArray['eventId'] = $data->getEventId();

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/.jane-openapi
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\Component\OpenApi31\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+    'validation' => true,
+];

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Client.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Expected\Model\Event : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getEvents(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetEvents(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Endpoint/GetEvents.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Endpoint/GetEvents.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Endpoint;
+
+class GetEvents extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/events';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Expected\Model\Event
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Expected\Model\Event', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Model/Event.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Model/Event.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model;
+
+class Event
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var \DateTime|null
+     */
+    protected $eventDate;
+    /**
+     * @var \DateTime|null
+     */
+    protected $createdAt;
+    /**
+     * @var \DateTime
+     */
+    protected $updatedAt;
+    /**
+     * @var string|null
+     */
+    protected $plainDate;
+    /**
+     * @return \DateTime|null
+     */
+    public function getEventDate(): ?\DateTime
+    {
+        return $this->eventDate;
+    }
+    /**
+     * @param \DateTime|null $eventDate
+     *
+     * @return self
+     */
+    public function setEventDate(?\DateTime $eventDate): self
+    {
+        $this->initialized['eventDate'] = true;
+        $this->eventDate = $eventDate;
+        return $this;
+    }
+    /**
+     * @return \DateTime|null
+     */
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+    /**
+     * @param \DateTime|null $createdAt
+     *
+     * @return self
+     */
+    public function setCreatedAt(?\DateTime $createdAt): self
+    {
+        $this->initialized['createdAt'] = true;
+        $this->createdAt = $createdAt;
+        return $this;
+    }
+    /**
+     * @return \DateTime
+     */
+    public function getUpdatedAt(): \DateTime
+    {
+        return $this->updatedAt;
+    }
+    /**
+     * @param \DateTime $updatedAt
+     *
+     * @return self
+     */
+    public function setUpdatedAt(\DateTime $updatedAt): self
+    {
+        $this->initialized['updatedAt'] = true;
+        $this->updatedAt = $updatedAt;
+        return $this;
+    }
+    /**
+     * @return string|null
+     */
+    public function getPlainDate(): ?string
+    {
+        return $this->plainDate;
+    }
+    /**
+     * @param string|null $plainDate
+     *
+     * @return self
+     */
+    public function setPlainDate(?string $plainDate): self
+    {
+        $this->initialized['plainDate'] = true;
+        $this->plainDate = $plainDate;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Normalizer/EventNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Normalizer/EventNormalizer.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class EventNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Expected\Model\Event::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Expected\Model\Event::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Expected\Model\Event();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($data, new \Jane\Component\OpenApi31\Tests\Expected\Validator\EventConstraint());
+        }
+        if (\array_key_exists('eventDate', $data) && $data['eventDate'] !== null) {
+            $object->setEventDate(\DateTime::createFromFormat('Y-m-d', $data['eventDate'])->setTime(0, 0, 0));
+        }
+        elseif (\array_key_exists('eventDate', $data) && $data['eventDate'] === null) {
+            $object->setEventDate(null);
+        }
+        if (\array_key_exists('createdAt', $data) && $data['createdAt'] !== null) {
+            $object->setCreatedAt(\DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['createdAt']));
+        }
+        elseif (\array_key_exists('createdAt', $data) && $data['createdAt'] === null) {
+            $object->setCreatedAt(null);
+        }
+        if (\array_key_exists('updatedAt', $data)) {
+            $object->setUpdatedAt(\DateTime::createFromFormat('Y-m-d\TH:i:sP', $data['updatedAt']));
+        }
+        if (\array_key_exists('plainDate', $data) && $data['plainDate'] !== null) {
+            $value = $data['plainDate'];
+            if (is_string($data['plainDate'])) {
+                $value = $data['plainDate'];
+            } elseif (is_null($data['plainDate'])) {
+                $value = $data['plainDate'];
+            }
+            $object->setPlainDate($value);
+        }
+        elseif (\array_key_exists('plainDate', $data) && $data['plainDate'] === null) {
+            $object->setPlainDate(null);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('eventDate')) {
+            $dataArray['eventDate'] = $data->getEventDate()?->format('Y-m-d');
+        }
+        $dataArray['createdAt'] = $data->getCreatedAt()?->format('Y-m-d\TH:i:sP');
+        if ($data->isInitialized('updatedAt') && null !== $data->getUpdatedAt()) {
+            $dataArray['updatedAt'] = $data->getUpdatedAt()->format('Y-m-d\TH:i:sP');
+        }
+        if ($data->isInitialized('plainDate')) {
+            $value = $data->getPlainDate();
+            if (is_string($data->getPlainDate())) {
+                $value = $data->getPlainDate();
+            } elseif (is_null($data->getPlainDate())) {
+                $value = $data->getPlainDate();
+            }
+            $dataArray['plainDate'] = $value;
+        }
+        if (!($context['skip_validation'] ?? false)) {
+            $this->validate($dataArray, new \Jane\Component\OpenApi31\Tests\Expected\Validator\EventConstraint());
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Expected\Model\Event::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi31\Tests\Expected\Model\Event::class => \Jane\Component\OpenApi31\Tests\Expected\Normalizer\EventNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            
+            \Jane\Component\OpenApi31\Tests\Expected\Model\Event::class => false,
+            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+        ];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(static function ($value) {
+            return $value ?? '';
+        }, $optionsResolved);
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            $allowReservedKey = in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Validator/EventConstraint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/expected/Validator/EventConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Validator;
+
+class EventConstraint extends \Symfony\Component\Validator\Constraints\Compound
+{
+    protected function getConstraints($options): array
+    {
+        return [new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.'), new \Symfony\Component\Validator\Constraints\Collection(fields: ['eventDate' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\Type(type: ['string', 'null'])]), 'createdAt' => new \Symfony\Component\Validator\Constraints\Required([new \Symfony\Component\Validator\Constraints\Type(type: ['string', 'null'])]), 'updatedAt' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\Type(type: ['string']), new \Symfony\Component\Validator\Constraints\NotNull(message: 'This value should not be null.')]), 'plainDate' => new \Symfony\Component\Validator\Constraints\Optional([new \Symfony\Component\Validator\Constraints\Type(type: ['string', 'null'])])], allowExtraFields: true)];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/nullable-date/openapi.json
+++ b/src/Component/OpenApi31/Tests/fixtures/nullable-date/openapi.json
@@ -1,0 +1,51 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Nullable date API",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/events": {
+            "get": {
+                "operationId": "getEvents",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Event"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Event": {
+                "type": "object",
+                "required": ["createdAt"],
+                "properties": {
+                    "eventDate": {
+                        "type": ["string", "null"],
+                        "format": "date"
+                    },
+                    "createdAt": {
+                        "type": ["string", "null"],
+                        "format": "date-time"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "plainDate": {
+                        "type": ["string", "null"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/ImageUploadedMessageNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/ImageUploadedMessageNormalizer.php
@@ -67,7 +67,7 @@ class ImageUploadedMessageNormalizer implements DenormalizerInterface, Normalize
             $dataArray['imageUrl'] = $data->getImageUrl();
         }
         if ($data->isInitialized('uploadedAt') && null !== $data->getUploadedAt()) {
-            $dataArray['uploadedAt'] = $data->getUploadedAt()?->format('Y-m-d\TH:i:sP');
+            $dataArray['uploadedAt'] = $data->getUploadedAt()->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('fileSize') && null !== $data->getFileSize()) {
             $dataArray['fileSize'] = $data->getFileSize();

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Normalizer/PlanetNormalizer.php
@@ -150,7 +150,7 @@ class PlanetNormalizer implements DenormalizerInterface, NormalizerInterface, De
             $dataArray['atmosphere'] = $values;
         }
         if ($data->isInitialized('discoveredAt') && null !== $data->getDiscoveredAt()) {
-            $dataArray['discoveredAt'] = $data->getDiscoveredAt()?->format('Y-m-d\TH:i:sP');
+            $dataArray['discoveredAt'] = $data->getDiscoveredAt()->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('image')) {
             $value_2 = $data->getImage();

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Normalizer/TripNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Normalizer/TripNormalizer.php
@@ -91,10 +91,10 @@ class TripNormalizer implements DenormalizerInterface, NormalizerInterface, Deno
             $dataArray['destination'] = $data->getDestination();
         }
         if ($data->isInitialized('departureTime') && null !== $data->getDepartureTime()) {
-            $dataArray['departure_time'] = $data->getDepartureTime()?->format('Y-m-d\TH:i:sP');
+            $dataArray['departure_time'] = $data->getDepartureTime()->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('arrivalTime') && null !== $data->getArrivalTime()) {
-            $dataArray['arrival_time'] = $data->getArrivalTime()?->format('Y-m-d\TH:i:sP');
+            $dataArray['arrival_time'] = $data->getArrivalTime()->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('operator') && null !== $data->getOperator()) {
             $dataArray['operator'] = $data->getOperator();

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Normalizer/TripsGetJsonResponse200DataItemNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Normalizer/TripsGetJsonResponse200DataItemNormalizer.php
@@ -94,10 +94,10 @@ class TripsGetJsonResponse200DataItemNormalizer implements DenormalizerInterface
             $dataArray['destination'] = $data->getDestination();
         }
         if ($data->isInitialized('departureTime') && null !== $data->getDepartureTime()) {
-            $dataArray['departure_time'] = $data->getDepartureTime()?->format('Y-m-d\TH:i:sP');
+            $dataArray['departure_time'] = $data->getDepartureTime()->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('arrivalTime') && null !== $data->getArrivalTime()) {
-            $dataArray['arrival_time'] = $data->getArrivalTime()?->format('Y-m-d\TH:i:sP');
+            $dataArray['arrival_time'] = $data->getArrivalTime()->format('Y-m-d\TH:i:sP');
         }
         if ($data->isInitialized('operator') && null !== $data->getOperator()) {
             $dataArray['operator'] = $data->getOperator();


### PR DESCRIPTION
## Description

Adds OpenAPI 3.1 support for nullable date/date-time properties and fixes an inverted nullability check in the JSON Schema guessing layer (follow-up to #848; the OpenAPI 3.0 part was fixed by #841).

OAS 3.1 expresses nullability via `type: ["string", "null"]` instead of 3.0's `nullable: true`. Such properties never reached `DateGuesser` / `DateTimeGuesser` because their support check demanded strict `type === 'string'`, so they fell through to the multiple-type guesser and produced branch-based normalization code whose null-safety depended on a guesser-internal implementation detail. Additionally, `CheckNullableTrait::isNullable()` returned the exact opposite of the truth for JSON Schema models (a type array containing `"null"` was detected as non-nullable).

## Changes

- Fix inverted null detection in `CheckNullableTrait::isNullable()` for JSON Schema models: `\in_array('null', $type)` / `'null' === $type` instead of the negated forms
- Accept `type: ["string", "null"]` (any order) in the base `DateGuesser` / `DateTimeGuesser` so nullable dates/datetimes generate the same null-safe code as OAS 3.0 `nullable: true` properties; combinations with additional real types still route to the multiple-type guesser
- New OpenApi31 regression fixture `nullable-date`: optional nullable `date`, required nullable `date-time`, non-null control and no-format string|null control
- Regenerate affected expected fixtures: 6 JsonSchema date/datetime fixtures (nullable-array branches collapse to single-line `?->format()`) and 10 OpenApi31 normalizers (non-nullable dates drop the unconditional nullsafe operator; outer null guards keep them safe)
- Add unit tests: `CheckNullableTraitTest` (9 cases over all three model branches) and `DateGuesserTest` (18-case support matrix for both guessers)
- CHANGELOG entry under Unreleased

## How to test

1. `composer install`
2. `vendor/bin/phpunit` — 399 tests, all green
3. Manual check: generate from an OAS 3.1 document containing `{"type": ["string", "null"], "format": "date-time"}` — the model getter returns `?\DateTime`, the normalizer emits `$data->getProperty()?->format(...)` and the denormalizer guards `null` before `createFromFormat`

## Notes

- Behavior change for pure JSON-Schema users: draft-style nullable dates now generate single-statement null-safe code; non-nullable dates lose the previously unconditional nullsafe operator (generated output stays safe thanks to existing outer null guards)
- No `composer.json` changes, no migrations, no config changes
- A separate task/worktree tracks the `MultipleGuesser` shared-clone aliasing bug discovered during analysis (out of scope here)
