### PR TITLE
feat(open-api-common)!: apply spec server plugins to custom HTTP clients (#789)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [JsonSchema] [GH#865](https://github.com/janephp/janephp/issues/865) New `enums-as-objects` option to generate native PHP backed enums for schemas with an `enum` keyword (`string` / `integer` types)
 - [OpenApi3] [GH#771](https://github.com/janephp/janephp/issues/771) Report clean generation errors for non-body parameters using an unsupported `schema.type` (or no `type`/`enum`) instead of crashing
 
+### Changed
+- **BC-breaking** [OpenApi] [GH#789](https://github.com/janephp/janephp/issues/789) The host / base path plugins built from the specification (`AddHostPlugin`, `AddPathPlugin`) are now also applied around a caller-provided PSR-18 client in the generated `Client::create()`: your client may now be wrapped in a `PluginClient` carrying the specification's server URL, so server URLs containing a path (e.g. `https://server.localhost/api/v3`) work with custom clients. Generated clients whose specification declares a server URL accept a fourth `bool $applyServerPlugins = true` argument to opt out and keep using your client as-is.
+
 ### Fixed
 - [OpenApi] [GH#763](https://github.com/janephp/janephp/issues/763) Generate models referenced by the `default` response when using `whitelisted-paths` (the default response is not part of the iterated status codes, so its models were filtered out)
 - [JsonSchema] [GH#585](https://github.com/janephp/janephp/issues/585) Reference normalizers of models from other mapped schemas (transitively) used by a schema's models in its generated `JaneObjectNormalizer`, so multi-namespace mappings no longer fail at runtime with "no supporting normalizer found"

--- a/docs/openapi/component.md
+++ b/docs/openapi/component.md
@@ -358,6 +358,18 @@ preprod and production environment.
 Jane OpenAPI will always try to use `https` if present in the scheme (or if there is no scheme). It will use the first scheme
 present if `https` is not present.
 
+Those plugins are also applied when you provide your own PSR-18 client to the static `create` method. If you do not want
+the host and/or base path of the specification to be applied around your client (for example because it is already fully
+configured with the correct base URL, or you manage the URL yourself through your own plugins), pass `false` as fourth
+argument:
+
+```php
+$apiClient = Vendor\Library\Generated\Client::create($myPsr18Client, [], [], false);
+```
+
+The parameter only exists on generated clients whose specification declares a server URL (OpenAPI 3 `servers`, OpenAPI 2
+`host` / `basePath`).
+
 ### Having custom plugins
 
 If you want to support more behavior such as authentication or other stuff that need a plugin, you can pass them

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-header/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Endpoint\GetFoo(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://www.foo-host.com/base-path');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/authentication-apiKey-query/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Endpoint\GetFoo(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://www.foo-host.com/base-path');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/from-url/expected/Client.php
@@ -35,19 +35,21 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Endpoint\ShowPetById($petId), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('http://petstore.swagger.io/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi2/Tests/fixtures/host/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/host/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Endpoint\TestHost(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://www.foo-host.com/base-path');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Client.php
@@ -18749,19 +18749,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\UpdateSystemIpsec($body, $queryParameters), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://10.0.0.10:8443/wsg/api/public/v11_1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
@@ -43,19 +43,21 @@ class Client extends \Jane\OpenApi2\Tests\Expected\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \Jane\OpenApi2\Tests\Expected\Endpoint\ListProjects($queryParameters), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.harvestapp.com/v2');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/whitelisted-paths/expected/Client.php
@@ -54,19 +54,21 @@ class Client extends \Jane\OpenApi2\Tests\Expected\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \Jane\OpenApi2\Tests\Expected\Endpoint\CreateProject($payload), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.harvestapp.com/v2');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/CustomClientServerPathRuntimeTest.php
+++ b/src/Component/OpenApi3/Tests/CustomClientServerPathRuntimeTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Http\Client\Common\Plugin\AddPathPlugin;
+use Http\Client\Common\PluginClient;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Jane\Component\OpenApiCommon\Console\Command\GenerateCommand;
+use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
+use Jane\Component\OpenApiCommon\Console\Loader\OpenApiMatcher;
+use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+/**
+ * Runtime test asserting that specification server plugins (host + path) are
+ * applied around a caller provided PSR-18 client, and can be opted out from.
+ *
+ * A dedicated client is generated from the issue-299 specification into an
+ * isolated namespace, as generated clients usually share their namespace
+ * across fixtures which would cause class redeclaration conflicts.
+ *
+ * @see https://github.com/janephp/janephp/issues/789
+ */
+class CustomClientServerPathRuntimeTest extends TestCase
+{
+    private const FIXTURE_DIR = __DIR__ . '/fixtures/issue-299';
+    private const NAMESPACE_PREFIX = 'Jane\Component\OpenApi3\Tests\Issue789CustomClient';
+    private static bool $classesLoaded = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::loadGeneratedClasses();
+    }
+
+    public function testCustomHttpClientReceivesSpecServerUrl(): void
+    {
+        $capturingClient = $this->createCapturingClient();
+        $client = self::createClient($capturingClient);
+
+        // @phpstan-ignore-next-line Classes are generated at runtime from the issue-299 specification.
+        $client->executeRawEndpoint(new Issue789CustomClient\Endpoint\GetUsers(['userState' => 'x']));
+
+        self::assertNotNull($capturingClient->lastRequest);
+        self::assertSame(
+            'https://example.com/rest/v1/users?userState=x',
+            (string) $capturingClient->lastRequest->getUri()
+        );
+    }
+
+    public function testCustomHttpClientCanOptOutFromServerPlugins(): void
+    {
+        $capturingClient = $this->createCapturingClient();
+        $client = self::createClient($capturingClient, [], [], false);
+
+        // @phpstan-ignore-next-line Classes are generated at runtime from the issue-299 specification.
+        $client->executeRawEndpoint(new Issue789CustomClient\Endpoint\GetUsers(['userState' => 'x']));
+
+        self::assertNotNull($capturingClient->lastRequest);
+        self::assertSame('/users?userState=x', (string) $capturingClient->lastRequest->getUri());
+    }
+
+    public function testCallerOwnedPathPrefixIsNotDuplicated(): void
+    {
+        $capturingClient = $this->createCapturingClient();
+        $preWrappedClient = new PluginClient($capturingClient, [
+            new AddPathPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri('https://caller.example.com/rest/v1')),
+        ]);
+
+        $client = self::createClient($preWrappedClient);
+
+        // @phpstan-ignore-next-line Classes are generated at runtime from the issue-299 specification.
+        $client->executeRawEndpoint(new Issue789CustomClient\Endpoint\GetUsers(['userState' => 'x']));
+
+        self::assertNotNull($capturingClient->lastRequest);
+        self::assertSame(
+            'https://example.com/rest/v1/users?userState=x',
+            (string) $capturingClient->lastRequest->getUri()
+        );
+    }
+
+    // @phpstan-ignore-next-line Classes are generated at runtime from the issue-299 specification.
+    private static function createClient(?ClientInterface $httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true): Issue789CustomClient\Client
+    {
+        // @phpstan-ignore-next-line Classes are generated at runtime from the issue-299 specification.
+        return Issue789CustomClient\Client::create($httpClient, $additionalPlugins, $additionalNormalizers, $applyServerPlugins);
+    }
+
+    private static function loadGeneratedClasses(): void
+    {
+        if (self::$classesLoaded) {
+            return;
+        }
+
+        self::generateClient();
+
+        $dir = self::generatedDir();
+
+        require_once $dir . '/Runtime/Client/Endpoint.php';
+        require_once $dir . '/Runtime/Client/EndpointTrait.php';
+        require_once $dir . '/Runtime/Client/BaseEndpoint.php';
+        require_once $dir . '/Runtime/Normalizer/CheckArray.php';
+        require_once $dir . '/Runtime/Normalizer/ValidatorTrait.php';
+        require_once $dir . '/Runtime/Normalizer/ReferenceNormalizer.php';
+        require_once $dir . '/Normalizer/JaneObjectNormalizer.php';
+        require_once $dir . '/Runtime/Client/Client.php';
+        require_once $dir . '/Endpoint/GetUsers.php';
+        require_once $dir . '/Client.php';
+
+        self::$classesLoaded = true;
+    }
+
+    private static function generateClient(): void
+    {
+        $dir = self::generatedDir();
+        $specFile = $dir . '/swagger-copy.yaml';
+
+        self::removeDirectory($dir);
+        @mkdir($dir, 0777, true);
+        copy(self::FIXTURE_DIR . '/swagger.yaml', $specFile);
+        file_put_contents($dir . '/.jane-openapi', \sprintf(
+            '<?php return [%s];',
+            implode(', ', [
+                "'openapi-file' => " . var_export($specFile, true),
+                "'namespace' => " . var_export(self::NAMESPACE_PREFIX, true),
+                "'directory' => " . var_export($dir, true),
+            ])
+        ));
+
+        $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+        $input = new ArrayInput(['--config-file' => $dir . '/.jane-openapi'], $command->getDefinition());
+        $command->execute($input, new NullOutput());
+    }
+
+    private static function generatedDir(): string
+    {
+        return sys_get_temp_dir() . '/janephp-issue-789-runtime-test';
+    }
+
+    private static function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            $item->isDir() ? @rmdir($item->getPathname()) : @unlink($item->getPathname());
+        }
+
+        @rmdir($dir);
+    }
+
+    private function createCapturingClient(): CapturingHttpClient
+    {
+        return new CapturingHttpClient();
+    }
+}
+
+final class CapturingHttpClient implements ClientInterface
+{
+    public ?RequestInterface $lastRequest = null;
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $this->lastRequest = $request;
+
+        return Psr17FactoryDiscovery::findResponseFactory()->createResponse(200);
+    }
+}

--- a/src/Component/OpenApi3/Tests/JaneOpenApiResourceTest.php
+++ b/src/Component/OpenApi3/Tests/JaneOpenApiResourceTest.php
@@ -15,6 +15,7 @@ use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
 use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -35,8 +36,10 @@ class JaneOpenApiResourceTest extends TestCase
         // 1. Generate
         $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
         $input = new ArrayInput(['--config-file' => $testDirectory->getRealPath() . \DIRECTORY_SEPARATOR . '.jane-openapi'], $command->getDefinition());
-        $command->execute($input, new NullOutput());
+        $output = new BufferedOutput();
+        $exitCode = $command->execute($input, $output);
 
+        $this->assertSame(0, $exitCode, \sprintf('Generation failed for data set "%s": %s', $name, $output->fetch()));
         $this->fixCodeStyle($testDirectory->getRealPath() . \DIRECTORY_SEPARATOR . 'expected');
         $this->fixCodeStyle($testDirectory->getRealPath() . \DIRECTORY_SEPARATOR . 'generated');
 

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-header/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetFoo(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://www.foo-host.com/base-path');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-apiKey-query/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetFoo(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://www.foo-host.com/base-path');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-basic/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetFoo(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://www.foo-host.com/base-path');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-http-bearer/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetFoo(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://www.foo-host.com/base-path');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/authentication-multiple-security-layers/expected/Client.php
@@ -31,19 +31,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetBaz(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('http://127.0.0.1/');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/from-url/expected/Client.php
@@ -36,19 +36,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\ShowPetById($petId), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('http://petstore.swagger.io/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Client.php
@@ -10718,18 +10718,20 @@ class Client extends \Github\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \Github\Endpoint\GitignoreGetAllTemplates(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.github.com');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Github\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port-and-base-path/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\TestHost(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('http://www.foo-host.com:8024/base-path');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host-with-port/expected/Client.php
@@ -13,18 +13,20 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\TestHost(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('http://www.foo-host.com:8024');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/host/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/host/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\TestHost(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://www.foo-host.com/base-path');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-299/expected/Client.php
@@ -18,19 +18,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetUsers($queryParameters), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://example.com/rest/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Client.php
@@ -1195,19 +1195,21 @@ class Client extends \CreditSafe\API\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \CreditSafe\API\Endpoint\CustomReportParameters($country, $queryParameters, $headerParameters), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://connect.creditsafe.com/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \CreditSafe\API\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Client.php
@@ -10321,18 +10321,20 @@ class Client extends \Jane\Generated\DigitalOcean\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \Jane\Generated\DigitalOcean\Endpoint\GenaiListEvaluationTestCasesByWorkspace($workspaceUuid), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.digitalocean.com');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Generated\DigitalOcean\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-803/expected/Client.php
@@ -21,19 +21,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetFiles($queryParameters, $headerParameters), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://example.com/rest/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/referenced-request-bodies/expected/Client.php
@@ -27,19 +27,21 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\PatchParentsByParentIdChildChildId($parentId, $childId, $requestBody), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://acme.localhost/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/twitter/expected/Client.php
@@ -161,18 +161,20 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetOpenApiSpec(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.twitter.com');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-array-notation/expected/Client.php
@@ -38,18 +38,20 @@ class Client extends \Jane\OpenApi3\Tests\Expected\Runtime\Client\Client
     {
         return $this->executeEndpoint(new \Jane\OpenApi3\Tests\Expected\Endpoint\AddOrDeleteRules($requestBody, $queryParameters, $accept), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.twitter.com');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths/expected/Client.php
@@ -38,18 +38,20 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\AddOrDeleteRules($requestBody, $queryParameters, $accept), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.twitter.com');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/array-items-validation/expected/Client.php
@@ -4,19 +4,21 @@ namespace Jane\Component\OpenApi31\Tests\Expected;
 
 class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Client
 {
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/custom-validators/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetPrice(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-869/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetMessage(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-939/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetProposal(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-940/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetProposal(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-963/expected/Client.php
@@ -15,19 +15,21 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetMemberBySelector($selector, $accept), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://server/ipnoos/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-966/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetOrder(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/issue-968/expected/Client.php
@@ -13,19 +13,21 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetReport(), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Client.php
@@ -126,19 +126,21 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetTicketCode($ticketId, $accept), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://redocly.com/_mock/docs/openapi/museum-api');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Client.php
@@ -147,18 +147,20 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetMe($accept), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://galaxy.scalar.com');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/simple/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/simple/expected/Client.php
@@ -36,19 +36,21 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\ShowPetById($petId), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Client.php
@@ -145,19 +145,21 @@ class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Cli
     {
         return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\CreateBookingPayment($bookingId, $requestBody, $accept), $fetch);
     }
-    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
     {
+        $plugins = [];
         if (null === $httpClient) {
             $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
-            $plugins = [];
+        }
+        if ($applyServerPlugins) {
             $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://try.microcks.io/rest/Train+Travel+API/1.0.0');
             $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
             $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
-            if (count($additionalPlugins) > 0) {
-                $plugins = array_merge($plugins, $additionalPlugins);
-            }
-            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
         $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];

--- a/src/Component/OpenApiCommon/Generator/Client/ClientGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/Client/ClientGenerator.php
@@ -44,17 +44,20 @@ trait ClientGenerator
             new Node\Param(new Expr\Variable('additionalNormalizers'), new Expr\Array_(), new Node\Identifier('array')),
         ];
 
+        if ($this->needsServerPlugins($context->getCurrentSchema()->getParsed())) {
+            $params[] = new Node\Param(
+                new Expr\Variable('applyServerPlugins'),
+                new Expr\ConstFetch(new Name('true')),
+                new Node\Identifier('bool')
+            );
+        }
+
         return new Stmt\ClassMethod(
             'create', [
                 'flags' => Modifiers::STATIC | Modifiers::PUBLIC,
                 'params' => $params,
                 'stmts' => [
-                    new Stmt\If_(
-                        new Expr\BinaryOp\Identical(new Expr\ConstFetch(new Name('null')), new Expr\Variable('httpClient')),
-                        [
-                            'stmts' => $this->getHttpClientCreateExpr($context),
-                        ]
-                    ),
+                    ...$this->getHttpClientCreateExpr($context),
                     new Stmt\Expression(new Expr\Assign(
                         new Expr\Variable('requestFactory'),
                         new Expr\StaticCall(

--- a/src/Component/OpenApiCommon/Generator/Client/HttpClientCreateGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/Client/HttpClientCreateGenerator.php
@@ -19,28 +19,72 @@ trait HttpClientCreateGenerator
     {
         /** @var OpenApi $openApi */
         $openApi = $context->getCurrentSchema()->getParsed();
-        $statements = [
-            new Stmt\Expression(new Expr\Assign(
-                new Expr\Variable('httpClient'),
-                new Expr\StaticCall(
-                    new Name\FullyQualified(Psr18ClientDiscovery::class),
-                    'find'
-                )
-            )),
-        ];
 
-        $needsServerPlugins = $this->needsServerPlugins($openApi);
-
-        $statements[] = new Stmt\Expression(new Expr\Assign(
-            new Expr\Variable('plugins'),
-            new Expr\Array_()
-        ));
-
-        if ($needsServerPlugins) {
-            $statements = array_merge($statements, $this->getServerPluginsStatements($openApi));
+        if (!$this->needsServerPlugins($openApi)) {
+            return [
+                new Stmt\If_(
+                    $this->createHttpClientNullCheck(),
+                    [
+                        'stmts' => [
+                            $this->createHttpClientDiscoveryStmt(),
+                            new Stmt\Expression(new Expr\Assign(
+                                new Expr\Variable('plugins'),
+                                new Expr\Array_()
+                            )),
+                            $this->createAdditionalPluginsMergeStmt(),
+                            $this->createPluginClientAssignStmt(),
+                        ],
+                    ]
+                ),
+            ];
         }
 
-        $statements[] = new Stmt\If_(
+        return [
+            new Stmt\Expression(new Expr\Assign(
+                new Expr\Variable('plugins'),
+                new Expr\Array_()
+            )),
+            new Stmt\If_(
+                $this->createHttpClientNullCheck(),
+                [
+                    'stmts' => [
+                        $this->createHttpClientDiscoveryStmt(),
+                    ],
+                ]
+            ),
+            new Stmt\If_(
+                new Expr\Variable('applyServerPlugins'),
+                [
+                    'stmts' => $this->getServerPluginsStatements($openApi),
+                ]
+            ),
+            $this->createAdditionalPluginsMergeStmt(),
+            $this->createPluginClientAssignStmt(),
+        ];
+    }
+
+    private function createHttpClientNullCheck(): Expr
+    {
+        return new Expr\BinaryOp\Identical(
+            new Expr\ConstFetch(new Name('null')),
+            new Expr\Variable('httpClient')
+        );
+    }
+
+    private function createHttpClientDiscoveryStmt(): Stmt\Expression
+    {
+        return new Stmt\Expression(new Expr\Assign(
+            new Expr\Variable('httpClient'),
+            new Expr\StaticCall(
+                new Name\FullyQualified(Psr18ClientDiscovery::class),
+                'find'
+            )
+        ));
+    }
+
+    private function createAdditionalPluginsMergeStmt(): Stmt\If_
+    {
+        return new Stmt\If_(
             new Expr\BinaryOp\Greater(
                 new Expr\FuncCall(new Name('count'), [new Node\Arg(new Expr\Variable('additionalPlugins'))]),
                 new Expr\ConstFetch(new Name('0'))
@@ -57,8 +101,11 @@ trait HttpClientCreateGenerator
                 ],
             ]
         );
+    }
 
-        $statements[] = new Stmt\Expression(new Expr\Assign(
+    private function createPluginClientAssignStmt(): Stmt\Expression
+    {
+        return new Stmt\Expression(new Expr\Assign(
             new Expr\Variable('httpClient'),
             new Expr\New_(
                 new Name\FullyQualified(PluginClient::class),
@@ -68,7 +115,5 @@ trait HttpClientCreateGenerator
                 ]
             )
         ));
-
-        return $statements;
     }
 }


### PR DESCRIPTION
## Description

Fixes the documented failure mode from #789: when a caller provides their own PSR-18 client to a generated `Client::create()`, the specification-derived `AddHostPlugin` / `AddPathPlugin` stack was skipped entirely, so server URLs containing a path (e.g. `https://server.localhost/api/v3`) never worked in custom-client mode.

The plugin statements emitted by `HttpClientCreateGenerator` are now wrapped in a runtime `if ($applyServerPlugins)` check instead of being nested inside the `if (null === $httpClient)` discovery block, and the resulting `PluginClient` wrap is applied around whatever client ends up in play — discovered or caller-provided.

This is a behavior change, not a pure bugfix: existing users passing fully configured clients will now get the specification's host/path applied around them.

## Changes

- Refactor `getHttpClientCreateExpr()` in `src/Component/OpenApiCommon/Generator/Client/HttpClientCreateGenerator.php`: `$plugins = []` moves outside the null-check, server-plugin statements go under a runtime `if ($applyServerPlugins)`, and the `PluginClient` wrap becomes unconditional for specs with servers. Specs without servers keep today's exact generated shape.
- Add an optional fourth parameter `bool $applyServerPlugins = true` to the generated `create()` in `ClientGenerator::getFactoryMethod()`; it is only generated for clients whose specification declares a server URL (OpenAPI 3 `servers`, OpenAPI 2 `host`/`basePath`), so non-server clients stay untouched.
- Regenerate expected fixtures: 35 `expected/Client.php` files across OpenApi2/OpenApi3/OpenApi31 (only server-declaring fixtures changed).
- Add runtime regression test `CustomClientServerPathRuntimeTest` (OpenApi3): custom client receives the spec base URL, opt-out keeps relative URIs, and a caller-owned `AddPathPlugin` is not duplicated thanks to the stock prefix-dedup guard.
- Document the new behavior and opt-out in `docs/openapi/component.md` ("Host and basePath support") and add a BC-breaking entry to `CHANGELOG.md`.

No dependency (`composer.json`), config or migration changes.

## How to test

1. `composer install`
2. `vendor/bin/phpunit src/Component/OpenApi3/Tests/CustomClientServerPathRuntimeTest.php` — exercises the three behaviors above against a capturing PSR-18 stub
3. `vendor/bin/phpunit` — full suite (372 tests), including fixture comparisons for all regenerated expected outputs
4. `castor qa:phpstan` and `castor qa:cs:check`

## Notes

- **BC-breaking**: callers passing their own PSR-18 client will now have it wrapped in a `PluginClient` carrying the spec's host/path plugins. Pass `applyServerPlugins: false` as fourth argument of `create()` to opt out.
- The opt-out parameter only exists on generated clients whose spec declares a server URL.
- Generated clients now come in two shapes (with/without the runtime gate) depending on whether the spec declares servers; kept intentionally to avoid churn on non-server fixtures.
- `AddPathPlugin`'s dedup only guards exact prefix repetition, not partial overlaps; the opt-out remains the sanctioned route for exotic stacks.
