### PR TITLE
feat(open-api): accept instance or class name for endpoint-generator

### DIFF
--- a/docs/openapi/component.md
+++ b/docs/openapi/component.md
@@ -185,8 +185,10 @@ return [
 There is many ways to use it, first you atleast need a regex defining which endpoint is whitelisted. This endpoint
 can be either a string or in an array. If you don't provide any HTTP method, we will just accept any methods, but
 you can provide either a string or array as second argument to specify which method you accept.
-- `endpoint-generator`: Generator Class which can specify custom endpoint interface & corresponding trait (this class
- should extends `\Jane\Component\OpenApi3\Generator\EndpointGenerator`)
+- `endpoint-generator`: Generator which can specify custom endpoint interface & corresponding trait. It accepts either
+ a class name (this class should extend `\Jane\Component\OpenApi3\Generator\EndpointGenerator`) or a ready-made
+ instance implementing `\Jane\Component\OpenApiCommon\Generator\EndpointGeneratorInterface`, so you can build it
+ yourself with the dependencies of your choice
 - `custom-query-resolver`: This option allows you to customize the query parameter normalizer for each of the API
  endpoint with a userland callback. Here is all possible combinations::
 ```php

--- a/src/Component/OpenApi2/Generator/GeneratorFactory.php
+++ b/src/Component/OpenApi2/Generator/GeneratorFactory.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApi2\Generator;
 use Jane\Component\JsonSchema\Generator\GeneratorInterface;
 use Jane\Component\OpenApi2\Generator\Parameter\BodyParameterGenerator;
 use Jane\Component\OpenApi2\Generator\Parameter\NonBodyParameterGenerator;
+use Jane\Component\OpenApiCommon\Generator\EndpointGeneratorInterface;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
 use Jane\Component\OpenApiCommon\Generator\OperationGenerator;
 use Jane\Component\OpenApiCommon\Naming\ChainOperationNaming;
@@ -16,7 +17,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class GeneratorFactory
 {
-    public static function build(DenormalizerInterface $serializer, string $endpointGeneratorClass): GeneratorInterface
+    public static function build(DenormalizerInterface $serializer, EndpointGeneratorInterface|string $endpointGenerator): GeneratorInterface
     {
         $parser = (new ParserFactory())->createForHostVersion();
 
@@ -28,11 +29,18 @@ class GeneratorFactory
             new OperationUrlNaming(),
         ]));
 
-        if (!class_exists($endpointGeneratorClass)) {
-            throw new \InvalidArgumentException(\sprintf('Unknown generator class %s', $endpointGeneratorClass));
+        if (!$endpointGenerator instanceof EndpointGeneratorInterface) {
+            if (!class_exists($endpointGenerator)) {
+                throw new \InvalidArgumentException(\sprintf('Unknown generator class %s', $endpointGenerator));
+            }
+
+            if (!is_a($endpointGenerator, EndpointGeneratorInterface::class, true)) {
+                throw new \InvalidArgumentException(\sprintf('Class %s does not implement %s', $endpointGenerator, EndpointGeneratorInterface::class));
+            }
+
+            $endpointGenerator = new $endpointGenerator($operationNaming, $bodyParameter, $nonBodyParameter, $serializer, $exceptionGenerator);
         }
 
-        $endpointGenerator = new $endpointGeneratorClass($operationNaming, $bodyParameter, $nonBodyParameter, $serializer, $exceptionGenerator);
         $operationGenerator = new OperationGenerator($endpointGenerator);
 
         return new ClientGenerator($operationGenerator, $operationNaming);

--- a/src/Component/OpenApi2/Tests/Generator/GeneratorFactoryTest.php
+++ b/src/Component/OpenApi2/Tests/Generator/GeneratorFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Component\OpenApi2\Tests\Generator;
+
+use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\OpenApi2\Generator\ClientGenerator;
+use Jane\Component\OpenApi2\Generator\EndpointGenerator;
+use Jane\Component\OpenApi2\Generator\GeneratorFactory;
+use Jane\Component\OpenApi2\JaneOpenApi;
+use Jane\Component\OpenApiCommon\Generator\ClientGenerator as BaseClientGenerator;
+use Jane\Component\OpenApiCommon\Generator\EndpointGeneratorInterface;
+use Jane\Component\OpenApiCommon\Generator\OperationGenerator;
+use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
+use PHPUnit\Framework\TestCase;
+
+final class GeneratorFactoryTest extends TestCase
+{
+    public function testBuildUsesProvidedEndpointGeneratorInstance(): void
+    {
+        $endpointGenerator = new class() implements EndpointGeneratorInterface {
+            public function createEndpointClass(OperationGuess $operation, Context $context): array
+            {
+                return [];
+            }
+        };
+
+        $clientGenerator = GeneratorFactory::build(JaneOpenApi::buildSerializer(), $endpointGenerator);
+
+        self::assertInstanceOf(ClientGenerator::class, $clientGenerator);
+        self::assertSame($endpointGenerator, $this->getEmbeddedEndpointGenerator($clientGenerator));
+    }
+
+    public function testBuildInstantiatesDefaultEndpointGeneratorFromClassName(): void
+    {
+        $clientGenerator = GeneratorFactory::build(JaneOpenApi::buildSerializer(), EndpointGenerator::class);
+
+        self::assertInstanceOf(EndpointGenerator::class, $this->getEmbeddedEndpointGenerator($clientGenerator));
+    }
+
+    public function testBuildRejectsUnknownGeneratorClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown generator class');
+
+        GeneratorFactory::build(JaneOpenApi::buildSerializer(), 'Not\\A\\Real\\Class');
+    }
+
+    public function testBuildRejectsClassNotImplementingEndpointGeneratorInterface(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not implement');
+
+        GeneratorFactory::build(JaneOpenApi::buildSerializer(), \stdClass::class);
+    }
+
+    private function getEmbeddedEndpointGenerator(ClientGenerator $clientGenerator): EndpointGeneratorInterface
+    {
+        $operationGenerator = (new \ReflectionProperty(BaseClientGenerator::class, 'operationGenerator'))->getValue($clientGenerator);
+        \assert($operationGenerator instanceof OperationGenerator);
+
+        $endpointGenerator = (new \ReflectionProperty(OperationGenerator::class, 'endpointGenerator'))->getValue($operationGenerator);
+        \assert($endpointGenerator instanceof EndpointGeneratorInterface);
+
+        return $endpointGenerator;
+    }
+}

--- a/src/Component/OpenApi3/Generator/GeneratorFactory.php
+++ b/src/Component/OpenApi3/Generator/GeneratorFactory.php
@@ -7,6 +7,7 @@ use Jane\Component\OpenApi3\Generator\Parameter\NonBodyParameterGenerator;
 use Jane\Component\OpenApi3\Generator\RequestBodyContent\DefaultBodyContentGenerator;
 use Jane\Component\OpenApi3\Generator\RequestBodyContent\FormBodyContentGenerator;
 use Jane\Component\OpenApi3\Generator\RequestBodyContent\JsonBodyContentGenerator;
+use Jane\Component\OpenApiCommon\Generator\EndpointGeneratorInterface;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
 use Jane\Component\OpenApiCommon\Generator\OperationGenerator;
 use Jane\Component\OpenApiCommon\Naming\ChainOperationNaming;
@@ -18,7 +19,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class GeneratorFactory
 {
-    public static function build(DenormalizerInterface $serializer, string $endpointGeneratorClass): GeneratorInterface
+    public static function build(DenormalizerInterface $serializer, EndpointGeneratorInterface|string $endpointGenerator): GeneratorInterface
     {
         $parser = (new ParserFactory())->createForHostVersion();
 
@@ -34,11 +35,18 @@ class GeneratorFactory
         $requestBodyGenerator->addRequestBodyGenerator(JsonBodyContentGenerator::JSON_TYPES, new JsonBodyContentGenerator($serializer));
         $requestBodyGenerator->addRequestBodyGenerator(['application/x-www-form-urlencoded', 'multipart/form-data'], new FormBodyContentGenerator($serializer));
 
-        if (!class_exists($endpointGeneratorClass)) {
-            throw new \InvalidArgumentException(\sprintf('Unknown generator class %s', $endpointGeneratorClass));
+        if (!$endpointGenerator instanceof EndpointGeneratorInterface) {
+            if (!class_exists($endpointGenerator)) {
+                throw new \InvalidArgumentException(\sprintf('Unknown generator class %s', $endpointGenerator));
+            }
+
+            if (!is_a($endpointGenerator, EndpointGeneratorInterface::class, true)) {
+                throw new \InvalidArgumentException(\sprintf('Class %s does not implement %s', $endpointGenerator, EndpointGeneratorInterface::class));
+            }
+
+            $endpointGenerator = new $endpointGenerator($operationNaming, $nonBodyParameter, $serializer, $exceptionGenerator, $requestBodyGenerator);
         }
 
-        $endpointGenerator = new $endpointGeneratorClass($operationNaming, $nonBodyParameter, $serializer, $exceptionGenerator, $requestBodyGenerator);
         $operationGenerator = new OperationGenerator($endpointGenerator);
 
         return new ClientGenerator($operationGenerator, $operationNaming);

--- a/src/Component/OpenApi3/Tests/Generator/GeneratorFactoryTest.php
+++ b/src/Component/OpenApi3/Tests/Generator/GeneratorFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Component\OpenApi3\Tests\Generator;
+
+use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\OpenApi3\Generator\ClientGenerator;
+use Jane\Component\OpenApi3\Generator\EndpointGenerator;
+use Jane\Component\OpenApi3\Generator\GeneratorFactory;
+use Jane\Component\OpenApi3\JaneOpenApi;
+use Jane\Component\OpenApiCommon\Generator\ClientGenerator as BaseClientGenerator;
+use Jane\Component\OpenApiCommon\Generator\EndpointGeneratorInterface;
+use Jane\Component\OpenApiCommon\Generator\OperationGenerator;
+use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
+use PHPUnit\Framework\TestCase;
+
+final class GeneratorFactoryTest extends TestCase
+{
+    public function testBuildUsesProvidedEndpointGeneratorInstance(): void
+    {
+        $endpointGenerator = new class() implements EndpointGeneratorInterface {
+            public function createEndpointClass(OperationGuess $operation, Context $context): array
+            {
+                return [];
+            }
+        };
+
+        $clientGenerator = GeneratorFactory::build(JaneOpenApi::buildSerializer(), $endpointGenerator);
+
+        self::assertInstanceOf(ClientGenerator::class, $clientGenerator);
+        self::assertSame($endpointGenerator, $this->getEmbeddedEndpointGenerator($clientGenerator));
+    }
+
+    public function testBuildInstantiatesDefaultEndpointGeneratorFromClassName(): void
+    {
+        $clientGenerator = GeneratorFactory::build(JaneOpenApi::buildSerializer(), EndpointGenerator::class);
+
+        self::assertInstanceOf(EndpointGenerator::class, $this->getEmbeddedEndpointGenerator($clientGenerator));
+    }
+
+    public function testBuildRejectsUnknownGeneratorClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown generator class');
+
+        GeneratorFactory::build(JaneOpenApi::buildSerializer(), 'Not\\A\\Real\\Class');
+    }
+
+    public function testBuildRejectsClassNotImplementingEndpointGeneratorInterface(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not implement');
+
+        GeneratorFactory::build(JaneOpenApi::buildSerializer(), \stdClass::class);
+    }
+
+    private function getEmbeddedEndpointGenerator(ClientGenerator $clientGenerator): EndpointGeneratorInterface
+    {
+        $operationGenerator = (new \ReflectionProperty(BaseClientGenerator::class, 'operationGenerator'))->getValue($clientGenerator);
+        \assert($operationGenerator instanceof OperationGenerator);
+
+        $endpointGenerator = (new \ReflectionProperty(OperationGenerator::class, 'endpointGenerator'))->getValue($operationGenerator);
+        \assert($endpointGenerator instanceof EndpointGeneratorInterface);
+
+        return $endpointGenerator;
+    }
+}

--- a/src/Component/OpenApi31/Generator/GeneratorFactory.php
+++ b/src/Component/OpenApi31/Generator/GeneratorFactory.php
@@ -7,6 +7,7 @@ use Jane\Component\OpenApi31\Generator\Parameter\NonBodyParameterGenerator;
 use Jane\Component\OpenApi31\Generator\RequestBodyContent\DefaultBodyContentGenerator;
 use Jane\Component\OpenApi31\Generator\RequestBodyContent\FormBodyContentGenerator;
 use Jane\Component\OpenApi31\Generator\RequestBodyContent\JsonBodyContentGenerator;
+use Jane\Component\OpenApiCommon\Generator\EndpointGeneratorInterface;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
 use Jane\Component\OpenApiCommon\Generator\OperationGenerator;
 use Jane\Component\OpenApiCommon\Naming\ChainOperationNaming;
@@ -18,7 +19,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 class GeneratorFactory
 {
-    public static function build(DenormalizerInterface $serializer, string $endpointGeneratorClass): GeneratorInterface
+    public static function build(DenormalizerInterface $serializer, EndpointGeneratorInterface|string $endpointGenerator): GeneratorInterface
     {
         $parser = (new ParserFactory())->createForHostVersion();
 
@@ -34,11 +35,18 @@ class GeneratorFactory
         $requestBodyGenerator->addRequestBodyGenerator(JsonBodyContentGenerator::JSON_TYPES, new JsonBodyContentGenerator($serializer));
         $requestBodyGenerator->addRequestBodyGenerator(['application/x-www-form-urlencoded', 'multipart/form-data'], new FormBodyContentGenerator($serializer));
 
-        if (!class_exists($endpointGeneratorClass)) {
-            throw new \InvalidArgumentException(\sprintf('Unknown generator class %s', $endpointGeneratorClass));
+        if (!$endpointGenerator instanceof EndpointGeneratorInterface) {
+            if (!class_exists($endpointGenerator)) {
+                throw new \InvalidArgumentException(\sprintf('Unknown generator class %s', $endpointGenerator));
+            }
+
+            if (!is_a($endpointGenerator, EndpointGeneratorInterface::class, true)) {
+                throw new \InvalidArgumentException(\sprintf('Class %s does not implement %s', $endpointGenerator, EndpointGeneratorInterface::class));
+            }
+
+            $endpointGenerator = new $endpointGenerator($operationNaming, $nonBodyParameter, $serializer, $exceptionGenerator, $requestBodyGenerator);
         }
 
-        $endpointGenerator = new $endpointGeneratorClass($operationNaming, $nonBodyParameter, $serializer, $exceptionGenerator, $requestBodyGenerator);
         $operationGenerator = new OperationGenerator($endpointGenerator);
 
         return new ClientGenerator($operationGenerator, $operationNaming);

--- a/src/Component/OpenApi31/Tests/Generator/GeneratorFactoryTest.php
+++ b/src/Component/OpenApi31/Tests/Generator/GeneratorFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Component\OpenApi31\Tests\Generator;
+
+use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\OpenApi31\Generator\ClientGenerator;
+use Jane\Component\OpenApi31\Generator\EndpointGenerator;
+use Jane\Component\OpenApi31\Generator\GeneratorFactory;
+use Jane\Component\OpenApi31\JaneOpenApi;
+use Jane\Component\OpenApiCommon\Generator\ClientGenerator as BaseClientGenerator;
+use Jane\Component\OpenApiCommon\Generator\EndpointGeneratorInterface;
+use Jane\Component\OpenApiCommon\Generator\OperationGenerator;
+use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
+use PHPUnit\Framework\TestCase;
+
+final class GeneratorFactoryTest extends TestCase
+{
+    public function testBuildUsesProvidedEndpointGeneratorInstance(): void
+    {
+        $endpointGenerator = new class() implements EndpointGeneratorInterface {
+            public function createEndpointClass(OperationGuess $operation, Context $context): array
+            {
+                return [];
+            }
+        };
+
+        $clientGenerator = GeneratorFactory::build(JaneOpenApi::buildSerializer(), $endpointGenerator);
+
+        self::assertInstanceOf(ClientGenerator::class, $clientGenerator);
+        self::assertSame($endpointGenerator, $this->getEmbeddedEndpointGenerator($clientGenerator));
+    }
+
+    public function testBuildInstantiatesDefaultEndpointGeneratorFromClassName(): void
+    {
+        $clientGenerator = GeneratorFactory::build(JaneOpenApi::buildSerializer(), EndpointGenerator::class);
+
+        self::assertInstanceOf(EndpointGenerator::class, $this->getEmbeddedEndpointGenerator($clientGenerator));
+    }
+
+    public function testBuildRejectsUnknownGeneratorClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown generator class');
+
+        GeneratorFactory::build(JaneOpenApi::buildSerializer(), 'Not\\A\\Real\\Class');
+    }
+
+    public function testBuildRejectsClassNotImplementingEndpointGeneratorInterface(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not implement');
+
+        GeneratorFactory::build(JaneOpenApi::buildSerializer(), \stdClass::class);
+    }
+
+    private function getEmbeddedEndpointGenerator(ClientGenerator $clientGenerator): EndpointGeneratorInterface
+    {
+        $operationGenerator = (new \ReflectionProperty(BaseClientGenerator::class, 'operationGenerator'))->getValue($clientGenerator);
+        \assert($operationGenerator instanceof OperationGenerator);
+
+        $endpointGenerator = (new \ReflectionProperty(OperationGenerator::class, 'endpointGenerator'))->getValue($operationGenerator);
+        \assert($endpointGenerator instanceof EndpointGeneratorInterface);
+
+        return $endpointGenerator;
+    }
+}


### PR DESCRIPTION
## Description

Allows the `endpoint-generator` configuration option to accept a pre-built generator instance instead of only a class name, so users can construct the endpoint generator themselves with the dependencies of their choice. Class-name strings remain fully supported for backward compatibility.

## Changes

- `GeneratorFactory::build()` now accepts `EndpointGeneratorInterface|string` in OpenAPI 2, 3 and 3.1 components (`src/Component/*/Generator/GeneratorFactory.php`); a provided instance is used as-is, a class-name string is instantiated as before with the factory collaborators.
- The class-name path now also validates that the configured class implements `EndpointGeneratorInterface` and throws an explicit `InvalidArgumentException` instead of failing later on constructor mismatch.
- New unit tests per component covering: instance identity (the exact instance is embedded in the generated client graph), default instantiation from class name, unknown class rejection, and non-implementing class rejection.
- Documentation updated (`docs/openapi/component.md`).

## How to test

1. `vendor/bin/phpunit --filter GeneratorFactoryTest`
2. `vendor/bin/phpunit` (full suite; existing `custom-endpoint-generator` fixtures confirm unchanged output)
3. `castor qa:phpstan && castor qa:cs:check`

## Notes

- No breaking change: existing configs passing an FQCN keep working.
- When an instance is provided, Jane no longer injects its standard collaborators — construction is fully owned by the caller.
