### PR TITLE
fix(open-api): mark generated status-level exceptions as abstract

### DIFF
--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Docker\Api\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/ConflictException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/ConflictException.php
@@ -2,7 +2,7 @@
 
 namespace Docker\Api\Exception;
 
-class ConflictException extends \RuntimeException implements ClientException
+abstract class ConflictException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/ForbiddenException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/ForbiddenException.php
@@ -2,7 +2,7 @@
 
 namespace Docker\Api\Exception;
 
-class ForbiddenException extends \RuntimeException implements ClientException
+abstract class ForbiddenException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/InternalServerErrorException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/InternalServerErrorException.php
@@ -2,7 +2,7 @@
 
 namespace Docker\Api\Exception;
 
-class InternalServerErrorException extends \RuntimeException implements ServerException
+abstract class InternalServerErrorException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Docker\Api\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/ServiceUnavailableException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/ServiceUnavailableException.php
@@ -2,7 +2,7 @@
 
 namespace Docker\Api\Exception;
 
-class ServiceUnavailableException extends \RuntimeException implements ServerException
+abstract class ServiceUnavailableException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/docker-api/expected/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace Docker\Api\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Exception/NotFoundException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/One/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\One\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/NotFoundException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Two\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Exception/Custom600Exception.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Exception/Custom600Exception.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Exception;
 
-class Custom600Exception extends \RuntimeException implements ServerException
+abstract class Custom600Exception extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Exception/InternalServerErrorException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Exception/InternalServerErrorException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Exception;
 
-class InternalServerErrorException extends \RuntimeException implements ServerException
+abstract class InternalServerErrorException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/exceptions/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Exception/ForbiddenException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Exception/ForbiddenException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class ForbiddenException extends \RuntimeException implements ClientException
+abstract class ForbiddenException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Exception/InternalServerErrorException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Exception/InternalServerErrorException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class InternalServerErrorException extends \RuntimeException implements ServerException
+abstract class InternalServerErrorException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Exception/UnprocessableEntityException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/issue-770/expected/Exception/UnprocessableEntityException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class UnprocessableEntityException extends \RuntimeException implements ClientException
+abstract class UnprocessableEntityException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/model-in-response/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi2\Tests\Expected\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/all-of-nullable-reference-property/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-discriminator/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/any-of-nullable-reference-property/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace ApiPlatform\Demo\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace ApiPlatform\Demo\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Exception/UnprocessableEntityException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/api-platform-demo/expected/Exception/UnprocessableEntityException.php
@@ -2,7 +2,7 @@
 
 namespace ApiPlatform\Demo\Exception;
 
-class UnprocessableEntityException extends \RuntimeException implements ClientException
+abstract class UnprocessableEntityException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Exception/InternalServerErrorException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/application-problem-json-response/expected/Exception/InternalServerErrorException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class InternalServerErrorException extends \RuntimeException implements ServerException
+abstract class InternalServerErrorException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/One/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\One\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exception-with-no-schema/expected/Two/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Two\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Exception/InternalServerErrorException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Exception/InternalServerErrorException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class InternalServerErrorException extends \RuntimeException implements ServerException
+abstract class InternalServerErrorException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/exceptions/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/ConflictException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/ConflictException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class ConflictException extends \RuntimeException implements ClientException
+abstract class ConflictException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/ForbiddenException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/ForbiddenException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class ForbiddenException extends \RuntimeException implements ClientException
+abstract class ForbiddenException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/GoneException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/GoneException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class GoneException extends \RuntimeException implements ClientException
+abstract class GoneException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/IAmATeapotException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/IAmATeapotException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class IAmATeapotException extends \RuntimeException implements ClientException
+abstract class IAmATeapotException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/InternalServerErrorException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/InternalServerErrorException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class InternalServerErrorException extends \RuntimeException implements ServerException
+abstract class InternalServerErrorException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/MethodNotAllowedException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/MethodNotAllowedException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class MethodNotAllowedException extends \RuntimeException implements ClientException
+abstract class MethodNotAllowedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/ServiceUnavailableException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/ServiceUnavailableException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class ServiceUnavailableException extends \RuntimeException implements ServerException
+abstract class ServiceUnavailableException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/TooManyRequestsException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/TooManyRequestsException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class TooManyRequestsException extends \RuntimeException implements ClientException
+abstract class TooManyRequestsException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/UnprocessableEntityException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/UnprocessableEntityException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class UnprocessableEntityException extends \RuntimeException implements ClientException
+abstract class UnprocessableEntityException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/UnsupportedMediaTypeException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/github/expected/Exception/UnsupportedMediaTypeException.php
@@ -2,7 +2,7 @@
 
 namespace Github\Exception;
 
