### PR TITLE
docs: fix typo compatiblity -> compatibility

### DIFF
--- a/docs/contributing/breaking_changes.md
+++ b/docs/contributing/breaking_changes.md
@@ -1,6 +1,6 @@
 # Backwards compatibility
 
-Backwards compatiblity is an important topic. Those libraries follow Semver, so backwards compatibility will only
+Backwards compatibility is an important topic. Those libraries follow Semver, so backwards compatibility will only
 break between major versions. This library may use deprecations notices to inform you of the change, but it's a low
 probability, you should always check the [CHANGELOG](https://github.com/janephp/janephp/blob/main/CHANGELOG.md) when switching to a new major version.
 


### PR DESCRIPTION
One-word typo fix in `docs/contributing/breaking_changes.md:3`: "Backwards compatiblity is an important..." -> "compatibility".
