### PR TITLE
fix(open-api-common): add scalar return types to response bodies (#800)

### DIFF
--- a/src/Component/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -8,6 +8,7 @@ use Jane\Component\OpenApi2\Guesser\GuessClass;
 use Jane\Component\OpenApi2\JsonSchema\Model\Response;
 use Jane\Component\OpenApi2\JsonSchema\Model\Schema;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
+use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
 use Jane\Component\OpenApiCommon\Registry\Registry;
 use PhpParser\Comment\Doc;
@@ -22,6 +23,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 trait GetTransformResponseBodyTrait
 {
+    use OpenApiNumberTypeResolverTrait;
+
     public function getTransformResponseBody(OperationGuess $operation, string $endpointName, GuessClass $guessClass, ExceptionGenerator $exceptionGenerator, Context $context): array
     {
         $outputStatements = [
@@ -144,6 +147,12 @@ EOD
             $serializeStmt = new Expr\FuncCall(new Name('json_decode'), [
                 new Arg(new Expr\Variable('body')),
             ]);
+
+            $scalarReturnType = $this->convertResponseType($schema);
+
+            if (null !== $scalarReturnType) {
+                $returnType = $scalarReturnType;
+            }
         }
 
         $returnStmt = new Stmt\Return_($serializeStmt);
@@ -181,5 +190,30 @@ EOD
                 'stmts' => [$returnStmt],
             ]
         )];