-class UnsupportedMediaTypeException extends \RuntimeException implements ClientException
+abstract class UnsupportedMediaTypeException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace CreditSafe\API\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Exception/ForbiddenException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Exception/ForbiddenException.php
@@ -2,7 +2,7 @@
 
 namespace CreditSafe\API\Exception;
 
-class ForbiddenException extends \RuntimeException implements ClientException
+abstract class ForbiddenException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace CreditSafe\API\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-337/expected/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace CreditSafe\API\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Gounlaf\JanephpBug\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-391/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Gounlaf\JanephpBug\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace PicturePark\API\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/ConflictException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/ConflictException.php
@@ -2,7 +2,7 @@
 
 namespace PicturePark\API\Exception;
 
-class ConflictException extends \RuntimeException implements ClientException
+abstract class ConflictException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/InternalServerErrorException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/InternalServerErrorException.php
@@ -2,7 +2,7 @@
 
 namespace PicturePark\API\Exception;
 
-class InternalServerErrorException extends \RuntimeException implements ServerException
+abstract class InternalServerErrorException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/MethodNotAllowedException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/MethodNotAllowedException.php
@@ -2,7 +2,7 @@
 
 namespace PicturePark\API\Exception;
 
-class MethodNotAllowedException extends \RuntimeException implements ClientException
+abstract class MethodNotAllowedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace PicturePark\API\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/PreconditionFailedException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/PreconditionFailedException.php
@@ -2,7 +2,7 @@
 
 namespace PicturePark\API\Exception;
 
-class PreconditionFailedException extends \RuntimeException implements ClientException
+abstract class PreconditionFailedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/TooManyRequestsException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/TooManyRequestsException.php
@@ -2,7 +2,7 @@
 
 namespace PicturePark\API\Exception;
 
-class TooManyRequestsException extends \RuntimeException implements ClientException
+abstract class TooManyRequestsException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-445/expected/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace PicturePark\API\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/ConflictException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/ConflictException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Exception;
 
-class ConflictException extends \RuntimeException implements ClientException
+abstract class ConflictException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/ForbiddenException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/ForbiddenException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Exception;
 
-class ForbiddenException extends \RuntimeException implements ClientException
+abstract class ForbiddenException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/InternalServerErrorException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/InternalServerErrorException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Exception;
 
-class InternalServerErrorException extends \RuntimeException implements ServerException
+abstract class InternalServerErrorException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/PreconditionFailedException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/PreconditionFailedException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Exception;
 
-class PreconditionFailedException extends \RuntimeException implements ClientException
+abstract class PreconditionFailedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/TooManyRequestsException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/TooManyRequestsException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Exception;
 
-class TooManyRequestsException extends \RuntimeException implements ClientException
+abstract class TooManyRequestsException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/UnprocessableEntityException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/issue-669/expected/Exception/UnprocessableEntityException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Generated\DigitalOcean\Exception;
 
