### PR TITLE
feat(open-api): generate BadResponseException for unmatched responses

### DIFF
--- a/docs/openapi/component.md
+++ b/docs/openapi/component.md
@@ -222,8 +222,10 @@ There are many ways to use it. You can either use the `__type` key to specify a 
  and throw it with the deserialized typed error model. When disabled, declared error responses are denormalized into
  their typed model and returned like any other response. Undeclared statuses remain governed by
  `throw-unexpected-status-code`. By default, it's enabled.
-- `throw-unexpected-status-code`: Will return a `UnexpectedStatusCodeException` if nothing has been matched during
- the transformation of the Endpoint body (including described exceptions). By default, it's disabled.
+- `throw-unexpected-status-code`: Will throw a `BadResponseException` if nothing has been matched during
+ the transformation of the Endpoint body (including described exceptions). This exception extends
+ `UnexpectedStatusCodeException` and exposes the original PSR-7 response through its `getResponse()` method.
+ By default, it's disabled.
 - `custom-string-format-mapping`: This option allows you to specify in which class a string property will be
  deserialized according to it's format option. It can be used to customize a date-time field, or to add non supported
 formats. More details in the dedicated section.

--- a/src/Component/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -72,7 +72,7 @@ trait GetTransformResponseBodyTrait
         if ($registry->getThrowUnexpectedStatusCode()) {
             $exceptionGenerator->createBaseExceptions($context);
 
-            $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\UnexpectedStatusCodeException';
+            $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\BadResponseException';
             $throwTypes[] = $throwType;
             $outputStatements = array_merge(
                 $outputStatements,
@@ -83,6 +83,7 @@ trait GetTransformResponseBodyTrait
                             [
                                 new Arg(new Expr\Variable('status')),
                                 new Arg(new Expr\Variable('body')),
+                                new Arg(new Expr\Variable('response')),
                             ]
                         )
                     )),

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-831/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/BadResponseException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/BadResponseException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Exception;
+
+class BadResponseException extends UnexpectedStatusCodeException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface|null
+     */
+    private $response;
+    public function __construct($status, $message = '', ?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct($status, $message);
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/throw-unexpected-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Exception;
 
-final class UnexpectedStatusCodeException extends \RuntimeException implements ClientException
+class UnexpectedStatusCodeException extends \RuntimeException implements ClientException
 {
     public function __construct($status, $message = '')
     {

--- a/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -125,7 +125,7 @@ trait GetTransformResponseBodyTrait
         if ($registry->getThrowUnexpectedStatusCode()) {
             $exceptionGenerator->createBaseExceptions($context);
 
-            $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\UnexpectedStatusCodeException';
+            $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\BadResponseException';
             $throwTypes[] = $throwType;
             $outputStatements = array_merge(
                 $outputStatements,
@@ -136,6 +136,7 @@ trait GetTransformResponseBodyTrait
                             [
                                 new Node\Arg(new Expr\Variable('status')),
                                 new Node\Arg(new Expr\Variable('body')),
+                                new Node\Arg(new Expr\Variable('response')),
                             ]
                         )
                     )),

--- a/src/Component/OpenApi3/Tests/BadResponseExceptionTest.php
+++ b/src/Component/OpenApi3/Tests/BadResponseExceptionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Jane\Component\OpenApi3\Tests\BadResponse\Endpoint\GetFoo;
+use Jane\Component\OpenApi3\Tests\BadResponse\Exception\BadResponseException;
+use Jane\Component\OpenApi3\Tests\BadResponse\Exception\UnexpectedStatusCodeException;
+use Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client\Client;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @see https://github.com/janephp/janephp/issues/815
+ */
+class BadResponseExceptionTest extends TestCase
+{
+    private const FIXTURE_DIR = __DIR__ . '/fixtures/bad-response-exception/expected';
+
+    protected function setUp(): void
+    {
+        foreach ([
+            'Runtime/Client/Client',
+            'Runtime/Client/Endpoint',
+            'Runtime/Client/EndpointTrait',
+            'Runtime/Client/BaseEndpoint',
+            'Exception/ApiException',
+            'Exception/ClientException',
+            'Exception/ServerException',
+            'Exception/UnexpectedStatusCodeException',
+            'Exception/BadResponseException',
+            'Endpoint/GetFoo',
+        ] as $file) {
+            require_once self::FIXTURE_DIR . '/' . $file . '.php';
+        }
+    }
+
+    public function testUndocumentedResponseThrowsBadResponseException(): void
+    {
+        $response = new Response(409, [], '{"message":"conflict"}');
+        $endpoint = new GetFoo();
+
+        try {
+            $endpoint->parseResponse($response, $this->createMock(SerializerInterface::class), Client::FETCH_OBJECT);
+            self::fail('No exception thrown for undocumented response.');
+        } catch (BadResponseException $e) {
+            self::assertSame(409, $e->getCode());
+            self::assertSame('{"message":"conflict"}', $e->getMessage());
+            self::assertSame($response, $e->getResponse());
+        }
+    }
+
+    public function testBadResponseExceptionIsACatchableUnexpectedStatusCodeException(): void
+    {
+        $response = new Response(503, [], 'unavailable');
+        $endpoint = new GetFoo();
+
+        try {
+            $endpoint->parseResponse($response, $this->createMock(SerializerInterface::class), Client::FETCH_OBJECT);
+            self::fail('No exception thrown for undocumented response.');
+        } catch (UnexpectedStatusCodeException $e) {
+            self::assertInstanceOf(BadResponseException::class, $e);
+            self::assertSame(503, $e->getCode());
+            self::assertSame('unavailable', $e->getMessage());
+        }
+    }
+
+    public function testDocumentedResponseStillReturnsNull(): void
+    {
+        $response = new Response(200, []);
+        $endpoint = new GetFoo();
+
+        self::assertNull($endpoint->parseResponse($response, $this->createMock(SerializerInterface::class), Client::FETCH_OBJECT));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Client.php
@@ -9,7 +9,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\PostFooBadRequestException
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\PostFooInternalServerErrorException
-     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\BadResponseException
      *
      * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
      */

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Endpoint/PostFoo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Endpoint/PostFoo.php
@@ -36,7 +36,7 @@ class PostFoo extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Bas
      *
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\PostFooBadRequestException
      * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\PostFooInternalServerErrorException
-     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\BadResponseException
      *
      * @return null
      */
@@ -53,7 +53,7 @@ class PostFoo extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Bas
         if (is_null($contentType) === false && (500 === $status && mb_strpos(strtolower($contentType), 'application/problem+json') !== false)) {
             throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\PostFooInternalServerErrorException($serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Expected\Model\ResponseProblemDetailsResponse500', 'json'), $response);
         }
-        throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException($status, $body);
+        throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\BadResponseException($status, $body, $response);
     }
     public function getAuthenticationScopes(): array
     {

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Exception/BadResponseException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Exception/BadResponseException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class BadResponseException extends UnexpectedStatusCodeException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface|null
+     */
+    private $response;
+    public function __construct($status, $message = '', ?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct($status, $message);
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/.jane-openapi
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\BadResponse',
+    'directory' => __DIR__ . '/generated',
+    'throw-unexpected-status-code' => true,
+];

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Client.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Jane\Component\OpenApi2\Tests\Expected;
+namespace Jane\Component\OpenApi3\Tests\BadResponse;
 
-class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Client
+class Client extends \Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client\Client
 {
     /**
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
-     * @throws \Jane\Component\OpenApi2\Tests\Expected\Exception\BadResponseException
+     * @throws \Jane\Component\OpenApi3\Tests\BadResponse\Exception\BadResponseException
      *
      * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
      */
-    public function testNoTag(string $fetch = self::FETCH_OBJECT)
+    public function getFoo(string $fetch = self::FETCH_OBJECT)
     {
-        return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Endpoint\TestNoTag(), $fetch);
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\BadResponse\Endpoint\GetFoo(), $fetch);
     }
     public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
     {
@@ -26,7 +26,7 @@ class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Clie
         }
         $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
         $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
-        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\BadResponse\Normalizer\JaneObjectNormalizer()];
         if (count($additionalNormalizers) > 0) {
             $normalizers = array_merge($normalizers, $additionalNormalizers);
         }

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Endpoint/GetFoo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Endpoint/GetFoo.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Jane\Component\OpenApi2\Tests\Expected\Endpoint;
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Endpoint;
 
-class TestNoTag extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Endpoint
+class GetFoo extends \Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client\Endpoint
 {
-    use \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\EndpointTrait;
+    use \Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client\EndpointTrait;
     public function getMethod(): string
     {
         return 'GET';
     }
     public function getUri(): string
     {
-        return '/test-exception';
+        return '/foo';
     }
     public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
     {
@@ -20,7 +20,7 @@ class TestNoTag extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\B
     /**
      * {@inheritdoc}
      *
-     * @throws \Jane\Component\OpenApi2\Tests\Expected\Exception\BadResponseException
+     * @throws \Jane\Component\OpenApi3\Tests\BadResponse\Exception\BadResponseException
      *
      * @return null
      */
@@ -31,7 +31,7 @@ class TestNoTag extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\B
         if (200 === $status) {
             return null;
         }
-        throw new \Jane\Component\OpenApi2\Tests\Expected\Exception\BadResponseException($status, $body, $response);
+        throw new \Jane\Component\OpenApi3\Tests\BadResponse\Exception\BadResponseException($status, $body, $response);
     }
     public function getAuthenticationScopes(): array
     {

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Exception/ApiException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Exception/BadResponseException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Exception/BadResponseException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Exception;
+
+class BadResponseException extends UnexpectedStatusCodeException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface|null
+     */
+    private $response;
+    public function __construct($status, $message = '', ?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct($status, $message);
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Exception/ClientException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Exception/ServerException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Exception/UnexpectedStatusCodeException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Exception;
 
 class UnexpectedStatusCodeException extends \RuntimeException implements ClientException
 {

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return array_combine(array_keys($this->normalizers), array_fill(0, count($this->normalizers), false));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/BaseEndpoint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client;
 
 use Http\Message\MultipartStream\MultipartStreamBuilder;
 use Psr\Http\Message\ResponseInterface;

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\BadResponse\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/openapi.json
+++ b/src/Component/OpenApi3/Tests/fixtures/bad-response-exception/openapi.json
@@ -1,0 +1,19 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Issue 815"
+    },
+    "paths": {
+        "/foo": {
+            "get": {
+                "operationId": "getFoo",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Client.php
@@ -7,7 +7,7 @@ class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Clie
     /**
      * @param null|\Jane\Component\OpenApi3\Tests\Expected\Model\FooPayload $requestBody
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
-     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\BadResponseException
      *
      * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
      */

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Endpoint/PostFoo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Endpoint/PostFoo.php
@@ -30,7 +30,7 @@ class PostFoo extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Bas
     /**
      * {@inheritdoc}
      *
-     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException
+     * @throws \Jane\Component\OpenApi3\Tests\Expected\Exception\BadResponseException
      *
      * @return null
      */
@@ -41,7 +41,7 @@ class PostFoo extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Bas
         if (200 === $status) {
             return null;
         }
-        throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\UnexpectedStatusCodeException($status, $body);
+        throw new \Jane\Component\OpenApi3\Tests\Expected\Exception\BadResponseException($status, $body, $response);
     }
     public function getAuthenticationScopes(): array
     {

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/BadResponseException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/BadResponseException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
+
+class BadResponseException extends UnexpectedStatusCodeException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface|null
+     */
+    private $response;
+    public function __construct($status, $message = '', ?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct($status, $message);
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/throw-unexcepted-status-code/expected/Exception/UnexpectedStatusCodeException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-final class UnexpectedStatusCodeException extends \RuntimeException implements ClientException
+class UnexpectedStatusCodeException extends \RuntimeException implements ClientException
 {
     public function __construct($status, $message = '')
     {

--- a/src/Component/OpenApi31/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi31/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -125,7 +125,7 @@ trait GetTransformResponseBodyTrait
         if ($registry->getThrowUnexpectedStatusCode()) {
             $exceptionGenerator->createBaseExceptions($context);
 
-            $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\UnexpectedStatusCodeException';
+            $throwType = '\\' . $context->getCurrentSchema()->getNamespace() . '\\Exception\\BadResponseException';
             $throwTypes[] = $throwType;
             $outputStatements = array_merge(
                 $outputStatements,
@@ -136,6 +136,7 @@ trait GetTransformResponseBodyTrait
                             [
                                 new Node\Arg(new Expr\Variable('status')),
                                 new Node\Arg(new Expr\Variable('body')),
+                                new Node\Arg(new Expr\Variable('response')),
                             ]
                         )
                     )),

--- a/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
@@ -293,7 +293,6 @@ EOD
                             new Name('ClientException'),
                         ],
                         'extends' => new Name('\\RuntimeException'),
-                        'flags' => Modifiers::FINAL,
                         'stmts' => [
                             new Stmt\ClassMethod('__construct', [
                                 'flags' => Modifiers::PUBLIC,
@@ -314,6 +313,63 @@ EOD
             ]);
 
             $schema->addFile(new File($schema->getDirectory() . '/Exception/UnexpectedStatusCodeException.php', $unexpectedStatusCodeException, 'Exception'));
+
+            $badResponseException = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Exception'), [
+                new Stmt\Class_(
+                    'BadResponseException',
+                    [
+                        'extends' => new Name('UnexpectedStatusCodeException'),
+                        'stmts' => [
+                            new Stmt\Property(Modifiers::PRIVATE, [
+                                new Stmt\PropertyProperty('response'),
+                            ], ['comments' => [new Doc(<<<EOD
+/**
+ * @var \Psr\Http\Message\ResponseInterface|null
+ */
+EOD
+                            )]]),
+                            new Stmt\ClassMethod('__construct', [
+                                'flags' => Modifiers::PUBLIC,
+                                'params' => [
+                                    new Param(new Expr\Variable('status')),
+                                    new Param(new Expr\Variable('message'), new Scalar\String_('')),
+                                    new Param(
+                                        new Expr\Variable('response'),
+                                        new Expr\ConstFetch(new Name('null')),
+                                        new Node\NullableType(new Name('\\Psr\\Http\\Message\\ResponseInterface'))
+                                    ),
+                                ],
+                                'stmts' => [
+                                    new Stmt\Expression(new Expr\StaticCall(new Name('parent'), '__construct', [
+                                        new Node\Arg(new Expr\Variable('status')),
+                                        new Node\Arg(new Expr\Variable('message')),
+                                    ])),
+                                    new Stmt\Expression(new Expr\Assign(
+                                        new Expr\PropertyFetch(
+                                            new Expr\Variable('this'),
+                                            'response'
+                                        ), new Expr\Variable('response')
+                                    )),
+                                ],
+                            ]),
+                            new Stmt\ClassMethod('getResponse', [
+                                'flags' => Modifiers::PUBLIC,
+                                'stmts' => [
+                                    new Stmt\Return_(
+                                        new Expr\PropertyFetch(
+                                            new Expr\Variable('this'),
+                                            'response'
+                                        )
+                                    ),
+                                ],
+                                'returnType' => new Name('?\\Psr\\Http\\Message\\ResponseInterface'),
+                            ]),
+                        ],
+                    ]
+                ),
+            ]);
+
+            $schema->addFile(new File($schema->getDirectory() . '/Exception/BadResponseException.php', $badResponseException, 'Exception'));
         }
     }
 


### PR DESCRIPTION
## Description

Adds the `BadResponseException` requested in #815: when the `throw-unexpected-status-code` option is enabled, generated endpoints now throw a dedicated `BadResponseException` instead of `UnexpectedStatusCodeException` when no documented response matches in `transformResponseBody()`. Undocumented responses (e.g. an unreported 409) are therefore no longer silently swallowed as `null`.

The new exception extends `UnexpectedStatusCodeException`, so existing user code catching the old class keeps working. It additionally carries the original PSR-7 response, exposed through a new `getResponse(): ?ResponseInterface` accessor.

## Changes

- `ExceptionGenerator::createBaseExceptions()` now also generates a `BadResponseException` class (extends `UnexpectedStatusCodeException`, stores status code, raw body and PSR-7 response); `UnexpectedStatusCodeException` is no longer generated `final` to allow the hierarchy
- Fall-through statement of `transformResponseBody()` updated in all three generators (OpenApi 2, 3 and 3.1): throws `BadResponseException($status, $body, $response)` with matching `@throws` docblocks propagated to Endpoints and Clients; documented-status exceptions are untouched
- Regenerated `expected/` fixtures for `throw-unexpected-status-code` (OA2), `throw-unexcepted-status-code` (OA3) and `application-problem-json-response` (OA3)
- New `bad-response-exception` OA3 fixture (isolated namespace, option enabled)
- New `BadResponseExceptionTest` behavioral test: undocumented 409 throws with correct code/message/response, still catchable as `UnexpectedStatusCodeException`, documented 200 still returns null
- Documented the new exception in `docs/openapi/component.md`; added scoped phpstan ignore patterns for runtime-required fixture classes

No breaking change intended: behavior only changes for users who already opted into `throw-unexpected-status-code`, and only by narrowing the thrown type (subclass). Default silent-null behavior is unchanged.

## How to test

1. `composer install`
2. `vendor/bin/phpunit src/Component/OpenApi3/Tests/BadResponseExceptionTest.php`
3. `vendor/bin/phpunit --exclude-group none` (one pre-existing unrelated failure on `fixtures-issue-831`, present on clean `next` too)
4. `castor qa:phpstan && castor qa:cs:check`

## Notes

- The OA3 fixture directory name `throw-unexcepted-status-code` contains a long-standing typo; intentionally left as is to keep the diff focused.
- Whether throwing should become the default (instead of opt-in) remains open — that would be BC-breaking and out of scope here.

Closes #815