+    }
+
+    private function convertResponseType(Schema $schema): ?string
+    {
+        $type = $schema->getType();
+
+        if (null === $type && null !== $schema->getEnum() && \count($schema->getEnum()) > 0) {
+            $type = 'string';
+        }
+
+        return match ($type) {
+            'string' => 'string',
+            'number' => $this->isNumberFloat(
+                $schema->getFormat(),
+                $schema->getDefault(),
+                $schema->getMinimum(),
+                $schema->getMaximum(),
+                $schema->getMultipleOf(),
+                $schema->getEnum()
+            ) ? 'float' : 'int',
+            'boolean' => 'bool',
+            'integer' => 'int',
+            'array' => 'array',
+            default => null,
+        };
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Client.php
@@ -128,7 +128,7 @@ class Client extends \Docker\Api\Runtime\Client\Client
      * @throws \Docker\Api\Exception\ContainerLogsNotFoundException
      * @throws \Docker\Api\Exception\ContainerLogsInternalServerErrorException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function containerLogs(string $id, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {
@@ -976,7 +976,7 @@ class Client extends \Docker\Api\Runtime\Client\Client
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      * @throws \Docker\Api\Exception\SystemPingInternalServerErrorException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function systemPing(string $fetch = self::FETCH_OBJECT)
     {
@@ -986,7 +986,7 @@ class Client extends \Docker\Api\Runtime\Client\Client
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      * @throws \Docker\Api\Exception\SystemPingHeadInternalServerErrorException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function systemPingHead(string $fetch = self::FETCH_OBJECT)
     {
@@ -1108,7 +1108,7 @@ class Client extends \Docker\Api\Runtime\Client\Client
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      * @throws \Docker\Api\Exception\ImageGetInternalServerErrorException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function imageGet(string $name, string $fetch = self::FETCH_OBJECT)
     {
@@ -1132,7 +1132,7 @@ class Client extends \Docker\Api\Runtime\Client\Client
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      * @throws \Docker\Api\Exception\ImageGetAllInternalServerErrorException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function imageGetAll(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {
@@ -1724,7 +1724,7 @@ class Client extends \Docker\Api\Runtime\Client\Client
      * @throws \Docker\Api\Exception\SwarmInitInternalServerErrorException
      * @throws \Docker\Api\Exception\SwarmInitServiceUnavailableException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function swarmInit(\Docker\Api\Model\SwarmInitPostBody $body, string $fetch = self::FETCH_OBJECT)
     {
@@ -1942,7 +1942,7 @@ class Client extends \Docker\Api\Runtime\Client\Client
      * @throws \Docker\Api\Exception\ServiceLogsInternalServerErrorException
      * @throws \Docker\Api\Exception\ServiceLogsServiceUnavailableException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function serviceLogs(string $id, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {
@@ -2010,7 +2010,7 @@ class Client extends \Docker\Api\Runtime\Client\Client
      * @throws \Docker\Api\Exception\TaskLogsInternalServerErrorException
      * @throws \Docker\Api\Exception\TaskLogsServiceUnavailableException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function taskLogs(string $id, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerLogs.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ContainerLogs.php
@@ -67,7 +67,7 @@ class ContainerLogs extends \Docker\Api\Runtime\Client\BaseEndpoint implements \
      * @throws \Docker\Api\Exception\ContainerLogsNotFoundException
      * @throws \Docker\Api\Exception\ContainerLogsInternalServerErrorException
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageGet.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageGet.php
@@ -58,7 +58,7 @@ class ImageGet extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Docke
      *
      * @throws \Docker\Api\Exception\ImageGetInternalServerErrorException
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageGetAll.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ImageGetAll.php
@@ -55,7 +55,7 @@ class ImageGetAll extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
      *
      * @throws \Docker\Api\Exception\ImageGetAllInternalServerErrorException
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceLogs.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/ServiceLogs.php
@@ -69,7 +69,7 @@ class ServiceLogs extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Do
      * @throws \Docker\Api\Exception\ServiceLogsInternalServerErrorException
      * @throws \Docker\Api\Exception\ServiceLogsServiceUnavailableException
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SwarmInit.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SwarmInit.php
@@ -35,7 +35,7 @@ class SwarmInit extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Dock
      * @throws \Docker\Api\Exception\SwarmInitInternalServerErrorException
      * @throws \Docker\Api\Exception\SwarmInitServiceUnavailableException
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SystemPing.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SystemPing.php
@@ -26,7 +26,7 @@ class SystemPing extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Doc
      *
      * @throws \Docker\Api\Exception\SystemPingInternalServerErrorException
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SystemPingHead.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/SystemPingHead.php
@@ -26,7 +26,7 @@ class SystemPingHead extends \Docker\Api\Runtime\Client\BaseEndpoint implements 
      *
      * @throws \Docker\Api\Exception\SystemPingHeadInternalServerErrorException
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/TaskLogs.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Endpoint/TaskLogs.php
@@ -69,7 +69,7 @@ class TaskLogs extends \Docker\Api\Runtime\Client\BaseEndpoint implements \Docke
      * @throws \Docker\Api\Exception\TaskLogsInternalServerErrorException
      * @throws \Docker\Api\Exception\TaskLogsServiceUnavailableException
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Client.php
@@ -17433,7 +17433,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\FindToolTraceRouteForbiddenException
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\FindToolTraceRouteInternalServerErrorException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function findToolTraceRoute(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {
@@ -17483,7 +17483,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\FindToolPingForbiddenException
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\FindToolPingInternalServerErrorException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function findToolPing(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Endpoint/FindToolPing.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Endpoint/FindToolPing.php
@@ -50,7 +50,7 @@ class FindToolPing extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Clien
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\FindToolPingForbiddenException
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\FindToolPingInternalServerErrorException
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Endpoint/FindToolTraceRoute.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Endpoint/FindToolTraceRoute.php
@@ -52,7 +52,7 @@ class FindToolTraceRoute extends \Jane\Component\OpenApi3\Tests\Expected\Runtime
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\FindToolTraceRouteForbiddenException
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\FindToolTraceRouteInternalServerErrorException
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Client.php
@@ -48,7 +48,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
     /**
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi2\Tests\Expected\Model\TestComplexListGetResponsedefault : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array|\Jane\Component\OpenApi2\Tests\Expected\Model\TestComplexListGetResponsedefault : \Psr\Http\Message\ResponseInterface)
      */
     public function getTestComplexList(string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Endpoint/GetTestComplexList.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Endpoint/GetTestComplexList.php
@@ -21,7 +21,7 @@ class GetTestComplexList extends \Jane\Component\OpenApi2\Tests\Expected\Runtime
      * {@inheritdoc}
      *
      *
-     * @return null|\Jane\Component\OpenApi2\Tests\Expected\Model\TestComplexListGetResponsedefault
+     * @return null|array|\Jane\Component\OpenApi2\Tests\Expected\Model\TestComplexListGetResponsedefault
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Client.php
@@ -16,7 +16,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
     /**
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function testRefArray(string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Endpoint/TestRefArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/response-reference/expected/Endpoint/TestRefArray.php
@@ -21,7 +21,7 @@ class TestRefArray extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Clien
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -11,6 +11,7 @@ use Jane\Component\OpenApi3\JsonSchema\Model\Schema;
 use Jane\Component\OpenApi3\JsonSchema\Normalizer\ResponseNormalizer;
 use Jane\Component\OpenApiCommon\Generator\ContentType;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
+use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
 use Jane\Component\OpenApiCommon\Registry\Registry;
 use PhpParser\Comment\Doc;
@@ -24,6 +25,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 trait GetTransformResponseBodyTrait
 {
+    use OpenApiNumberTypeResolverTrait;
+
     public function getTransformResponseBody(OperationGuess $operation, string $endpointName, GuessClass $guessClass, ExceptionGenerator $exceptionGenerator, Context $context): array
     {
         $outputStatements = [
@@ -314,6 +317,12 @@ EOD
             $serializeStmt = new Expr\FuncCall(new Name('json_decode'), [
                 new Node\Arg(new Expr\Variable('body')),
             ]);
+
+            $scalarReturnType = $this->convertResponseType($schema);
+
+            if (null !== $scalarReturnType) {
+                $returnType = $scalarReturnType;
+            }
         }
 
         $contentStatement = new Stmt\Return_($serializeStmt);
@@ -339,5 +348,30 @@ EOD
         }
 
         return [$returnType, $throwType, $contentStatement];
+    }
+
+    private function convertResponseType(Schema $schema): ?string
+    {
+        $type = $schema->getType();
+
+        if (null === $type && null !== $schema->getEnum() && \count($schema->getEnum()) > 0) {
+            $type = 'string';
+        }
+
+        return match ($type) {
+            'string' => 'string',
+            'number' => $this->isNumberFloat(
+                $schema->getFormat(),
+                $schema->getDefault(),
+                $schema->getMinimum(),
+                $schema->getMaximum(),
+                $schema->getMultipleOf(),
+                $schema->getEnum()
+            ) ? 'float' : 'int',
+            'boolean' => 'bool',
+            'integer' => 'int',
+            'array' => 'array',
+            default => null,
+        };
     }
 }

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Client.php
@@ -238,7 +238,7 @@ class Client extends \Github\Runtime\Client\Client
      * @throws \Github\Exception\ReposRemoveStatusCheckContextsNotFoundException
      * @throws \Github\Exception\ReposRemoveStatusCheckContextsUnprocessableEntityException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function reposRemoveStatusCheckContexts(string $owner, string $repo, string $branch, ?array $requestBody = null, string $fetch = self::FETCH_OBJECT)
     {
@@ -252,7 +252,7 @@ class Client extends \Github\Runtime\Client\Client
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      * @throws \Github\Exception\ReposGetAllStatusCheckContextsNotFoundException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function reposGetAllStatusCheckContexts(string $owner, string $repo, string $branch, string $fetch = self::FETCH_OBJECT)
     {
@@ -269,7 +269,7 @@ class Client extends \Github\Runtime\Client\Client
      * @throws \Github\Exception\ReposAddStatusCheckContextsForbiddenException
      * @throws \Github\Exception\ReposAddStatusCheckContextsNotFoundException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function reposAddStatusCheckContexts(string $owner, string $repo, string $branch, ?array $requestBody = null, string $fetch = self::FETCH_OBJECT)
     {
@@ -285,7 +285,7 @@ class Client extends \Github\Runtime\Client\Client
      * @throws \Github\Exception\ReposSetStatusCheckContextsUnprocessableEntityException
      * @throws \Github\Exception\ReposSetStatusCheckContextsNotFoundException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function reposSetStatusCheckContexts(string $owner, string $repo, string $branch, ?array $requestBody = null, string $fetch = self::FETCH_OBJECT)
     {
@@ -1576,7 +1576,7 @@ class Client extends \Github\Runtime\Client\Client
      * @param string $repo
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function reposGetPunchCardStats(string $owner, string $repo, string $fetch = self::FETCH_OBJECT)
     {
@@ -2376,7 +2376,7 @@ class Client extends \Github\Runtime\Client\Client
      * @param string $repo
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function reposGetCodeFrequencyStats(string $owner, string $repo, string $fetch = self::FETCH_OBJECT)
     {
@@ -5716,7 +5716,7 @@ class Client extends \Github\Runtime\Client\Client
      * @throws \Github\Exception\UsersListEmailsForAuthenticatedForbiddenException
      * @throws \Github\Exception\UsersListEmailsForAuthenticatedUnauthorizedException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function usersListEmailsForAuthenticated(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {
@@ -5731,7 +5731,7 @@ class Client extends \Github\Runtime\Client\Client
      * @throws \Github\Exception\UsersAddEmailForAuthenticatedForbiddenException
      * @throws \Github\Exception\UsersAddEmailForAuthenticatedUnauthorizedException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function usersAddEmailForAuthenticated($requestBody = null, string $fetch = self::FETCH_OBJECT)
     {
@@ -5834,7 +5834,7 @@ class Client extends \Github\Runtime\Client\Client
      * @throws \Github\Exception\UsersListPublicEmailsForAuthenticatedForbiddenException
      * @throws \Github\Exception\UsersListPublicEmailsForAuthenticatedUnauthorizedException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function usersListPublicEmailsForAuthenticated(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {
@@ -6020,7 +6020,7 @@ class Client extends \Github\Runtime\Client\Client
      * @throws \Github\Exception\UsersSetPrimaryEmailVisibilityForAuthenticatedUnauthorizedException
      * @throws \Github\Exception\UsersSetPrimaryEmailVisibilityForAuthenticatedUnprocessableEntityException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function usersSetPrimaryEmailVisibilityForAuthenticated(?\Github\Model\UserEmailVisibilityPatchBody $requestBody = null, string $fetch = self::FETCH_OBJECT)
     {
@@ -10712,7 +10712,7 @@ class Client extends \Github\Runtime\Client\Client
     /**
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function gitignoreGetAllTemplates(string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GitignoreGetAllTemplates.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/GitignoreGetAllTemplates.php
@@ -25,7 +25,7 @@ class GitignoreGetAllTemplates extends \Github\Runtime\Client\BaseEndpoint imple
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposAddStatusCheckContexts.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposAddStatusCheckContexts.php
@@ -48,7 +48,7 @@ class ReposAddStatusCheckContexts extends \Github\Runtime\Client\BaseEndpoint im
      * @throws \Github\Exception\ReposAddStatusCheckContextsForbiddenException
      * @throws \Github\Exception\ReposAddStatusCheckContextsNotFoundException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetAllStatusCheckContexts.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetAllStatusCheckContexts.php
@@ -41,7 +41,7 @@ class ReposGetAllStatusCheckContexts extends \Github\Runtime\Client\BaseEndpoint
      *
      * @throws \Github\Exception\ReposGetAllStatusCheckContextsNotFoundException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetCodeFrequencyStats.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetCodeFrequencyStats.php
@@ -37,7 +37,7 @@ class ReposGetCodeFrequencyStats extends \Github\Runtime\Client\BaseEndpoint imp
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetPunchCardStats.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposGetPunchCardStats.php
@@ -43,7 +43,7 @@ class ReposGetPunchCardStats extends \Github\Runtime\Client\BaseEndpoint impleme
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposRemoveStatusCheckContexts.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposRemoveStatusCheckContexts.php
@@ -47,7 +47,7 @@ class ReposRemoveStatusCheckContexts extends \Github\Runtime\Client\BaseEndpoint
      * @throws \Github\Exception\ReposRemoveStatusCheckContextsNotFoundException
      * @throws \Github\Exception\ReposRemoveStatusCheckContextsUnprocessableEntityException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposSetStatusCheckContexts.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/ReposSetStatusCheckContexts.php
@@ -47,7 +47,7 @@ class ReposSetStatusCheckContexts extends \Github\Runtime\Client\BaseEndpoint im
      * @throws \Github\Exception\ReposSetStatusCheckContextsUnprocessableEntityException
      * @throws \Github\Exception\ReposSetStatusCheckContextsNotFoundException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersAddEmailForAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersAddEmailForAuthenticated.php
@@ -40,7 +40,7 @@ class UsersAddEmailForAuthenticated extends \Github\Runtime\Client\BaseEndpoint 
      * @throws \Github\Exception\UsersAddEmailForAuthenticatedForbiddenException
      * @throws \Github\Exception\UsersAddEmailForAuthenticatedUnauthorizedException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListEmailsForAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListEmailsForAuthenticated.php
@@ -49,7 +49,7 @@ class UsersListEmailsForAuthenticated extends \Github\Runtime\Client\BaseEndpoin
      * @throws \Github\Exception\UsersListEmailsForAuthenticatedForbiddenException
      * @throws \Github\Exception\UsersListEmailsForAuthenticatedUnauthorizedException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListPublicEmailsForAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersListPublicEmailsForAuthenticated.php
@@ -49,7 +49,7 @@ class UsersListPublicEmailsForAuthenticated extends \Github\Runtime\Client\BaseE
      * @throws \Github\Exception\UsersListPublicEmailsForAuthenticatedForbiddenException
      * @throws \Github\Exception\UsersListPublicEmailsForAuthenticatedUnauthorizedException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersSetPrimaryEmailVisibilityForAuthenticated.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Endpoint/UsersSetPrimaryEmailVisibilityForAuthenticated.php
@@ -40,7 +40,7 @@ class UsersSetPrimaryEmailVisibilityForAuthenticated extends \Github\Runtime\Cli
      * @throws \Github\Exception\UsersSetPrimaryEmailVisibilityForAuthenticatedUnauthorizedException
      * @throws \Github\Exception\UsersSetPrimaryEmailVisibilityForAuthenticatedUnprocessableEntityException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Client.php
@@ -12,7 +12,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * } $queryParameters
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function getUsers(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Endpoint/GetUsers.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Endpoint/GetUsers.php
@@ -45,7 +45,7 @@ class GetUsers extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Ba
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Client.php
@@ -594,7 +594,7 @@ class Client extends \CreditSafe\API\Runtime\Client\Client
      * @throws \CreditSafe\API\Exception\ListCountriesOfMonitoredCompaniesForbiddenException
      * @throws \CreditSafe\API\Exception\ListCountriesOfMonitoredCompaniesNotFoundException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function listCountriesOfMonitoredCompanies(string $portfolioId, array $headerParameters = [], string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListCountriesOfMonitoredCompanies.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Endpoint/ListCountriesOfMonitoredCompanies.php
@@ -51,7 +51,7 @@ class ListCountriesOfMonitoredCompanies extends \CreditSafe\API\Runtime\Client\B
      * @throws \CreditSafe\API\Exception\ListCountriesOfMonitoredCompaniesForbiddenException
      * @throws \CreditSafe\API\Exception\ListCountriesOfMonitoredCompaniesNotFoundException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Client.php
@@ -464,7 +464,7 @@ class Client extends \PicturePark\API\Runtime\Client\Client
      * @throws \PicturePark\API\Exception\ContentPermissionSetGetPermissionsTooManyRequestsException
      * @throws \PicturePark\API\Exception\ContentPermissionSetGetPermissionsInternalServerErrorException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function contentPermissionSetGetPermissions(string $id, string $fetch = self::FETCH_OBJECT)
     {
@@ -1410,7 +1410,7 @@ class Client extends \PicturePark\API\Runtime\Client\Client
      * @throws \PicturePark\API\Exception\IdentityProviderGetSynchronizableAttributesTooManyRequestsException
      * @throws \PicturePark\API\Exception\IdentityProviderGetSynchronizableAttributesInternalServerErrorException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function identityProviderGetSynchronizableAttributes(string $fetch = self::FETCH_OBJECT)
     {
@@ -2341,7 +2341,7 @@ class Client extends \PicturePark\API\Runtime\Client\Client
      * @throws \PicturePark\API\Exception\SchemaPermissionSetGetPermissionsTooManyRequestsException
      * @throws \PicturePark\API\Exception\SchemaPermissionSetGetPermissionsInternalServerErrorException
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function schemaPermissionSetGetPermissions(string $id, string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentPermissionSetGetPermissions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/ContentPermissionSetGetPermissions.php
@@ -41,7 +41,7 @@ class ContentPermissionSetGetPermissions extends \PicturePark\API\Runtime\Client
      * @throws \PicturePark\API\Exception\ContentPermissionSetGetPermissionsTooManyRequestsException
      * @throws \PicturePark\API\Exception\ContentPermissionSetGetPermissionsInternalServerErrorException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/IdentityProviderGetSynchronizableAttributes.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/IdentityProviderGetSynchronizableAttributes.php
@@ -32,7 +32,7 @@ class IdentityProviderGetSynchronizableAttributes extends \PicturePark\API\Runti
      * @throws \PicturePark\API\Exception\IdentityProviderGetSynchronizableAttributesTooManyRequestsException
      * @throws \PicturePark\API\Exception\IdentityProviderGetSynchronizableAttributesInternalServerErrorException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaPermissionSetGetPermissions.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Endpoint/SchemaPermissionSetGetPermissions.php
@@ -41,7 +41,7 @@ class SchemaPermissionSetGetPermissions extends \PicturePark\API\Runtime\Client\
      * @throws \PicturePark\API\Exception\SchemaPermissionSetGetPermissionsTooManyRequestsException
      * @throws \PicturePark\API\Exception\SchemaPermissionSetGetPermissionsInternalServerErrorException
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Client.php
@@ -8,7 +8,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * @param null|\Jane\Component\OpenApi3\Tests\Expected\Model\FilePostBody $requestBody
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function postFile(?\Jane\Component\OpenApi3\Tests\Expected\Model\FilePostBody $requestBody = null, string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Endpoint/PostFile.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-737/expected/Endpoint/PostFile.php
@@ -45,7 +45,7 @@ class PostFile extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Ba
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Client.php
@@ -9,7 +9,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * @param array $accept Accept content header *\/*|application/json
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function mimeTypeGeneratedValidDocBlock(string $requestBody, string $fetch = self::FETCH_OBJECT, array $accept = [])
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Endpoint/MimeTypeGeneratedValidDocBlock.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-810/expected/Endpoint/MimeTypeGeneratedValidDocBlock.php
@@ -41,7 +41,7 @@ class MimeTypeGeneratedValidDocBlock extends \Jane\Component\OpenApi3\Tests\Expe
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Client.php
@@ -8,7 +8,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\ExpectedMultiPartBoolean\Run
      * @param null|\Jane\Component\OpenApi3\Tests\ExpectedMultiPartBoolean\Model\FileDepositPostBody $requestBody
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function postFileDeposit(?\Jane\Component\OpenApi3\Tests\ExpectedMultiPartBoolean\Model\FileDepositPostBody $requestBody = null, string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Endpoint/PostFileDeposit.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-boolean/expected/Endpoint/PostFileDeposit.php
@@ -45,7 +45,7 @@ class PostFileDeposit extends \Jane\Component\OpenApi3\Tests\ExpectedMultiPartBo
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Client.php
@@ -8,7 +8,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * @param null|\Jane\Component\OpenApi3\Tests\Expected\Model\FilePostBody $requestBody
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function postFile(?\Jane\Component\OpenApi3\Tests\Expected\Model\FilePostBody $requestBody = null, string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Endpoint/PostFile.php
+++ b/src/Component/OpenApi3/Tests/fixtures/multipart-nested-object/expected/Endpoint/PostFile.php
@@ -45,7 +45,7 @@ class PostFile extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Ba
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Client.php
@@ -16,7 +16,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     /**
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
      */
     public function testRefArray(string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Endpoint/TestRefArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference/expected/Endpoint/TestRefArray.php
@@ -25,7 +25,7 @@ class TestRefArray extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Clien
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|array
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Client.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|int : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getInteger(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetInteger(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getString(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetString(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|bool : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getBoolean(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetBoolean(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|float : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getNumberFloat(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetNumberFloat(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|int : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getNumberPlain(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetNumberPlain(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getEnumWithoutType(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetEnumWithoutType(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|array : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getArrayOfIntegers(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetArrayOfIntegers(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|int : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getNullableInteger(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetNullableInteger(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetArrayOfIntegers.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetArrayOfIntegers.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetArrayOfIntegers extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/array-of-integers';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|array
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return json_decode($body);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetBoolean.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetBoolean.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetBoolean extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/boolean';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|bool
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return json_decode($body);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetEnumWithoutType.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetEnumWithoutType.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetEnumWithoutType extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/enum-without-type';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|string
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return json_decode($body);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetInteger.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetInteger.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetInteger extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/integer';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|int
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return json_decode($body);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetNullableInteger.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetNullableInteger.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetNullableInteger extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/nullable-integer';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|int
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return json_decode($body);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetNumberFloat.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetNumberFloat.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetNumberFloat extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/number-float';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|float
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return json_decode($body);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetNumberPlain.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetNumberPlain.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetNumberPlain extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/number-plain';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|int
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return json_decode($body);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetString.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Endpoint/GetString.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetString extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/string';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|string
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return json_decode($body);
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [
+            
+            \Jane\Component\JsonSchemaRuntime\Reference::class => false,
+        ];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $optionsResolved = array_map(static function ($value) {
+            return $value ?? '';
+        }, $optionsResolved);
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            $allowReservedKey = in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $this->getHeadersOptionsResolver()->resolve($this->headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/scalar-response/openapi.json
+++ b/src/Component/OpenApi3/Tests/fixtures/scalar-response/openapi.json
@@ -1,0 +1,153 @@
+{
+    "openapi": "3.0.4",
+    "info": {
+        "title": "Scalar response types",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/integer": {
+            "get": {
+                "operationId": "getInteger",
+                "responses": {
+                    "200": {
+                        "description": "An integer value",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/string": {
+            "get": {
+                "operationId": "getString",
+                "responses": {
+                    "200": {
+                        "description": "A string value",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/boolean": {
+            "get": {
+                "operationId": "getBoolean",
+                "responses": {
+                    "200": {
+                        "description": "A boolean value",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/number-float": {
+            "get": {
+                "operationId": "getNumberFloat",
+                "responses": {
+                    "200": {
+                        "description": "A float value",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "number",
+                                    "format": "float"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/number-plain": {
+            "get": {
+                "operationId": "getNumberPlain",
+                "responses": {
+                    "200": {
+                        "description": "A number value without format",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/enum-without-type": {
+            "get": {
+                "operationId": "getEnumWithoutType",
+                "responses": {
+                    "200": {
+                        "description": "An enum value without explicit type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "enum": [
+                                        "foo",
+                                        "bar"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/array-of-integers": {
+            "get": {
+                "operationId": "getArrayOfIntegers",
+                "responses": {
+                    "200": {
+                        "description": "An array of integers",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "integer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/nullable-integer": {
+            "get": {
+                "operationId": "getNullableInteger",
+                "responses": {
+                    "200": {
+                        "description": "A nullable integer value",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "integer",
+                                    "nullable": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Client.php
@@ -155,7 +155,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     /**
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
-     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     * @return ($fetch is 'object' ? null|string : \Psr\Http\Message\ResponseInterface)
      */
     public function getOpenApiSpec(string $fetch = self::FETCH_OBJECT)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/GetOpenApiSpec.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Endpoint/GetOpenApiSpec.php
@@ -25,7 +25,7 @@ class GetOpenApiSpec extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Cli
      * {@inheritdoc}
      *
      *
-     * @return null
+     * @return null|string
      */
     protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
     {

--- a/src/Component/OpenApi31/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi31/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -11,6 +11,7 @@ use Jane\Component\OpenApi31\JsonSchema\Model\Response;
 use Jane\Component\OpenApi31\JsonSchema\Normalizer\ResponseNormalizer;
 use Jane\Component\OpenApiCommon\Generator\ContentType;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
+use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
 use Jane\Component\OpenApiCommon\Registry\Registry;
 use PhpParser\Comment\Doc;
@@ -24,6 +25,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 trait GetTransformResponseBodyTrait
 {
+    use OpenApiNumberTypeResolverTrait;
+
     public function getTransformResponseBody(OperationGuess $operation, string $endpointName, GuessClass $guessClass, ExceptionGenerator $exceptionGenerator, Context $context): array
     {
         $outputStatements = [
@@ -312,6 +315,12 @@ EOD
             $serializeStmt = new Expr\FuncCall(new Name('json_decode'), [
                 new Node\Arg(new Expr\Variable('body')),
             ]);
+
+            $scalarReturnType = $this->convertResponseType($schema);
+
+            if (null !== $scalarReturnType) {
+                $returnType = $scalarReturnType;
+            }
         }
 
         $contentStatement = new Stmt\Return_($serializeStmt);
@@ -337,5 +346,34 @@ EOD
         }
 
         return [$returnType, $throwType, $contentStatement];
+    }
+
+    private function convertResponseType(JsonSchema $schema): ?string
+    {
+        $type = $schema->getType();
+        if (\is_array($type)) {
+            $type = array_filter($type, fn ($t) => $t !== 'null');
+            $type = reset($type) ?: null;
+        }
+
+        if (null === $type && null !== $schema->getEnum() && \count($schema->getEnum()) > 0) {
+            $type = 'string';
+        }
+
+        return match ($type) {
+            'string' => 'string',
+            'number' => $this->isNumberFloat(
+                $schema->getFormat(),
+                $schema->getDefault(),
+                $schema->getMinimum(),
+                $schema->getMaximum(),
+                $schema->getMultipleOf(),
+                $schema->getEnum()
+            ) ? 'float' : 'int',
+            'boolean' => 'bool',
+            'integer' => 'int',
+            'array' => 'array',
+            default => null,
+        };
     }
 }


### PR DESCRIPTION
## Description

Fixes #800: endpoints whose response body schema is a scalar now generate a PHPDoc return type that matches what `json_decode()` actually returns. Previously such endpoints were documented as `@return null` only, so any tool promoting PHPDoc types to native return types (Rector, php-cs-fixer) generated code that failed at runtime with a TypeError whenever the API returned a scalar body.

## Changes

- Add a private `convertResponseType()` helper to the three `GetTransformResponseBodyTrait` implementations (OpenApi2, OpenApi3, OpenApi31) and set `$returnType` from it inside the `json_decode($body)` fallback branch of `createContentDenormalizationStatement()`
- Map OpenAPI types following the existing parameter-generator convention: `string` → `string`, `boolean` → `bool`, `integer` → `int`, `array` → `array`, enum without type → `string`; compose `OpenApiNumberTypeResolverTrait` so `number` resolves to `float` or `int` based on format/default/min/max/multipleOf/enum
- OpenApi31 additionally normalizes JSON-Schema style `type` arrays (ignores `null` entries, uses the first remaining type)
- Schemas that cannot be mapped (free-form objects, `oneOf` references, unknown types) keep the previous `null` behavior, as do error-status exception paths
- New `scalar-response` fixture under `src/Component/OpenApi3/Tests/fixtures/` covering integer, string, boolean, number with/without format, enum without type, array of integers and nullable integer responses
- Regenerated `expected/` fixtures impacted by the new docblocks: 10 OpenApi3 fixtures and 4 OpenApi2 fixtures; OpenApi3 `Client.php` conditional return docs updated accordingly (e.g. `@return ($fetch is 'object' ? null|string : ...)`)

## How to test

1. `vendor/bin/phpunit --filter testResources src/Component/OpenApi3/Tests/JaneOpenApiResourceTest.php`
2. `vendor/bin/phpunit --filter testResources src/Component/OpenApi31/Tests/JaneOpenApiResourceTest.php`
3. `vendor/bin/phpunit --filter testResources src/Component/OpenApi2/Tests/JaneOpenApiResourceTest.php`
4. `castor qa:phpstan`
5. `castor qa:cs:check`

## Notes

- `type: number` without float hints maps to `int`, deliberately mirroring the existing parameter converters (`NonBodyParameterGenerator::convertParameterType()`).
- Free-form objects and `oneOf` response schemas intentionally stay undocumented (`null`): `json_decode()` returns `\stdClass` there, which is out of scope for this fix.
- OpenApi31 expected fixtures required no changes: its only non-model response (`scalar-galaxy`) uses a `oneOf` reference, which stays unmapped.