-class UnprocessableEntityException extends \RuntimeException implements ClientException
+abstract class UnprocessableEntityException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/model-in-response/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/response-reference-with-schema-reference/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/whitelisted-paths-reference-without-content/expected/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi3\Tests\Expected\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/museum/expected/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/museum/expected/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/ConflictException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/ConflictException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class ConflictException extends \RuntimeException implements ClientException
+abstract class ConflictException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/ForbiddenException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/ForbiddenException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class ForbiddenException extends \RuntimeException implements ClientException
+abstract class ForbiddenException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/TooManyRequestsException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/TooManyRequestsException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class TooManyRequestsException extends \RuntimeException implements ClientException
+abstract class TooManyRequestsException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/UnprocessableEntityException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/scalar-galaxy/expected/Exception/UnprocessableEntityException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class UnprocessableEntityException extends \RuntimeException implements ClientException
+abstract class UnprocessableEntityException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/BadRequestException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/BadRequestException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class BadRequestException extends \RuntimeException implements ClientException
+abstract class BadRequestException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/ConflictException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/ConflictException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class ConflictException extends \RuntimeException implements ClientException
+abstract class ConflictException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/ForbiddenException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/ForbiddenException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class ForbiddenException extends \RuntimeException implements ClientException
+abstract class ForbiddenException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/InternalServerErrorException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/InternalServerErrorException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class InternalServerErrorException extends \RuntimeException implements ServerException
+abstract class InternalServerErrorException extends \RuntimeException implements ServerException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/NotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class NotFoundException extends \RuntimeException implements ClientException
+abstract class NotFoundException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/TooManyRequestsException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/TooManyRequestsException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class TooManyRequestsException extends \RuntimeException implements ClientException
+abstract class TooManyRequestsException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/UnauthorizedException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/train-travel/expected/Exception/UnauthorizedException.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\Tests\Expected\Exception;
 
-class UnauthorizedException extends \RuntimeException implements ClientException
+abstract class UnauthorizedException extends \RuntimeException implements ClientException
 {
     public function __construct(string $message)
     {

--- a/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
@@ -332,6 +332,7 @@ EOD
             new Stmt\Class_(
                 $highLevelExceptionName,
                 [
+                    'flags' => Modifiers::ABSTRACT,
                     'extends' => new Name('\\RuntimeException'),
                     'implements' => [new Name($code >= 500 ? 'ServerException' : 'ClientException')],
                     'stmts' => [


### PR DESCRIPTION
## Description

Fixes #912. Jane generates a status-level base exception (e.g. `<namespace>\Exception\NotFoundException`) for each error status referenced by an operation, plus one endpoint-specific subclass per operation. Those base classes are inheritance anchors only — the generated client never instantiates them — but they were dumped as plain concrete classes. Under strict "abstract or final" coding styles (e.g. php-cs-fixer's `final_class` rule), they get auto-marked `final`, which breaks the generated package since their intended usage is extension.

This PR dumps them as `abstract`.

## Changes

- `ExceptionGenerator::createHighLevelException()` now emits `'flags' => Modifiers::ABSTRACT` for status-level exceptions; since OpenAPI 2.x, 3.0 and 3.1 share this generator, all three outputs are fixed at once.
- Refreshed the committed `expected/` fixtures across OpenApi2, OpenApi3 and OpenApi31 via `castor jane:replace-all-expected-fixtures` (89 files). The diff is limited to `class X ...` → `abstract class X ...`; endpoint-specific subclasses remain concrete.

## How to test

1. `composer install`
2. Generate a client whose spec has error responses (e.g. any fixture): base exception files now read `abstract class NotFoundException extends \RuntimeException implements ClientException`
3. `vendor/bin/phpunit`

## Notes

- **BC break**: after regeneration, code doing `throw new NotFoundException(...)` (or any other status-level exception) directly will fail; `catch` blocks and `instanceof` checks keep working. Intentional per #912.
- The `issue-831` fixture file-count assertion fails on this branch's base commit independently of this change (stale fixtures, refreshed upstream by #1011); CI may show exactly that one failure.
