### PR TITLE
feat(open-api): support x-namespace extension for sub-namespaces (#838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- [OpenApi] [GH#838](https://github.com/janephp/janephp/issues/838) New `x-namespace` Specification Extension: declaring it on an operation moves its Endpoint (and inline request / response models) to a sub-namespace, declaring it on a schema moves its Model, Normalizer & Validator there. Artifacts without the attribute keep the flat layout
+- [OpenApi31] The internal 3.1 models now capture `x-*` specification extensions on the `Operation` object and on schemas, matching what OpenAPI 2.0 / 3.0 already preserved
 - [JsonSchema] New `<Namespace>\Runtime\JsonObject` runtime class shipped with every generated library, used to represent objects & maps in normalized payloads
 - [Docs] New [Architecture Decision Records](docs/contributing/adrs/index.md) documenting key generator/runtime decisions
 - [OpenApi] [GH#832](https://github.com/janephp/janephp/issues/832) New `operation-namings` option to customize client method names and endpoint class names through `Jane\Component\OpenApiCommon\Naming\OperationNamingInterface` instances. Providing an empty array (the default) keeps the built-in chain (`operationId` based naming with URL based fallback). As a side effect, an operation named exactly `'0'` is now consistently treated as a valid name by the naming chain instead of being skipped

--- a/docs/contributing/adrs/0006-follow-upstream-specifications.md
+++ b/docs/contributing/adrs/0006-follow-upstream-specifications.md
@@ -1,0 +1,49 @@
+# ADR 0006: Follow upstream specifications faithfully
+
+- **Status**: Accepted
+- **Codified**: 2026-08, while adding the `x-namespace` feature ([#838](https://github.com/janephp/janephp/issues/838))
+
+## Context
+
+Jane parses specifications into its own generated models before guessing and
+generating code. Anything the parser silently drops is invisible to every
+downstream feature.
+
+This bit us concretely with `x-namespace`: OAS 3.1 guarantees preservation of
+`x-*` vendor extensions ([Specification
+Extensions](https://spec.openapis.org/oas/v3.1.0#specification-extensions) — a
+guarantee `version31.json` itself cites), yet Jane's 3.1 models dropped them:
+the meta-schema declared extensions only through an indirection
+(`"$ref": "#/$defs/specification-extensions"`), which the extensions detection
+does not resolve, so every generated 3.1 model discarded `x-*` data at parse
+time. The divergence from the specification was silent and only surfaced
+because a feature needed the data.
+
+## Decision
+
+1. When an OpenAPI / JSON Schema specification defines a construct (fields,
+   vendor extensions, semantics), Jane's parsers must preserve and expose it
+   faithfully. A gap between what a specification guarantees and what Jane's
+   parsed models expose is a bug, not a limitation.
+2. Meta-schema updates (`version*.json`) must propagate to the internal models
+   they generate (`src/Component/*/JsonSchema/`): parser parity is part of the
+   work when specifications evolve.
+3. Spec-guaranteed data may not be repurposed or overloaded for features:
+   new capabilities are expressed with explicit annotations (e.g.
+   `x-namespace` for sub-namespaces) rather than abusing unrelated fields,
+   tags or comments.
+
+## Consequences
+
+- Parser-parity work becomes mandatory upkeep: when upstream specifications or
+  their meta-schemas change, the internal models must be regenerated and the
+  diff reviewed in the same effort.
+- Features can rely on spec-guaranteed data being present in parsed models.
+- Occasional regeneration churn inside internal model/normalizer trees is an
+  accepted cost, kept reviewable by scoping each regeneration to its cause.
+
+## Links
+
+- [#838](https://github.com/janephp/janephp/issues/838) — the `x-namespace` feature that surfaced the 3.1 gap
+- [OAS 3.1 §Specification Extensions](https://spec.openapis.org/oas/v3.1.0#specification-extensions)
+- [ADR 0004](0004-fixtures-are-immutable.md) — how regeneration output stays reviewable

--- a/docs/contributing/adrs/index.md
+++ b/docs/contributing/adrs/index.md
@@ -23,6 +23,7 @@ Each record follows a lightweight ADR format:
 | [0003](0003-no-arrayobject.md) | No `\ArrayObject` — dedicated value objects & `iterable` hints | Accepted |
 | [0004](0004-fixtures-are-immutable.md) | Test fixtures are immutable — regenerate, never hand-edit | Accepted |
 | [0005](0005-php-floor.md) | Stay within the PHP `^8.1` floor | Accepted |
+| [0006](0006-follow-upstream-specifications.md) | Follow upstream specifications faithfully | Accepted |
 
 ## Adding a new record
 

--- a/docs/openapi/component.md
+++ b/docs/openapi/component.md
@@ -263,6 +263,54 @@ Additional rules:
 - Parameters declaring a `content` field are serialized from their content and ignore `style` / `explode`,
   as specified by OpenAPI.
 
+## Namespacing generated code with `x-namespace`
+
+By default, Jane generates every Endpoint in `Endpoint\`, every Model in `Model\`, ... With the OpenAPI
+[Specification Extensions](https://spec.openapis.org/oas/v3.1.0#specification-extensions) mechanism, you can opt-in
+to a sub-namespace per artifact by declaring an `x-namespace` attribute:
+
+- on an **operation**: its Endpoint class (and the Models generated for its inline request bodies / responses, see
+  below) moves to `Endpoint\<x-namespace>\`
+- on a **schema** (`components.schemas` entry in OpenAPI 3.x, `definitions` entry in OpenAPI 2): its Model,
+  Normalizer and Validator classes move to `Model\<x-namespace>\`, `Normalizer\<x-namespace>\`, ...
+
+```yaml
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      x-namespace: Admin\Reports
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+components:
+  schemas:
+    User:
+      x-namespace: Directory
+      type: object
+```
+
+With this specification:
+
+- `Endpoint\Admin\Reports\GetUsers` is generated instead of `Endpoint\GetUsers`
+- `Model\Directory\User` (+ its normalizer / validator) is generated instead of `Model\User`
+
+Rules:
+
+- The value may contain several segments separated by `\` or `/`, e.g. `"Admin\Reports"` or `"Directory/Users"`.
+  Each segment is sanitized like class names (invalid characters removed, reserved words prefixed with `_`,
+  e.g. `"list"` becomes `_List`).
+- Artifacts without the attribute keep the flat layout: adding `x-namespace` only affects annotated artifacts.
+- Inline request body / response models of a namespaced operation inherit the operation's namespace, so they stay
+  next to their endpoint. A schema referenced by that operation which declares its own `x-namespace` always wins:
+  explicit attributes are never overridden.
+- Renaming or removing an `x-namespace` attribute after generation changes the FQCNs of the affected classes and is
+  therefore a BC break for consumers of your generated library.
+
 ## Using a generated client
 
 Generating a client will produce same classes as the [JSON Schema](../json_schema/component.md) library:

--- a/src/Component/JsonSchema/Generator/EnumGenerator.php
+++ b/src/Component/JsonSchema/Generator/EnumGenerator.php
@@ -15,19 +15,26 @@ class EnumGenerator implements GeneratorInterface
 {
     public const FILE_TYPE_ENUM = 'enum';
 
+    public function __construct(
+        private readonly ?Naming $naming = null,
+    ) {
+    }
+
     public function generate(Schema $schema, string $className, Context $context): void
     {
-        $namespace = $schema->getNamespace() . '\\Model';
+        $naming = $this->naming ?? new Naming();
 
         foreach ($schema->getClasses() as $class) {
             if (!$class instanceof EnumGuess) {
                 continue;
             }
 
+            $subNamespace = $class->getSubNamespace();
+            $namespace = $naming->getModelNamespace($schema->getNamespace(), $subNamespace);
             $enum = $this->createEnum($class);
 
             $namespaceStmt = new Stmt\Namespace_(new Name($namespace), [$enum]);
-            $schema->addFile(new File($schema->getDirectory() . '/Model/' . $class->getName() . '.php', $namespaceStmt, self::FILE_TYPE_ENUM));
+            $schema->addFile(new File($naming->getArtifactPath($schema->getDirectory(), 'Model', $subNamespace) . '/' . $class->getName() . '.php', $namespaceStmt, self::FILE_TYPE_ENUM));
         }
     }
 

--- a/src/Component/JsonSchema/Generator/ModelGenerator.php
+++ b/src/Component/JsonSchema/Generator/ModelGenerator.php
@@ -49,12 +49,13 @@ class ModelGenerator implements GeneratorInterface
      */
     public function generate(Schema $schema, string $className, Context $context): void
     {
-        $namespace = $schema->getNamespace() . '\\Model';
-
         foreach ($schema->getClasses() as $class) {
             if ($class instanceof NonObjectGuessInterface) {
                 continue;
             }
+
+            $subNamespace = $class->getSubNamespace();
+            $namespace = $this->naming->getModelNamespace($schema->getNamespace(), $subNamespace);
 
             $properties = [];
             $methods = [];
@@ -68,7 +69,7 @@ class ModelGenerator implements GeneratorInterface
             $model = $this->doCreateModel($class, $properties, $methods);
 
             $namespaceStmt = new Stmt\Namespace_(new Name($namespace), [$model]);
-            $schema->addFile(new File($schema->getDirectory() . '/Model/' . $class->getName() . '.php', $namespaceStmt, self::FILE_TYPE_MODEL));
+            $schema->addFile(new File($this->naming->getArtifactPath($schema->getDirectory(), 'Model', $subNamespace) . '/' . $class->getName() . '.php', $namespaceStmt, self::FILE_TYPE_MODEL));
         }
     }
 

--- a/src/Component/JsonSchema/Generator/Naming.php
+++ b/src/Component/JsonSchema/Generator/Naming.php
@@ -108,6 +108,54 @@ class Naming
         return \sprintf('%s\\%s', $this->getRuntimeNamespace($schemaNamespace, $namespace), $class);
     }
 
+    public function getModelNamespace(string $schemaNamespace, array $subNamespace = []): string
+    {
+        return $this->getNamespacedChild($schemaNamespace, 'Model', $subNamespace);
+    }
+
+    public function getNormalizerNamespace(string $schemaNamespace, array $subNamespace = []): string
+    {
+        return $this->getNamespacedChild($schemaNamespace, 'Normalizer', $subNamespace);
+    }
+
+    public function getValidatorNamespace(string $schemaNamespace, array $subNamespace = []): string
+    {
+        return $this->getNamespacedChild($schemaNamespace, 'Validator', $subNamespace);
+    }
+
+    public function getEndpointNamespace(string $schemaNamespace, array $subNamespace = []): string
+    {
+        return $this->getNamespacedChild($schemaNamespace, 'Endpoint', $subNamespace);
+    }
+
+    /**
+     * Base directory for generated artifacts of a given type, e.g. "<dir>/Model" or "<dir>/Model/Users".
+     *
+     * @param string[] $subNamespace Sanitized segments appended after the artifact directory
+     */
+    public function getArtifactPath(string $directory, string $artifact, array $subNamespace = []): string
+    {
+        $path = $directory . '/' . $artifact;
+        foreach ($subNamespace as $segment) {
+            $path .= '/' . $segment;
+        }
+
+        return $path;
+    }
+
+    /**
+     * @param string[] $subNamespace Sanitized segments appended after the child namespace, e.g. ['Users'] => "<ns>\Model\Users"
+     */
+    private function getNamespacedChild(string $schemaNamespace, string $child, array $subNamespace): string
+    {
+        $namespaceSuffix = '';
+        if (\count($subNamespace) > 0) {
+            $namespaceSuffix = '\\' . implode('\\', $subNamespace);
+        }
+
+        return $schemaNamespace . '\\' . $child . $namespaceSuffix;
+    }
+
     protected function cleaning(string $name, bool $class = false): string
     {
         if (preg_match('/\$/', $name)) {

--- a/src/Component/JsonSchema/Generator/Normalizer/DenormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/Normalizer/DenormalizerGenerator.php
@@ -139,7 +139,7 @@ trait DenormalizerGenerator
         if ($this->validation) {
             $schema = $context->getCurrentSchema();
             $contextVariable = new Expr\Variable('context');
-            $constraintFqdn = $schema->getNamespace() . '\\Validator\\' . $this->naming->getConstraintName($classGuess->getName());
+            $constraintFqdn = $this->naming->getValidatorNamespace($schema->getNamespace(), $classGuess->getSubNamespace()) . '\\' . $this->naming->getConstraintName($classGuess->getName());
 
             $statements[] = new Stmt\If_(new Expr\BooleanNot(new Expr\BinaryOp\Coalesce(new Expr\ArrayDimFetch($contextVariable, new Scalar\String_('skip_validation')), new Expr\ConstFetch(new Name('false')))), ['stmts' => [
                 new Stmt\Expression(new Expr\MethodCall(new Expr\Variable('this'), 'validate', [

--- a/src/Component/JsonSchema/Generator/Normalizer/ExternalNormalizersResolver.php
+++ b/src/Component/JsonSchema/Generator/Normalizer/ExternalNormalizersResolver.php
@@ -81,9 +81,11 @@ class ExternalNormalizersResolver
                     [$dependencySchema, $dependencyClass] = $owners[$dependencyFqcn];
 
                     if ($dependencySchema !== $schema) {
+                        $subNamespace = $this->getSubNamespaceSuffix($dependencyClass);
                         $mappings[$dependencyFqcn] = \sprintf(
-                            '%s\\Normalizer\\%sNormalizer',
+                            '%s\\Normalizer%s\\%sNormalizer',
                             $dependencySchema->getNamespace(),
+                            $subNamespace,
                             $dependencyClass->getName()
                         );
                     }
@@ -126,6 +128,21 @@ class ExternalNormalizersResolver
 
     private function getModelFqcn(Schema $schema, ClassGuess $class): string
     {
-        return \sprintf('%s\\Model\\%s', $schema->getNamespace(), $class->getName());
+        return \sprintf(
+            '%s\\Model%s\\%s',
+            $schema->getNamespace(),
+            $this->getSubNamespaceSuffix($class),
+            $class->getName()
+        );
+    }
+
+    /**
+     * @return string "\"-prefixed sub-namespace (e.g. "\Users"), empty string when the class uses the flat layout
+     */
+    private function getSubNamespaceSuffix(ClassGuess $class): string
+    {
+        $subNamespace = $class->getSubNamespace();
+
+        return [] === $subNamespace ? '' : '\\' . implode('\\', $subNamespace);
     }
 }

--- a/src/Component/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/Normalizer/NormalizerGenerator.php
@@ -182,7 +182,7 @@ trait NormalizerGenerator
         if ($this->validation) {
             $schema = $context->getCurrentSchema();
             $contextVariable = new Expr\Variable('context');
-            $constraintFqdn = $schema->getNamespace() . '\\Validator\\' . $this->naming->getConstraintName($classGuess->getName());
+            $constraintFqdn = $this->naming->getValidatorNamespace($schema->getNamespace(), $classGuess->getSubNamespace()) . '\\' . $this->naming->getConstraintName($classGuess->getName());
 
             $statements[] = new Stmt\If_(new Expr\BooleanNot(new Expr\BinaryOp\Coalesce(new Expr\ArrayDimFetch($contextVariable, new Scalar\String_('skip_validation')), new Expr\ConstFetch(new Name('false')))), ['stmts' => [
                 new Stmt\Expression(new Expr\MethodCall(new Expr\Variable('this'), 'validate', [

--- a/src/Component/JsonSchema/Generator/NormalizerGenerator.php
+++ b/src/Component/JsonSchema/Generator/NormalizerGenerator.php
@@ -70,7 +70,9 @@ class NormalizerGenerator implements GeneratorInterface
                 continue;
             }
 
-            $modelFqdn = $schema->getNamespace() . '\\Model\\' . $class->getName();
+            $subNamespace = $class->getSubNamespace();
+            $normalizerNamespace = $this->naming->getNormalizerNamespace($schema->getNamespace(), $subNamespace);
+            $modelFqdn = $this->naming->getModelNamespace($schema->getNamespace(), $subNamespace) . '\\' . $class->getName();
 
             $methods = [];
             $methods[] = $this->createSupportsDenormalizationMethod($modelFqdn);
@@ -106,9 +108,9 @@ class NormalizerGenerator implements GeneratorInterface
 
             $useStmts = array_merge($useStmts, [$symfony7NormalizerClass]);
 
-            $namespace = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Normalizer'), $useStmts);
-            $normalizers[$modelFqdn] = $schema->getNamespace() . '\\Normalizer\\' . $symfony7NormalizerClass->name;
-            $schema->addFile(new File($schema->getDirectory() . '/Normalizer/' . $symfony7NormalizerClass->name . '.php', $namespace, self::FILE_TYPE_NORMALIZER));
+            $namespace = new Stmt\Namespace_(new Name($normalizerNamespace), $useStmts);
+            $normalizers[$modelFqdn] = $normalizerNamespace . '\\' . $symfony7NormalizerClass->name;
+            $schema->addFile(new File($this->naming->getArtifactPath($schema->getDirectory(), 'Normalizer', $subNamespace) . '/' . $symfony7NormalizerClass->name . '.php', $namespace, self::FILE_TYPE_NORMALIZER));
         }
 
         // Add normalizers of models from other schemas transitively used by this schema's models,

--- a/src/Component/JsonSchema/Generator/ValidatorGenerator.php
+++ b/src/Component/JsonSchema/Generator/ValidatorGenerator.php
@@ -28,7 +28,6 @@ class ValidatorGenerator implements GeneratorInterface
     public function generate(Schema $schema, string $className, Context $context): void
     {
         $registry = $context->getRegistry();
-        $namespace = $schema->getNamespace() . '\\Validator';
 
         foreach ($schema->getClasses() as $class) {
             if ($class instanceof NonObjectGuessInterface) {
@@ -38,6 +37,8 @@ class ValidatorGenerator implements GeneratorInterface
             // The Constraint class is always generated, even without any validator guess: normalizers and
             // parent Compound constraints reference it unconditionally, so skipping it would leave a
             // reference to a class that does not exist, fataling at runtime.
+            $subNamespace = $class->getSubNamespace();
+            $namespace = $this->naming->getValidatorNamespace($schema->getNamespace(), $subNamespace);
             $className = $this->naming->getConstraintName($class->getName());
             $collectionItemsConstraints = [];
             $collectionItems = [];
@@ -62,8 +63,8 @@ class ValidatorGenerator implements GeneratorInterface
                     $localNamespace = $namespace;
                     if (null !== $classGuess->getClassReference()) {
                         foreach ($registry->getSchemas() as $localSchema) {
-                            if (null !== $localSchema->getClass($classGuess->getClassReference())) {
-                                $localNamespace = $localSchema->getNamespace() . '\\Validator';
+                            if (null !== ($referencedClass = $localSchema->getClass($classGuess->getClassReference()))) {
+                                $localNamespace = $this->naming->getValidatorNamespace($localSchema->getNamespace(), $referencedClass->getSubNamespace());
                             }
                         }
                     }
@@ -126,7 +127,7 @@ class ValidatorGenerator implements GeneratorInterface
             );
 
             $namespaceStmt = new Node\Stmt\Namespace_(new Node\Name($namespace), [$class]);
-            $schema->addFile(new File($schema->getDirectory() . '/Validator/' . $className . '.php', $namespaceStmt, self::FILE_TYPE_VALIDATOR));
+            $schema->addFile(new File($this->naming->getArtifactPath($schema->getDirectory(), 'Validator', $subNamespace) . '/' . $className . '.php', $namespaceStmt, self::FILE_TYPE_VALIDATOR));
         }
     }
 

--- a/src/Component/JsonSchema/Guesser/Guess/ClassGuess.php
+++ b/src/Component/JsonSchema/Guesser/Guess/ClassGuess.php
@@ -13,6 +13,8 @@ class ClassGuess
     /** @var array<Type> */
     private array $extensionsType = [];
     private array $constraints = [];
+    /** @var string[] Sub-namespace segments appended after "Model", "Normalizer", ... when the artifact declares an "x-namespace" extension */
+    private array $subNamespace = [];
 
     /**
      * @param object $object Object link to the generation
@@ -40,6 +42,22 @@ class ClassGuess
     public function getReference(): string
     {
         return $this->reference;
+    }
+
+    /**
+     * @return string[] Sub-namespace segments (already sanitized), empty when the artifact uses the flat layout
+     */
+    public function getSubNamespace(): array
+    {
+        return $this->subNamespace;
+    }
+
+    /**
+     * @param string[] $subNamespace
+     */
+    public function setSubNamespace(array $subNamespace): void
+    {
+        $this->subNamespace = $subNamespace;
     }
 
     /**

--- a/src/Component/JsonSchema/Guesser/Guess/EnumType.php
+++ b/src/Component/JsonSchema/Guesser/Guess/EnumType.php
@@ -10,11 +10,15 @@ use PhpParser\Node\Name\FullyQualified;
 
 class EnumType extends Type
 {
+    /**
+     * @param string[] $subNamespace Sub-namespace segments of the enum inside "Model"
+     */
     public function __construct(
         ?object $object,
         string $backingType,
         private readonly string $className,
         private readonly string $namespace,
+        private readonly array $subNamespace = [],
     ) {
         parent::__construct($object, $backingType);
     }
@@ -64,10 +68,12 @@ class EnumType extends Type
 
     private function getFqdn(bool $withRoot = true): string
     {
+        $subNamespaceSuffix = [] === $this->subNamespace ? '' : '\\' . implode('\\', $this->subNamespace);
+
         if ($withRoot) {
-            return '\\' . $this->namespace . '\\Model\\' . $this->className;
+            return '\\' . $this->namespace . '\\Model' . $subNamespaceSuffix . '\\' . $this->className;
         }
 
-        return $this->namespace . '\\Model\\' . $this->className;
+        return $this->namespace . '\\Model' . $subNamespaceSuffix . '\\' . $this->className;
     }
 }

--- a/src/Component/JsonSchema/Guesser/Guess/ObjectType.php
+++ b/src/Component/JsonSchema/Guesser/Guess/ObjectType.php
@@ -15,12 +15,14 @@ class ObjectType extends Type
 {
     /**
      * @param array<string, array<string>|null> $discriminants
+     * @param string[]                          $subNamespace  Sub-namespace segments of the model inside "Model"
      */
     public function __construct(
         object $object,
         private readonly string $className,
         private readonly string $namespace,
         private readonly array $discriminants = [],
+        private readonly array $subNamespace = [],
     ) {
         parent::__construct($object, 'object');
     }
@@ -126,17 +128,33 @@ class ObjectType extends Type
         return $this->className;
     }
 
+    /**
+     * @return string[]
+     */
+    public function getSubNamespace(): array
+    {
+        return $this->subNamespace;
+    }
+
     public function getFqdn(bool $withRoot = true): string
     {
         if ($withRoot) {
-            return '\\' . $this->namespace . '\\Model\\' . $this->className;
+            return '\\' . $this->getFqdn(false);
         }
 
-        return $this->namespace . '\\Model\\' . $this->className;
+        return $this->namespace . '\\Model' . $this->getSubNamespaceSuffix() . '\\' . $this->className;
     }
 
     public function getNamespace(): string
     {
         return $this->namespace;
+    }
+
+    /**
+     * @return string "\"-prefixed sub-namespace (e.g. "\Users"), empty string when the model uses the flat layout
+     */
+    private function getSubNamespaceSuffix(): string
+    {
+        return [] === $this->subNamespace ? '' : '\\' . implode('\\', $this->subNamespace);
     }
 }

--- a/src/Component/JsonSchema/Guesser/JsonSchema/AllOfGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/AllOfGuesser.php
@@ -116,7 +116,7 @@ class AllOfGuesser implements GuesserInterface, TypeGuesserInterface, ChainGuess
                 throw new \RuntimeException("Schema for reference $reference could not be found");
             }
 
-            return new ObjectType($object, $class->getName(), $schema->getNamespace());
+            return new ObjectType($object, $class->getName(), $schema->getNamespace(), [], $class->getSubNamespace());
         }
 
         foreach ($object->getAllOf() as $allOfIndex => $allOf) {

--- a/src/Component/JsonSchema/Guesser/JsonSchema/EnumGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/EnumGuesser.php
@@ -74,7 +74,8 @@ class EnumGuesser implements GuesserInterface, ClassGuesserInterface, TypeGuesse
                 $object,
                 $backingType,
                 $classGuess->getName(),
-                $schema->getNamespace()
+                $schema->getNamespace(),
+                $classGuess->getSubNamespace()
             );
         }
 

--- a/src/Component/JsonSchema/Guesser/JsonSchema/ObjectGuesser.php
+++ b/src/Component/JsonSchema/Guesser/JsonSchema/ObjectGuesser.php
@@ -208,7 +208,7 @@ class ObjectGuesser implements GuesserInterface, PropertiesGuesserInterface, Typ
         }
 
         if ($registry->hasClass($reference) && null !== ($schema = $registry->getSchema($reference))) {
-            return new ObjectType($object, $registry->getClass($reference)->getName(), $schema->getNamespace(), $discriminants);
+            return new ObjectType($object, $registry->getClass($reference)->getName(), $schema->getNamespace(), $discriminants, $registry->getClass($reference)->getSubNamespace());
         }
 
         return new Type($object, 'object');

--- a/src/Component/JsonSchema/JsonSchema/Model/JsonSchema.php
+++ b/src/Component/JsonSchema/JsonSchema/Model/JsonSchema.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\JsonSchema\JsonSchema\Model;
 
-class JsonSchema
+class JsonSchema extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/JsonSchema/JsonSchema/Normalizer/JsonSchemaNormalizer.php
+++ b/src/Component/JsonSchema/JsonSchema/Normalizer/JsonSchemaNormalizer.php
@@ -69,39 +69,51 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         }
         if (\array_key_exists('$id', $data) && $data['$id'] !== null) {
             $object->setDollarId($data['$id']);
+            unset($data['$id']);
         }
         elseif (\array_key_exists('$id', $data) && $data['$id'] === null) {
             $object->setDollarId(null);
+            unset($data['$id']);
         }
         if (\array_key_exists('$schema', $data) && $data['$schema'] !== null) {
             $object->setDollarSchema($data['$schema']);
+            unset($data['$schema']);
         }
         elseif (\array_key_exists('$schema', $data) && $data['$schema'] === null) {
             $object->setDollarSchema(null);
+            unset($data['$schema']);
         }
         if (\array_key_exists('$ref', $data) && $data['$ref'] !== null) {
             $object->setDollarRef($data['$ref']);
+            unset($data['$ref']);
         }
         elseif (\array_key_exists('$ref', $data) && $data['$ref'] === null) {
             $object->setDollarRef(null);
+            unset($data['$ref']);
         }
         if (\array_key_exists('$anchor', $data) && $data['$anchor'] !== null) {
             $object->setDollarAnchor($data['$anchor']);
+            unset($data['$anchor']);
         }
         elseif (\array_key_exists('$anchor', $data) && $data['$anchor'] === null) {
             $object->setDollarAnchor(null);
+            unset($data['$anchor']);
         }
         if (\array_key_exists('$dynamicRef', $data) && $data['$dynamicRef'] !== null) {
             $object->setDollarDynamicRef($data['$dynamicRef']);
+            unset($data['$dynamicRef']);
         }
         elseif (\array_key_exists('$dynamicRef', $data) && $data['$dynamicRef'] === null) {
             $object->setDollarDynamicRef(null);
+            unset($data['$dynamicRef']);
         }
         if (\array_key_exists('$dynamicAnchor', $data) && $data['$dynamicAnchor'] !== null) {
             $object->setDollarDynamicAnchor($data['$dynamicAnchor']);
+            unset($data['$dynamicAnchor']);
         }
         elseif (\array_key_exists('$dynamicAnchor', $data) && $data['$dynamicAnchor'] === null) {
             $object->setDollarDynamicAnchor(null);
+            unset($data['$dynamicAnchor']);
         }
         if (\array_key_exists('$vocabulary', $data) && $data['$vocabulary'] !== null) {
             $values = new \Jane\Component\JsonSchema\JsonSchema\Runtime\JsonObject();
@@ -109,15 +121,19 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values[$key] = $value;
             }
             $object->setDollarVocabulary($values);
+            unset($data['$vocabulary']);
         }
         elseif (\array_key_exists('$vocabulary', $data) && $data['$vocabulary'] === null) {
             $object->setDollarVocabulary(null);
+            unset($data['$vocabulary']);
         }
         if (\array_key_exists('$comment', $data) && $data['$comment'] !== null) {
             $object->setDollarComment($data['$comment']);
+            unset($data['$comment']);
         }
         elseif (\array_key_exists('$comment', $data) && $data['$comment'] === null) {
             $object->setDollarComment(null);
+            unset($data['$comment']);
         }
         if (\array_key_exists('$defs', $data) && $data['$defs'] !== null) {
             $values_1 = new \Jane\Component\JsonSchema\JsonSchema\Runtime\JsonObject();
@@ -131,9 +147,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_1[$key_1] = $value_2;
             }
             $object->setDollarDefs($values_1);
+            unset($data['$defs']);
         }
         elseif (\array_key_exists('$defs', $data) && $data['$defs'] === null) {
             $object->setDollarDefs(null);
+            unset($data['$defs']);
         }
         if (\array_key_exists('prefixItems', $data) && $data['prefixItems'] !== null) {
             $values_2 = [];
@@ -147,9 +165,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_2[] = $value_4;
             }
             $object->setPrefixItems($values_2);
+            unset($data['prefixItems']);
         }
         elseif (\array_key_exists('prefixItems', $data) && $data['prefixItems'] === null) {
             $object->setPrefixItems(null);
+            unset($data['prefixItems']);
         }
         if (\array_key_exists('items', $data) && $data['items'] !== null) {
             $value_5 = $data['items'];
@@ -171,9 +191,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_5 = $values_3;
             }
             $object->setItems($value_5);
+            unset($data['items']);
         }
         elseif (\array_key_exists('items', $data) && $data['items'] === null) {
             $object->setItems(null);
+            unset($data['items']);
         }
         if (\array_key_exists('contains', $data) && $data['contains'] !== null) {
             $value_8 = $data['contains'];
@@ -183,9 +205,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_8 = $data['contains'];
             }
             $object->setContains($value_8);
+            unset($data['contains']);
         }
         elseif (\array_key_exists('contains', $data) && $data['contains'] === null) {
             $object->setContains(null);
+            unset($data['contains']);
         }
         if (\array_key_exists('additionalProperties', $data) && $data['additionalProperties'] !== null) {
             $value_9 = $data['additionalProperties'];
@@ -195,9 +219,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_9 = $data['additionalProperties'];
             }
             $object->setAdditionalProperties($value_9);
+            unset($data['additionalProperties']);
         }
         elseif (\array_key_exists('additionalProperties', $data) && $data['additionalProperties'] === null) {
             $object->setAdditionalProperties(null);
+            unset($data['additionalProperties']);
         }
         if (\array_key_exists('properties', $data) && $data['properties'] !== null) {
             $values_4 = new \Jane\Component\JsonSchema\JsonSchema\Runtime\JsonObject();
@@ -211,9 +237,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_4[$key_2] = $value_11;
             }
             $object->setProperties($values_4);
+            unset($data['properties']);
         }
         elseif (\array_key_exists('properties', $data) && $data['properties'] === null) {
             $object->setProperties(null);
+            unset($data['properties']);
         }
         if (\array_key_exists('patternProperties', $data) && $data['patternProperties'] !== null) {
             $values_5 = new \Jane\Component\JsonSchema\JsonSchema\Runtime\JsonObject();
@@ -227,9 +255,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_5[$key_3] = $value_13;
             }
             $object->setPatternProperties($values_5);
+            unset($data['patternProperties']);
         }
         elseif (\array_key_exists('patternProperties', $data) && $data['patternProperties'] === null) {
             $object->setPatternProperties(null);
+            unset($data['patternProperties']);
         }
         if (\array_key_exists('dependentSchemas', $data) && $data['dependentSchemas'] !== null) {
             $values_6 = new \Jane\Component\JsonSchema\JsonSchema\Runtime\JsonObject();
@@ -243,9 +273,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_6[$key_4] = $value_15;
             }
             $object->setDependentSchemas($values_6);
+            unset($data['dependentSchemas']);
         }
         elseif (\array_key_exists('dependentSchemas', $data) && $data['dependentSchemas'] === null) {
             $object->setDependentSchemas(null);
+            unset($data['dependentSchemas']);
         }
         if (\array_key_exists('propertyNames', $data) && $data['propertyNames'] !== null) {
             $value_16 = $data['propertyNames'];
@@ -255,9 +287,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_16 = $data['propertyNames'];
             }
             $object->setPropertyNames($value_16);
+            unset($data['propertyNames']);
         }
         elseif (\array_key_exists('propertyNames', $data) && $data['propertyNames'] === null) {
             $object->setPropertyNames(null);
+            unset($data['propertyNames']);
         }
         if (\array_key_exists('if', $data) && $data['if'] !== null) {
             $value_17 = $data['if'];
@@ -267,9 +301,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_17 = $data['if'];
             }
             $object->setIf($value_17);
+            unset($data['if']);
         }
         elseif (\array_key_exists('if', $data) && $data['if'] === null) {
             $object->setIf(null);
+            unset($data['if']);
         }
         if (\array_key_exists('then', $data) && $data['then'] !== null) {
             $value_18 = $data['then'];
@@ -279,9 +315,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_18 = $data['then'];
             }
             $object->setThen($value_18);
+            unset($data['then']);
         }
         elseif (\array_key_exists('then', $data) && $data['then'] === null) {
             $object->setThen(null);
+            unset($data['then']);
         }
         if (\array_key_exists('else', $data) && $data['else'] !== null) {
             $value_19 = $data['else'];
@@ -291,9 +329,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_19 = $data['else'];
             }
             $object->setElse($value_19);
+            unset($data['else']);
         }
         elseif (\array_key_exists('else', $data) && $data['else'] === null) {
             $object->setElse(null);
+            unset($data['else']);
         }
         if (\array_key_exists('allOf', $data) && $data['allOf'] !== null) {
             $values_7 = [];
@@ -307,9 +347,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_7[] = $value_21;
             }
             $object->setAllOf($values_7);
+            unset($data['allOf']);
         }
         elseif (\array_key_exists('allOf', $data) && $data['allOf'] === null) {
             $object->setAllOf(null);
+            unset($data['allOf']);
         }
         if (\array_key_exists('anyOf', $data) && $data['anyOf'] !== null) {
             $values_8 = [];
@@ -323,9 +365,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_8[] = $value_23;
             }
             $object->setAnyOf($values_8);
+            unset($data['anyOf']);
         }
         elseif (\array_key_exists('anyOf', $data) && $data['anyOf'] === null) {
             $object->setAnyOf(null);
+            unset($data['anyOf']);
         }
         if (\array_key_exists('oneOf', $data) && $data['oneOf'] !== null) {
             $values_9 = [];
@@ -339,9 +383,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_9[] = $value_25;
             }
             $object->setOneOf($values_9);
+            unset($data['oneOf']);
         }
         elseif (\array_key_exists('oneOf', $data) && $data['oneOf'] === null) {
             $object->setOneOf(null);
+            unset($data['oneOf']);
         }
         if (\array_key_exists('not', $data) && $data['not'] !== null) {
             $value_26 = $data['not'];
@@ -351,9 +397,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_26 = $data['not'];
             }
             $object->setNot($value_26);
+            unset($data['not']);
         }
         elseif (\array_key_exists('not', $data) && $data['not'] === null) {
             $object->setNot(null);
+            unset($data['not']);
         }
         if (\array_key_exists('unevaluatedItems', $data) && $data['unevaluatedItems'] !== null) {
             $value_27 = $data['unevaluatedItems'];
@@ -363,9 +411,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_27 = $data['unevaluatedItems'];
             }
             $object->setUnevaluatedItems($value_27);
+            unset($data['unevaluatedItems']);
         }
         elseif (\array_key_exists('unevaluatedItems', $data) && $data['unevaluatedItems'] === null) {
             $object->setUnevaluatedItems(null);
+            unset($data['unevaluatedItems']);
         }
         if (\array_key_exists('unevaluatedProperties', $data) && $data['unevaluatedProperties'] !== null) {
             $value_28 = $data['unevaluatedProperties'];
@@ -375,9 +425,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_28 = $data['unevaluatedProperties'];
             }
             $object->setUnevaluatedProperties($value_28);
+            unset($data['unevaluatedProperties']);
         }
         elseif (\array_key_exists('unevaluatedProperties', $data) && $data['unevaluatedProperties'] === null) {
             $object->setUnevaluatedProperties(null);
+            unset($data['unevaluatedProperties']);
         }
         if (\array_key_exists('type', $data) && $data['type'] !== null) {
             $value_29 = $data['type'];
@@ -391,15 +443,19 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_29 = $data['type'];
             }
             $object->setType($value_29);
+            unset($data['type']);
         }
         elseif (\array_key_exists('type', $data) && $data['type'] === null) {
             $object->setType(null);
+            unset($data['type']);
         }
         if (\array_key_exists('const', $data) && $data['const'] !== null) {
             $object->setConst($data['const']);
+            unset($data['const']);
         }
         elseif (\array_key_exists('const', $data) && $data['const'] === null) {
             $object->setConst(null);
+            unset($data['const']);
         }
         if (\array_key_exists('enum', $data) && $data['enum'] !== null) {
             $values_11 = [];
@@ -407,99 +463,131 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_11[] = $value_31;
             }
             $object->setEnum($values_11);
+            unset($data['enum']);
         }
         elseif (\array_key_exists('enum', $data) && $data['enum'] === null) {
             $object->setEnum(null);
+            unset($data['enum']);
         }
         if (\array_key_exists('multipleOf', $data) && $data['multipleOf'] !== null) {
             $object->setMultipleOf($data['multipleOf']);
+            unset($data['multipleOf']);
         }
         elseif (\array_key_exists('multipleOf', $data) && $data['multipleOf'] === null) {
             $object->setMultipleOf(null);
+            unset($data['multipleOf']);
         }
         if (\array_key_exists('maximum', $data) && $data['maximum'] !== null) {
             $object->setMaximum($data['maximum']);
+            unset($data['maximum']);
         }
         elseif (\array_key_exists('maximum', $data) && $data['maximum'] === null) {
             $object->setMaximum(null);
+            unset($data['maximum']);
         }
         if (\array_key_exists('exclusiveMaximum', $data) && $data['exclusiveMaximum'] !== null) {
             $object->setExclusiveMaximum($data['exclusiveMaximum']);
+            unset($data['exclusiveMaximum']);
         }
         elseif (\array_key_exists('exclusiveMaximum', $data) && $data['exclusiveMaximum'] === null) {
             $object->setExclusiveMaximum(null);
+            unset($data['exclusiveMaximum']);
         }
         if (\array_key_exists('minimum', $data) && $data['minimum'] !== null) {
             $object->setMinimum($data['minimum']);
+            unset($data['minimum']);
         }
         elseif (\array_key_exists('minimum', $data) && $data['minimum'] === null) {
             $object->setMinimum(null);
+            unset($data['minimum']);
         }
         if (\array_key_exists('exclusiveMinimum', $data) && $data['exclusiveMinimum'] !== null) {
             $object->setExclusiveMinimum($data['exclusiveMinimum']);
+            unset($data['exclusiveMinimum']);
         }
         elseif (\array_key_exists('exclusiveMinimum', $data) && $data['exclusiveMinimum'] === null) {
             $object->setExclusiveMinimum(null);
+            unset($data['exclusiveMinimum']);
         }
         if (\array_key_exists('maxLength', $data) && $data['maxLength'] !== null) {
             $object->setMaxLength($data['maxLength']);
+            unset($data['maxLength']);
         }
         elseif (\array_key_exists('maxLength', $data) && $data['maxLength'] === null) {
             $object->setMaxLength(null);
+            unset($data['maxLength']);
         }
         if (\array_key_exists('minLength', $data) && $data['minLength'] !== null) {
             $object->setMinLength($data['minLength']);
+            unset($data['minLength']);
         }
         elseif (\array_key_exists('minLength', $data) && $data['minLength'] === null) {
             $object->setMinLength(null);
+            unset($data['minLength']);
         }
         if (\array_key_exists('pattern', $data) && $data['pattern'] !== null) {
             $object->setPattern($data['pattern']);
+            unset($data['pattern']);
         }
         elseif (\array_key_exists('pattern', $data) && $data['pattern'] === null) {
             $object->setPattern(null);
+            unset($data['pattern']);
         }
         if (\array_key_exists('maxItems', $data) && $data['maxItems'] !== null) {
             $object->setMaxItems($data['maxItems']);
+            unset($data['maxItems']);
         }
         elseif (\array_key_exists('maxItems', $data) && $data['maxItems'] === null) {
             $object->setMaxItems(null);
+            unset($data['maxItems']);
         }
         if (\array_key_exists('minItems', $data) && $data['minItems'] !== null) {
             $object->setMinItems($data['minItems']);
+            unset($data['minItems']);
         }
         elseif (\array_key_exists('minItems', $data) && $data['minItems'] === null) {
             $object->setMinItems(null);
+            unset($data['minItems']);
         }
         if (\array_key_exists('uniqueItems', $data) && $data['uniqueItems'] !== null) {
             $object->setUniqueItems($data['uniqueItems']);
+            unset($data['uniqueItems']);
         }
         elseif (\array_key_exists('uniqueItems', $data) && $data['uniqueItems'] === null) {
             $object->setUniqueItems(null);
+            unset($data['uniqueItems']);
         }
         if (\array_key_exists('maxContains', $data) && $data['maxContains'] !== null) {
             $object->setMaxContains($data['maxContains']);
+            unset($data['maxContains']);
         }
         elseif (\array_key_exists('maxContains', $data) && $data['maxContains'] === null) {
             $object->setMaxContains(null);
+            unset($data['maxContains']);
         }
         if (\array_key_exists('minContains', $data) && $data['minContains'] !== null) {
             $object->setMinContains($data['minContains']);
+            unset($data['minContains']);
         }
         elseif (\array_key_exists('minContains', $data) && $data['minContains'] === null) {
             $object->setMinContains(null);
+            unset($data['minContains']);
         }
         if (\array_key_exists('maxProperties', $data) && $data['maxProperties'] !== null) {
             $object->setMaxProperties($data['maxProperties']);
+            unset($data['maxProperties']);
         }
         elseif (\array_key_exists('maxProperties', $data) && $data['maxProperties'] === null) {
             $object->setMaxProperties(null);
+            unset($data['maxProperties']);
         }
         if (\array_key_exists('minProperties', $data) && $data['minProperties'] !== null) {
             $object->setMinProperties($data['minProperties']);
+            unset($data['minProperties']);
         }
         elseif (\array_key_exists('minProperties', $data) && $data['minProperties'] === null) {
             $object->setMinProperties(null);
+            unset($data['minProperties']);
         }
         if (\array_key_exists('required', $data) && $data['required'] !== null) {
             $values_12 = [];
@@ -507,9 +595,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_12[] = $value_32;
             }
             $object->setRequired($values_12);
+            unset($data['required']);
         }
         elseif (\array_key_exists('required', $data) && $data['required'] === null) {
             $object->setRequired(null);
+            unset($data['required']);
         }
         if (\array_key_exists('dependentRequired', $data) && $data['dependentRequired'] !== null) {
             $values_13 = new \Jane\Component\JsonSchema\JsonSchema\Runtime\JsonObject();
@@ -521,45 +611,59 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_13[$key_5] = $values_14;
             }
             $object->setDependentRequired($values_13);
+            unset($data['dependentRequired']);
         }
         elseif (\array_key_exists('dependentRequired', $data) && $data['dependentRequired'] === null) {
             $object->setDependentRequired(null);
+            unset($data['dependentRequired']);
         }
         if (\array_key_exists('title', $data) && $data['title'] !== null) {
             $object->setTitle($data['title']);
+            unset($data['title']);
         }
         elseif (\array_key_exists('title', $data) && $data['title'] === null) {
             $object->setTitle(null);
+            unset($data['title']);
         }
         if (\array_key_exists('description', $data) && $data['description'] !== null) {
             $object->setDescription($data['description']);
+            unset($data['description']);
         }
         elseif (\array_key_exists('description', $data) && $data['description'] === null) {
             $object->setDescription(null);
+            unset($data['description']);
         }
         if (\array_key_exists('default', $data) && $data['default'] !== null) {
             $object->setDefault($data['default']);
+            unset($data['default']);
         }
         elseif (\array_key_exists('default', $data) && $data['default'] === null) {
             $object->setDefault(null);
+            unset($data['default']);
         }
         if (\array_key_exists('deprecated', $data) && $data['deprecated'] !== null) {
             $object->setDeprecated($data['deprecated']);
+            unset($data['deprecated']);
         }
         elseif (\array_key_exists('deprecated', $data) && $data['deprecated'] === null) {
             $object->setDeprecated(null);
+            unset($data['deprecated']);
         }
         if (\array_key_exists('readOnly', $data) && $data['readOnly'] !== null) {
             $object->setReadOnly($data['readOnly']);
+            unset($data['readOnly']);
         }
         elseif (\array_key_exists('readOnly', $data) && $data['readOnly'] === null) {
             $object->setReadOnly(null);
+            unset($data['readOnly']);
         }
         if (\array_key_exists('writeOnly', $data) && $data['writeOnly'] !== null) {
             $object->setWriteOnly($data['writeOnly']);
+            unset($data['writeOnly']);
         }
         elseif (\array_key_exists('writeOnly', $data) && $data['writeOnly'] === null) {
             $object->setWriteOnly(null);
+            unset($data['writeOnly']);
         }
         if (\array_key_exists('examples', $data) && $data['examples'] !== null) {
             $values_15 = [];
@@ -567,27 +671,35 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_15[] = $value_35;
             }
             $object->setExamples($values_15);
+            unset($data['examples']);
         }
         elseif (\array_key_exists('examples', $data) && $data['examples'] === null) {
             $object->setExamples(null);
+            unset($data['examples']);
         }
         if (\array_key_exists('format', $data) && $data['format'] !== null) {
             $object->setFormat($data['format']);
+            unset($data['format']);
         }
         elseif (\array_key_exists('format', $data) && $data['format'] === null) {
             $object->setFormat(null);
+            unset($data['format']);
         }
         if (\array_key_exists('contentEncoding', $data) && $data['contentEncoding'] !== null) {
             $object->setContentEncoding($data['contentEncoding']);
+            unset($data['contentEncoding']);
         }
         elseif (\array_key_exists('contentEncoding', $data) && $data['contentEncoding'] === null) {
             $object->setContentEncoding(null);
+            unset($data['contentEncoding']);
         }
         if (\array_key_exists('contentMediaType', $data) && $data['contentMediaType'] !== null) {
             $object->setContentMediaType($data['contentMediaType']);
+            unset($data['contentMediaType']);
         }
         elseif (\array_key_exists('contentMediaType', $data) && $data['contentMediaType'] === null) {
             $object->setContentMediaType(null);
+            unset($data['contentMediaType']);
         }
         if (\array_key_exists('contentSchema', $data) && $data['contentSchema'] !== null) {
             $value_36 = $data['contentSchema'];
@@ -597,9 +709,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_36 = $data['contentSchema'];
             }
             $object->setContentSchema($value_36);
+            unset($data['contentSchema']);
         }
         elseif (\array_key_exists('contentSchema', $data) && $data['contentSchema'] === null) {
             $object->setContentSchema(null);
+            unset($data['contentSchema']);
         }
         if (\array_key_exists('definitions', $data) && $data['definitions'] !== null) {
             $values_16 = new \Jane\Component\JsonSchema\JsonSchema\Runtime\JsonObject();
@@ -613,9 +727,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_16[$key_6] = $value_38;
             }
             $object->setDefinitions($values_16);
+            unset($data['definitions']);
         }
         elseif (\array_key_exists('definitions', $data) && $data['definitions'] === null) {
             $object->setDefinitions(null);
+            unset($data['definitions']);
         }
         if (\array_key_exists('dependencies', $data) && $data['dependencies'] !== null) {
             $values_17 = new \Jane\Component\JsonSchema\JsonSchema\Runtime\JsonObject();
@@ -635,21 +751,27 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $values_17[$key_7] = $value_40;
             }
             $object->setDependencies($values_17);
+            unset($data['dependencies']);
         }
         elseif (\array_key_exists('dependencies', $data) && $data['dependencies'] === null) {
             $object->setDependencies(null);
+            unset($data['dependencies']);
         }
         if (\array_key_exists('$recursiveAnchor', $data) && $data['$recursiveAnchor'] !== null) {
             $object->setDollarRecursiveAnchor($data['$recursiveAnchor']);
+            unset($data['$recursiveAnchor']);
         }
         elseif (\array_key_exists('$recursiveAnchor', $data) && $data['$recursiveAnchor'] === null) {
             $object->setDollarRecursiveAnchor(null);
+            unset($data['$recursiveAnchor']);
         }
         if (\array_key_exists('$recursiveRef', $data) && $data['$recursiveRef'] !== null) {
             $object->setDollarRecursiveRef($data['$recursiveRef']);
+            unset($data['$recursiveRef']);
         }
         elseif (\array_key_exists('$recursiveRef', $data) && $data['$recursiveRef'] === null) {
             $object->setDollarRecursiveRef(null);
+            unset($data['$recursiveRef']);
         }
         if (\array_key_exists('additionalItems', $data) && $data['additionalItems'] !== null) {
             $value_42 = $data['additionalItems'];
@@ -659,9 +781,16 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
                 $value_42 = $data['additionalItems'];
             }
             $object->setAdditionalItems($value_42);
+            unset($data['additionalItems']);
         }
         elseif (\array_key_exists('additionalItems', $data) && $data['additionalItems'] === null) {
             $object->setAdditionalItems(null);
+            unset($data['additionalItems']);
+        }
+        foreach ($data as $key_8 => $value_43) {
+            if (preg_match('/^x-/', (string) $key_8)) {
+                $object[$key_8] = $value_43;
+            }
         }
         return $object;
     }
@@ -1263,6 +1392,11 @@ class JsonSchemaNormalizer implements DenormalizerInterface, NormalizerInterface
         }
         else {
             $dataArray['additionalItems'] = null;
+        }
+        foreach ($data as $key_8 => $value_43) {
+            if (preg_match('/^x-/', (string) $key_8)) {
+                $dataArray[$key_8] = $value_43;
+            }
         }
         return $dataArray;
     }

--- a/src/Component/JsonSchema/Tests/data/json-schema.json
+++ b/src/Component/JsonSchema/Tests/data/json-schema.json
@@ -205,6 +205,9 @@
             "deprecated": true
         }
     },
+    "patternProperties": {
+        "^x-": {}
+    },
     "$defs": {
         "anchorString": {
             "type": "string",

--- a/src/Component/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi2/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -10,6 +10,7 @@ use Jane\Component\OpenApi2\JsonSchema\Model\Schema;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
 use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
+use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
 use Jane\Component\OpenApiCommon\Registry\Registry;
 use PhpParser\Comment\Doc;
 use PhpParser\Modifiers;
@@ -128,7 +129,7 @@ EOD
         $class = null;
 
         if (null !== $classGuess) {
-            $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model\\' . $classGuess->getName();
+            $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model' . XNamespaceResolver::subNamespaceSuffix($classGuess) . '\\' . $classGuess->getName();
 
             if ($array) {
                 $class .= '[]';

--- a/src/Component/OpenApi2/Generator/EndpointGenerator.php
+++ b/src/Component/OpenApi2/Generator/EndpointGenerator.php
@@ -96,10 +96,14 @@ class EndpointGenerator implements EndpointGeneratorInterface
         $class->stmts[] = $transformBodyMethod;
         $class->stmts[] = $this->getAuthenticationScopesMethod($operation);
 
+        $subNamespace = $operation->getSubNamespace();
+        $endpointPath = $naming->getArtifactPath($context->getCurrentSchema()->getDirectory(), 'Endpoint', $subNamespace);
+        $endpointNamespace = $naming->getEndpointNamespace($context->getCurrentSchema()->getNamespace(), $subNamespace);
+
         $file = new File(
-            $context->getCurrentSchema()->getDirectory() . \DIRECTORY_SEPARATOR . 'Endpoint' . \DIRECTORY_SEPARATOR . $endpointName . '.php',
+            $endpointPath . \DIRECTORY_SEPARATOR . $endpointName . '.php',
             new Stmt\Namespace_(
-                new Name($context->getCurrentSchema()->getNamespace() . '\\Endpoint'),
+                new Name($endpointNamespace),
                 [
                     $class,
                 ]
@@ -109,6 +113,6 @@ class EndpointGenerator implements EndpointGeneratorInterface
 
         $context->getCurrentSchema()->addFile($file);
 
-        return [$context->getCurrentSchema()->getNamespace() . '\\Endpoint\\' . $endpointName, $methodParams, $methodParamsDoc, $outputTypes, $throwTypes];
+        return [$endpointNamespace . '\\' . $endpointName, $methodParams, $methodParamsDoc, $outputTypes, $throwTypes];
     }
 }

--- a/src/Component/OpenApi2/Generator/Parameter/BodyParameterGenerator.php
+++ b/src/Component/OpenApi2/Generator/Parameter/BodyParameterGenerator.php
@@ -3,6 +3,7 @@
 namespace Jane\Component\OpenApi2\Generator\Parameter;
 
 use Jane\Component\JsonSchema\Generator\Context\Context;
+use Jane\Component\JsonSchema\Guesser\Guess\ClassGuess as BaseClassGuess;
 use Jane\Component\JsonSchemaRuntime\Reference;
 use Jane\Component\OpenApi2\Guesser\GuessClass;
 use Jane\Component\OpenApi2\JsonSchema\Model\BodyParameter;
@@ -81,7 +82,9 @@ class BodyParameterGenerator extends ParameterGenerator
 
         if (null === $resolvedSchema) {
             if ($context->getRegistry()->hasClass($reference)) {
-                return [['\\' . $context->getRegistry()->getSchema($reference)->getNamespace() . '\\Model\\' . $context->getRegistry()->getClass($reference)->getName()], false];
+                $classGuess = $context->getRegistry()->getClass($reference);
+
+                return [['\\' . $this->getModelNamespace($context, $reference, $classGuess) . $classGuess->getName()], false];
             }
 
             return [$this->convertParameterType($schema->getType(), $schema->getFormat()), false];
@@ -98,13 +101,24 @@ class BodyParameterGenerator extends ParameterGenerator
             return [$this->convertParameterType($resolvedSchema->getType(), $resolvedSchema->getFormat()), false];
         }
 
-        $class = '\\' . $context->getRegistry()->getSchema($jsonReference)->getNamespace() . '\\Model\\' . $class->getName();
+        $class = '\\' . $this->getModelNamespace($context, $jsonReference, $class) . $class->getName();
 
         if ($array) {
             $class .= '[]';
         }
 
         return [[$class], $array];
+    }
+
+    /**
+     * Computes the model namespace (schema namespace + "Model" + sub-namespace of the guessed class).
+     */
+    private function getModelNamespace(Context $context, string $reference, ?BaseClassGuess $classGuess): string
+    {
+        $subNamespace = null !== $classGuess ? $classGuess->getSubNamespace() : [];
+        $suffix = [] === $subNamespace ? '\\Model\\' : '\\Model\\' . implode('\\', $subNamespace) . '\\';
+
+        return $context->getRegistry()->getSchema($reference)->getNamespace() . $suffix;
     }
 
     private function convertParameterType(string $type, ?string $format = null): array

--- a/src/Component/OpenApi2/Guesser/OpenApiSchema/OpenApiGuesser.php
+++ b/src/Component/OpenApi2/Guesser/OpenApiSchema/OpenApiGuesser.php
@@ -15,6 +15,7 @@ use Jane\Component\OpenApi2\JsonSchema\Model\Response;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
 use Jane\Component\OpenApiCommon\Naming\OperationNamingFactory;
 use Jane\Component\OpenApiCommon\Naming\OperationNamingInterface;
+use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
 use Jane\Component\OpenApiCommon\Registry\Registry as OpenApiRegistry;
 use Jane\Component\OpenApiCommon\Registry\Schema;
 
@@ -23,10 +24,12 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
     use ChainGuesserAwareTrait;
 
     private OperationNamingInterface $naming;
+    private XNamespaceResolver $xNamespaceResolver;
 
     public function __construct(?OperationNamingInterface $naming = null)
     {
         $this->naming = $naming ?? OperationNamingFactory::create();
+        $this->xNamespaceResolver = new XNamespaceResolver();
     }
 
     public function supportObject($object): bool
@@ -42,7 +45,9 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
     {
         if (null !== $object->getDefinitions()) {
             foreach ($object->getDefinitions() as $key => $definition) {
-                $this->chainGuesser->guessClass($definition, $key, $reference . '/definitions/' . $key, $registry);
+                $definitionReference = $reference . '/definitions/' . $key;
+                $this->chainGuesser->guessClass($definition, $key, $definitionReference, $registry);
+                $this->xNamespaceResolver->stampClassGuess($registry, $definitionReference, $definition);
             }
         }
         if (null !== $object->getSecurityDefinitions() && is_iterable($object->getSecurityDefinitions())) {
@@ -183,11 +188,17 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
         $schema->addOperation($reference, $operationGuess);
         $schema->initOperationRelations($operationName);
 
+        $operationSubNamespace = $this->xNamespaceResolver->resolveFromObject($operation);
+        $operationGuess->setSubNamespace($operationSubNamespace);
+
         if ($operation->getParameters()) {
             foreach ($operation->getParameters() as $key => $parameter) {
                 if ($parameter instanceof BodyParameter) {
                     $subReference = $reference . '/parameters/' . $key;
                     $this->chainGuesser->guessClass($parameter->getSchema(), $name . 'Body', $subReference, $registry);
+                    if (null !== $parameter->getSchema()) {
+                        $this->xNamespaceResolver->stampClassGuess($registry, $subReference, $parameter->getSchema());
+                    }
                     if (null !== ($guessClass = $schema->getClass($subReference))) {
                         $schema->addOperationRelation($operationName, $guessClass->getName());
                     }
@@ -200,11 +211,16 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
                 if ($response instanceof Response) {
                     $subReference = $reference . '/responses/' . $status;
                     $this->chainGuesser->guessClass($response->getSchema(), $name . 'Response' . $status, $subReference, $registry);
+                    if (null !== $response->getSchema()) {
+                        $this->xNamespaceResolver->stampClassGuess($registry, $subReference, $response->getSchema());
+                    }
                     if (null !== ($guessClass = $schema->getClass($subReference))) {
                         $schema->addOperationRelation($operationName, $guessClass->getName());
                     }
                 }
             }
         }
+
+        $this->xNamespaceResolver->propagateToOperationModels($schema, $operationGuess, $operationSubNamespace);
     }
 }

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/.jane-openapi
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.json',
+    'namespace' => 'Jane\Component\OpenApi2\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Client.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi2\Tests\Expected\Model\FlatItem : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getFlatItems(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Endpoint\GetFlatItems(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi2\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200 : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getNamespacedReport(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Endpoint\Admin\Reports\GetNamespacedReport(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi2\Tests\Expected\Model\Catalog\TaggedItem : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getTaggedItems(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi2\Tests\Expected\Endpoint\Ops\Monitoring\GetTaggedItems(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
+    {
+        $plugins = [];
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+        }
+        if ($applyServerPlugins) {
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+        }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi2\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Endpoint/Admin/Reports/GetNamespacedReport.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Endpoint/Admin/Reports/GetNamespacedReport.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Endpoint\Admin\Reports;
+
+class GetNamespacedReport extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/namespaced-report';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi2\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (200 === $status) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Endpoint/GetFlatItems.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Endpoint/GetFlatItems.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Endpoint;
+
+class GetFlatItems extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/flat-items';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi2\Tests\Expected\Model\FlatItem
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (200 === $status) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Expected\Model\FlatItem', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Endpoint/Ops/Monitoring/GetTaggedItems.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Endpoint/Ops/Monitoring/GetTaggedItems.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Endpoint\Ops\Monitoring;
+
+class GetTaggedItems extends \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi2\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/tagged-items';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi2\Tests\Expected\Model\Catalog\TaggedItem
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (200 === $status) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi2\Tests\Expected\Model\Catalog\TaggedItem', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Model/Admin/Reports/NamespacedReportGetResponse200.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Model/Admin/Reports/NamespacedReportGetResponse200.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Model\Admin\Reports;
+
+class NamespacedReportGetResponse200
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $title;
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+    /**
+     * @param string $title
+     *
+     * @return self
+     */
+    public function setTitle(string $title): self
+    {
+        $this->initialized['title'] = true;
+        $this->title = $title;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Model/Catalog/TaggedItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Model/Catalog/TaggedItem.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Model\Catalog;
+
+class TaggedItem
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $label;
+    /**
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+    /**
+     * @param string $label
+     *
+     * @return self
+     */
+    public function setLabel(string $label): self
+    {
+        $this->initialized['label'] = true;
+        $this->label = $label;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Model/FlatItem.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Model/FlatItem.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Model;
+
+class FlatItem
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Normalizer/Admin/Reports/NamespacedReportGetResponse200Normalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Normalizer/Admin/Reports/NamespacedReportGetResponse200Normalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Normalizer\Admin\Reports;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class NamespacedReportGetResponse200Normalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi2\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi2\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('title', $data)) {
+            $object->setTitle($data['title']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('title') && null !== $data->getTitle()) {
+            $dataArray['title'] = $data->getTitle();
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi2\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Normalizer/Catalog/TaggedItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Normalizer/Catalog/TaggedItemNormalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Normalizer\Catalog;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class TaggedItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi2\Tests\Expected\Model\Catalog\TaggedItem::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Expected\Model\Catalog\TaggedItem::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi2\Tests\Expected\Model\Catalog\TaggedItem();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('label', $data)) {
+            $object->setLabel($data['label']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('label') && null !== $data->getLabel()) {
+            $dataArray['label'] = $data->getLabel();
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi2\Tests\Expected\Model\Catalog\TaggedItem::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Normalizer/FlatItemNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Normalizer/FlatItemNormalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FlatItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi2\Tests\Expected\Model\FlatItem::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi2\Tests\Expected\Model\FlatItem::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi2\Tests\Expected\Model\FlatItem();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('name') && null !== $data->getName()) {
+            $dataArray['name'] = $data->getName();
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi2\Tests\Expected\Model\FlatItem::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi2\Tests\Expected\Model\FlatItem::class => \Jane\Component\OpenApi2\Tests\Expected\Normalizer\FlatItemNormalizer::class,
+        
+        \Jane\Component\OpenApi2\Tests\Expected\Model\Catalog\TaggedItem::class => \Jane\Component\OpenApi2\Tests\Expected\Normalizer\Catalog\TaggedItemNormalizer::class,
+        
+        \Jane\Component\OpenApi2\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class => \Jane\Component\OpenApi2\Tests\Expected\Normalizer\Admin\Reports\NamespacedReportGetResponse200Normalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return array_combine(array_keys($this->normalizers), array_fill(0, count($this->normalizers), false));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi2/Tests/fixtures/x-namespace/swagger.json
+++ b/src/Component/OpenApi2/Tests/fixtures/x-namespace/swagger.json
@@ -1,0 +1,79 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "x-namespace API",
+        "version": "1.0.0"
+    },
+    "host": "api.example.com",
+    "basePath": "/v1",
+    "schemes": [
+        "https"
+    ],
+    "paths": {
+        "/flat-items": {
+            "get": {
+                "operationId": "getFlatItems",
+                "responses": {
+                    "200": {
+                        "description": "A flat item",
+                        "schema": {
+                            "$ref": "#/definitions/FlatItem"
+                        }
+                    }
+                }
+            }
+        },
+        "/namespaced-report": {
+            "get": {
+                "operationId": "getNamespacedReport",
+                "x-namespace": "Admin\\Reports",
+                "responses": {
+                    "200": {
+                        "description": "An inline report model, namespaced by the operation extension",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/tagged-items": {
+            "get": {
+                "operationId": "getTaggedItems",
+                "x-namespace": "Ops\\Monitoring",
+                "responses": {
+                    "200": {
+                        "description": "A schema declaring its own x-namespace keeps it",
+                        "schema": {
+                            "$ref": "#/definitions/TaggedItem"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "FlatItem": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "TaggedItem": {
+            "type": "object",
+            "x-namespace": "Catalog",
+            "properties": {
+                "label": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -13,6 +13,7 @@ use Jane\Component\OpenApiCommon\Generator\ContentType;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
 use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
+use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
 use Jane\Component\OpenApiCommon\Registry\Registry;
 use PhpParser\Comment\Doc;
 use PhpParser\Modifiers;
@@ -298,7 +299,7 @@ EOD
         $class = null;
 
         if (null !== $classGuess) {
-            $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model\\' . $classGuess->getName();
+            $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model' . XNamespaceResolver::subNamespaceSuffix($classGuess) . '\\' . $classGuess->getName();
 
             if ($array) {
                 $class .= '[]';

--- a/src/Component/OpenApi3/Generator/EndpointGenerator.php
+++ b/src/Component/OpenApi3/Generator/EndpointGenerator.php
@@ -106,10 +106,14 @@ class EndpointGenerator implements EndpointGeneratorInterface
         $class->stmts[] = $transformBodyMethod;
         $class->stmts[] = $this->getAuthenticationScopesMethod($operation);
 
+        $subNamespace = $operation->getSubNamespace();
+        $endpointPath = $naming->getArtifactPath($context->getCurrentSchema()->getDirectory(), 'Endpoint', $subNamespace);
+        $endpointNamespace = $naming->getEndpointNamespace($context->getCurrentSchema()->getNamespace(), $subNamespace);
+
         $file = new File(
-            $context->getCurrentSchema()->getDirectory() . \DIRECTORY_SEPARATOR . 'Endpoint' . \DIRECTORY_SEPARATOR . $endpointName . '.php',
+            $endpointPath . \DIRECTORY_SEPARATOR . $endpointName . '.php',
             new Stmt\Namespace_(
-                new Name($context->getCurrentSchema()->getNamespace() . '\\Endpoint'),
+                new Name($endpointNamespace),
                 [
                     $class,
                 ]
@@ -119,6 +123,6 @@ class EndpointGenerator implements EndpointGeneratorInterface
 
         $context->getCurrentSchema()->addFile($file);
 
-        return [$context->getCurrentSchema()->getNamespace() . '\\Endpoint\\' . $endpointName, $methodParams, $methodParamsDoc, $outputTypes, $throwTypes];
+        return [$endpointNamespace . '\\' . $endpointName, $methodParams, $methodParamsDoc, $outputTypes, $throwTypes];
     }
 }

--- a/src/Component/OpenApi3/Generator/RequestBodyContent/AbstractBodyContentGenerator.php
+++ b/src/Component/OpenApi3/Generator/RequestBodyContent/AbstractBodyContentGenerator.php
@@ -7,6 +7,7 @@ use Jane\Component\OpenApi3\Generator\RequestBodyContentGeneratorInterface;
 use Jane\Component\OpenApi3\Guesser\GuessClass;
 use Jane\Component\OpenApi3\JsonSchema\Model\MediaType;
 use Jane\Component\OpenApi3\JsonSchema\Model\Schema;
+use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -41,7 +42,7 @@ abstract class AbstractBodyContentGenerator implements RequestBodyContentGenerat
             return [$types, $array];
         }
 
-        $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model\\' . $classGuess->getName();
+        $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model' . XNamespaceResolver::subNamespaceSuffix($classGuess) . '\\' . $classGuess->getName();
 
         if ($array) {
             $class .= '[]';
@@ -59,7 +60,7 @@ abstract class AbstractBodyContentGenerator implements RequestBodyContentGenerat
             return $this->typeToCondition($schema?->getType(), $schema?->getFormat(), new Expr\PropertyFetch(new Expr\Variable('this'), 'body'));
         }
 
-        $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model\\' . $classGuess->getName();
+        $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model' . XNamespaceResolver::subNamespaceSuffix($classGuess) . '\\' . $classGuess->getName();
 
         if ($array) {
             return new Expr\BinaryOp\LogicalAnd(

--- a/src/Component/OpenApi3/Guesser/OpenApiSchema/OpenApiGuesser.php
+++ b/src/Component/OpenApi3/Guesser/OpenApiSchema/OpenApiGuesser.php
@@ -20,6 +20,7 @@ use Jane\Component\OpenApi3\JsonSchema\Model\Schema;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
 use Jane\Component\OpenApiCommon\Naming\OperationNamingFactory;
 use Jane\Component\OpenApiCommon\Naming\OperationNamingInterface;
+use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
 use Jane\Component\OpenApiCommon\Registry\Registry as OpenApiRegistry;
 use Jane\Component\OpenApiCommon\Registry\Schema as OpenApiRegistrySchema;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -34,12 +35,14 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
     private const IN_BODY = 'body';
     private SluggerInterface $slugger;
     private OperationNamingInterface $naming;
+    private XNamespaceResolver $xNamespaceResolver;
 
     public function __construct(DenormalizerInterface $denormalizer, ?OperationNamingInterface $naming = null)
     {
         $this->denormalizer = $denormalizer;
         $this->slugger = new AsciiSlugger();
         $this->naming = $naming ?? OperationNamingFactory::create();
+        $this->xNamespaceResolver = new XNamespaceResolver();
     }
 
     public function supportObject($object): bool
@@ -55,7 +58,9 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
     {
         if ($object->getComponents() instanceof Components && is_iterable($object->getComponents()->getSchemas())) {
             foreach ($object->getComponents()->getSchemas() as $key => $definition) {
-                $this->chainGuesser->guessClass($definition, $key, $reference . '/components/schemas/' . $key, $registry);
+                $definitionReference = $reference . '/components/schemas/' . $key;
+                $this->chainGuesser->guessClass($definition, $key, $definitionReference, $registry);
+                $this->xNamespaceResolver->stampClassGuess($registry, $definitionReference, $definition);
             }
         }
         if ($object->getComponents() instanceof Components && is_iterable($object->getComponents()->getSecuritySchemes())) {
@@ -199,6 +204,9 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
         $operationGuess = new OperationGuess($pathItem, $operation, $path, $operationType, $reference, $securityScopes);
         $operationName = $this->naming->getEndpointName($operationGuess);
 
+        $operationSubNamespace = $this->xNamespaceResolver->resolveFromObject($operation);
+        $operationGuess->setSubNamespace($operationSubNamespace);
+
         /** @var OpenApiRegistrySchema|null $schema */
         $schema = $registry->getSchema($reference);
         if ($schema === null) {
@@ -212,6 +220,9 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
                 if ($parameter instanceof Parameter && self::IN_BODY === $parameter->getIn()) {
                     $subReference = $reference . '/parameters/' . $key;
                     $this->chainGuesser->guessClass($parameter->getSchema(), $name . 'Body', $subReference, $registry);
+                    if (null !== $parameter->getSchema()) {
+                        $this->xNamespaceResolver->stampClassGuess($registry, $subReference, $parameter->getSchema());
+                    }
                     if (null !== ($guessClass = $schema->getClass($subReference))) {
                         $schema->addOperationRelation($operationName, $guessClass->getName());
                     }
@@ -228,6 +239,9 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
             foreach ($operation->getRequestBody()->getContent() as $contentType => $content) {
                 $subReference = $reference . '/requestBody/content/' . $contentType . '/schema';
                 $this->chainGuesser->guessClass($content->getSchema(), $name . 'Body', $subReference, $registry);
+                if (null !== $content->getSchema()) {
+                    $this->xNamespaceResolver->stampClassGuess($registry, $subReference, $content->getSchema());
+                }
                 if (null !== ($guessClass = $schema->getClass($subReference))) {
                     $schema->addOperationRelation($operationName, $guessClass->getName());
                 }
@@ -245,6 +259,9 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
                             : $name . 'Response' . $status;
                         $subReference = $reference . '/responses/' . $status . '/content/' . $contentType . '/schema';
                         $this->chainGuesser->guessClass($content->getSchema(), $responseName, $subReference, $registry);
+                        if (null !== $content->getSchema()) {
+                            $this->xNamespaceResolver->stampClassGuess($registry, $subReference, $content->getSchema());
+                        }
                         if (null !== ($guessClass = $schema->getClass($subReference))) {
                             $schema->addOperationRelation($operationName, $guessClass->getName());
                         }
@@ -252,6 +269,8 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
                 }
             }
         }
+
+        $this->xNamespaceResolver->propagateToOperationModels($schema, $operationGuess, $operationSubNamespace);
     }
 
     private function slugContentType($contentType): string

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Client.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Expected\Model\FlatItem : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getFlatItems(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetFlatItems(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200 : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getNamespacedReport(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\Admin\Reports\GetNamespacedReport(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\Expected\Model\Catalog\TaggedItem : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getTaggedItems(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\Ops\Monitoring\GetTaggedItems(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
+    {
+        $plugins = [];
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+        }
+        if ($applyServerPlugins) {
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+        }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Endpoint/Admin/Reports/GetNamespacedReport.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Endpoint/Admin/Reports/GetNamespacedReport.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint\Admin\Reports;
+
+class GetNamespacedReport extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/namespaced-report';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Endpoint/GetFlatItems.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Endpoint/GetFlatItems.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetFlatItems extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/flat-items';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\FlatItem
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Expected\Model\FlatItem', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Endpoint/Ops/Monitoring/GetTaggedItems.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Endpoint/Ops/Monitoring/GetTaggedItems.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint\Ops\Monitoring;
+
+class GetTaggedItems extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/tagged-items';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\Expected\Model\Catalog\TaggedItem
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\Expected\Model\Catalog\TaggedItem', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Model/Admin/Reports/NamespacedReportGetResponse200.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Model/Admin/Reports/NamespacedReportGetResponse200.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model\Admin\Reports;
+
+class NamespacedReportGetResponse200 extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $title;
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+    /**
+     * @param string $title
+     *
+     * @return self
+     */
+    public function setTitle(string $title): self
+    {
+        $this->initialized['title'] = true;
+        $this->title = $title;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Model/Catalog/TaggedItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Model/Catalog/TaggedItem.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model\Catalog;
+
+class TaggedItem extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $label;
+    /**
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+    /**
+     * @param string $label
+     *
+     * @return self
+     */
+    public function setLabel(string $label): self
+    {
+        $this->initialized['label'] = true;
+        $this->label = $label;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Model/FlatItem.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Model/FlatItem.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Model;
+
+class FlatItem extends \ArrayObject
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Normalizer/Admin/Reports/NamespacedReportGetResponse200Normalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Normalizer/Admin/Reports/NamespacedReportGetResponse200Normalizer.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer\Admin\Reports;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class NamespacedReportGetResponse200Normalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('title', $data)) {
+            $object->setTitle($data['title']);
+            unset($data['title']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('title') && null !== $data->getTitle()) {
+            $dataArray['title'] = $data->getTitle();
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Normalizer/Catalog/TaggedItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Normalizer/Catalog/TaggedItemNormalizer.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer\Catalog;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class TaggedItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\Catalog\TaggedItem::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\Catalog\TaggedItem::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\Catalog\TaggedItem();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('label', $data)) {
+            $object->setLabel($data['label']);
+            unset($data['label']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('label') && null !== $data->getLabel()) {
+            $dataArray['label'] = $data->getLabel();
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\Catalog\TaggedItem::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Normalizer/FlatItemNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Normalizer/FlatItemNormalizer.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FlatItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi3\Tests\Expected\Model\FlatItem::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\Expected\Model\FlatItem::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi3\Tests\Expected\Model\FlatItem();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+            unset($data['name']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('name') && null !== $data->getName()) {
+            $dataArray['name'] = $data->getName();
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi3\Tests\Expected\Model\FlatItem::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi3\Tests\Expected\Model\FlatItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\FlatItemNormalizer::class,
+        
+        \Jane\Component\OpenApi3\Tests\Expected\Model\Catalog\TaggedItem::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\Catalog\TaggedItemNormalizer::class,
+        
+        \Jane\Component\OpenApi3\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class => \Jane\Component\OpenApi3\Tests\Expected\Normalizer\Admin\Reports\NamespacedReportGetResponse200Normalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return array_combine(array_keys($this->normalizers), array_fill(0, count($this->normalizers), false));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/x-namespace/openapi.json
+++ b/src/Component/OpenApi3/Tests/fixtures/x-namespace/openapi.json
@@ -1,0 +1,93 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "x-namespace API",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://api.example.com/v1"
+        }
+    ],
+    "paths": {
+        "/flat-items": {
+            "get": {
+                "operationId": "getFlatItems",
+                "responses": {
+                    "200": {
+                        "description": "A flat item",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlatItem"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/namespaced-report": {
+            "get": {
+                "operationId": "getNamespacedReport",
+                "x-namespace": "Admin\\Reports",
+                "responses": {
+                    "200": {
+                        "description": "An inline report model, namespaced by the operation extension",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/tagged-items": {
+            "get": {
+                "operationId": "getTaggedItems",
+                "x-namespace": "Ops\\Monitoring",
+                "responses": {
+                    "200": {
+                        "description": "A schema declaring its own x-namespace keeps it",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TaggedItem"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "FlatItem": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "TaggedItem": {
+                "type": "object",
+                "x-namespace": "Catalog",
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Component/OpenApi31/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi31/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -13,6 +13,7 @@ use Jane\Component\OpenApiCommon\Generator\ContentType;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
 use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
+use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
 use Jane\Component\OpenApiCommon\Registry\Registry;
 use PhpParser\Comment\Doc;
 use PhpParser\Modifiers;
@@ -296,7 +297,7 @@ EOD
         $class = null;
 
         if (null !== $classGuess) {
-            $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model\\' . $classGuess->getName();
+            $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model' . XNamespaceResolver::subNamespaceSuffix($classGuess) . '\\' . $classGuess->getName();
 
             if ($array) {
                 $class .= '[]';

--- a/src/Component/OpenApi31/Generator/EndpointGenerator.php
+++ b/src/Component/OpenApi31/Generator/EndpointGenerator.php
@@ -106,10 +106,14 @@ class EndpointGenerator implements EndpointGeneratorInterface
         $class->stmts[] = $transformBodyMethod;
         $class->stmts[] = $this->getAuthenticationScopesMethod($operation);
 
+        $subNamespace = $operation->getSubNamespace();
+        $endpointPath = $naming->getArtifactPath($context->getCurrentSchema()->getDirectory(), 'Endpoint', $subNamespace);
+        $endpointNamespace = $naming->getEndpointNamespace($context->getCurrentSchema()->getNamespace(), $subNamespace);
+
         $file = new File(
-            $context->getCurrentSchema()->getDirectory() . \DIRECTORY_SEPARATOR . 'Endpoint' . \DIRECTORY_SEPARATOR . $endpointName . '.php',
+            $endpointPath . \DIRECTORY_SEPARATOR . $endpointName . '.php',
             new Stmt\Namespace_(
-                new Name($context->getCurrentSchema()->getNamespace() . '\\Endpoint'),
+                new Name($endpointNamespace),
                 [
                     $class,
                 ]
@@ -119,6 +123,6 @@ class EndpointGenerator implements EndpointGeneratorInterface
 
         $context->getCurrentSchema()->addFile($file);
 
-        return [$context->getCurrentSchema()->getNamespace() . '\\Endpoint\\' . $endpointName, $methodParams, $methodParamsDoc, $outputTypes, $throwTypes];
+        return [$endpointNamespace . '\\' . $endpointName, $methodParams, $methodParamsDoc, $outputTypes, $throwTypes];
     }
 }

--- a/src/Component/OpenApi31/Generator/RequestBodyContent/AbstractBodyContentGenerator.php
+++ b/src/Component/OpenApi31/Generator/RequestBodyContent/AbstractBodyContentGenerator.php
@@ -7,6 +7,7 @@ use Jane\Component\JsonSchema\JsonSchema\Model\JsonSchema;
 use Jane\Component\OpenApi31\Generator\RequestBodyContentGeneratorInterface;
 use Jane\Component\OpenApi31\Guesser\GuessClass;
 use Jane\Component\OpenApi31\JsonSchema\Model\MediaType;
+use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -48,7 +49,7 @@ abstract class AbstractBodyContentGenerator implements RequestBodyContentGenerat
             return [$types, $array];
         }
 
-        $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model\\' . $classGuess->getName();
+        $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model' . XNamespaceResolver::subNamespaceSuffix($classGuess) . '\\' . $classGuess->getName();
 
         if ($array) {
             $class .= '[]';
@@ -74,7 +75,7 @@ abstract class AbstractBodyContentGenerator implements RequestBodyContentGenerat
             return $this->typeToCondition($type, $format, new Expr\PropertyFetch(new Expr\Variable('this'), 'body'));
         }
 
-        $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model\\' . $classGuess->getName();
+        $class = $context->getRegistry()->getSchema($classGuess->getReference())->getNamespace() . '\\Model' . XNamespaceResolver::subNamespaceSuffix($classGuess) . '\\' . $classGuess->getName();
 
         if ($array) {
             return new Expr\BinaryOp\LogicalAnd(

--- a/src/Component/OpenApi31/Guesser/OpenApiSchema/OpenApiGuesser.php
+++ b/src/Component/OpenApi31/Guesser/OpenApiSchema/OpenApiGuesser.php
@@ -21,6 +21,7 @@ use Jane\Component\OpenApi31\JsonSchema\Normalizer\ResponseNormalizer;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
 use Jane\Component\OpenApiCommon\Naming\OperationNamingFactory;
 use Jane\Component\OpenApiCommon\Naming\OperationNamingInterface;
+use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
 use Jane\Component\OpenApiCommon\Registry\Registry as OpenApiRegistry;
 use Jane\Component\OpenApiCommon\Registry\Schema as OpenApiRegistrySchema;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -35,12 +36,14 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
     private const IN_BODY = 'body';
     private SluggerInterface $slugger;
     private OperationNamingInterface $naming;
+    private XNamespaceResolver $xNamespaceResolver;
 
     public function __construct(DenormalizerInterface $denormalizer, ?OperationNamingInterface $naming = null)
     {
         $this->denormalizer = $denormalizer;
         $this->slugger = new AsciiSlugger();
         $this->naming = $naming ?? OperationNamingFactory::create();
+        $this->xNamespaceResolver = new XNamespaceResolver();
     }
 
     public function supportObject($object): bool
@@ -56,7 +59,9 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
     {
         if ($object->getComponents() instanceof Components && is_iterable($object->getComponents()->getSchemas())) {
             foreach ($object->getComponents()->getSchemas() as $key => $definition) {
-                $this->chainGuesser->guessClass($definition, $key, $reference . '/components/schemas/' . $key, $registry);
+                $definitionReference = $reference . '/components/schemas/' . $key;
+                $this->chainGuesser->guessClass($definition, $key, $definitionReference, $registry);
+                $this->xNamespaceResolver->stampClassGuess($registry, $definitionReference, $definition);
             }
         }
         if ($object->getComponents() instanceof Components && is_iterable($object->getComponents()->getSecuritySchemes())) {
@@ -253,11 +258,17 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
         $schema->addOperation($reference, $operationGuess);
         $schema->initOperationRelations($operationName);
 
+        $operationSubNamespace = $this->xNamespaceResolver->resolveFromObject($operation);
+        $operationGuess->setSubNamespace($operationSubNamespace);
+
         if (null !== $operation->getParameters() && \count($operation->getParameters()) > 0) {
             foreach ($operation->getParameters() as $key => $parameter) {
                 if ($parameter instanceof Parameter && self::IN_BODY === $parameter->getIn()) {
                     $subReference = $reference . '/parameters/' . $key;
                     $this->chainGuesser->guessClass($parameter->getSchema(), $name . 'Body', $subReference, $registry);
+                    if (null !== $parameter->getSchema()) {
+                        $this->xNamespaceResolver->stampClassGuess($registry, $subReference, $parameter->getSchema());
+                    }
                     if (null !== ($guessClass = $schema->getClass($subReference))) {
                         $schema->addOperationRelation($operationName, $guessClass->getName());
                     }
@@ -274,6 +285,9 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
             foreach ($operation->getRequestBody()->getContent() as $contentType => $content) {
                 $subReference = $reference . '/requestBody/content/' . $contentType . '/schema';
                 $this->chainGuesser->guessClass($content->getSchema(), $name . 'Body', $subReference, $registry);
+                if (null !== $content->getSchema()) {
+                    $this->xNamespaceResolver->stampClassGuess($registry, $subReference, $content->getSchema());
+                }
                 if (null !== ($guessClass = $schema->getClass($subReference))) {
                     $schema->addOperationRelation($operationName, $guessClass->getName());
                 }
@@ -294,6 +308,9 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
                             : $name . 'Response' . $status;
                         $subReference = $reference . '/responses/' . $status . '/content/' . $contentType . '/schema';
                         $this->chainGuesser->guessClass($content->getSchema(), $responseName, $subReference, $registry);
+                        if (null !== $content->getSchema()) {
+                            $this->xNamespaceResolver->stampClassGuess($registry, $subReference, $content->getSchema());
+                        }
                         if (null !== ($guessClass = $schema->getClass($subReference))) {
                             $schema->addOperationRelation($operationName, $guessClass->getName());
                         }
@@ -301,6 +318,8 @@ class OpenApiGuesser implements GuesserInterface, ClassGuesserInterface, ChainGu
                 }
             }
         }
+
+        $this->xNamespaceResolver->propagateToOperationModels($schema, $operationGuess, $operationSubNamespace);
     }
 
     private function slugContentType($contentType): string

--- a/src/Component/OpenApi31/JsonSchema/Model/Operation.php
+++ b/src/Component/OpenApi31/JsonSchema/Model/Operation.php
@@ -2,7 +2,7 @@
 
 namespace Jane\Component\OpenApi31\JsonSchema\Model;
 
-class Operation
+class Operation extends \ArrayObject
 {
     /**
      * @var array

--- a/src/Component/OpenApi31/JsonSchema/Normalizer/OperationNormalizer.php
+++ b/src/Component/OpenApi31/JsonSchema/Normalizer/OperationNormalizer.php
@@ -133,6 +133,12 @@ class OperationNormalizer implements DenormalizerInterface, NormalizerInterface,
             $object->setServers(null);
         }
 
+        foreach ($data as $key => $value) {
+            if (preg_match('/^x-/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+
         return $object;
     }
 
@@ -202,6 +208,12 @@ class OperationNormalizer implements DenormalizerInterface, NormalizerInterface,
                 $values_6[] = $this->normalizer->normalize($value_6, 'json', $context);
             }
             $dataArray['servers'] = $values_6;
+        }
+
+        foreach ($data as $key => $value) {
+            if (preg_match('/^x-/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
         }
 
         return $dataArray;

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/.jane-openapi
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\Component\OpenApi31\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Client.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Expected\Model\FlatItem : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getFlatItems(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\GetFlatItems(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200 : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getNamespacedReport(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\Admin\Reports\GetNamespacedReport(), $fetch);
+    }
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\Expected\Model\Catalog\TaggedItem : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getTaggedItems(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\Expected\Endpoint\Ops\Monitoring\GetTaggedItems(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [], bool $applyServerPlugins = true)
+    {
+        $plugins = [];
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+        }
+        if ($applyServerPlugins) {
+            $uri = \Http\Discovery\Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.example.com/v1');
+            $plugins[] = new \Http\Client\Common\Plugin\AddHostPlugin($uri);
+            $plugins[] = new \Http\Client\Common\Plugin\AddPathPlugin($uri);
+        }
+        if (count($additionalPlugins) > 0) {
+            $plugins = array_merge($plugins, $additionalPlugins);
+        }
+        $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Endpoint/Admin/Reports/GetNamespacedReport.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Endpoint/Admin/Reports/GetNamespacedReport.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Endpoint\Admin\Reports;
+
+class GetNamespacedReport extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/namespaced-report';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Endpoint/GetFlatItems.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Endpoint/GetFlatItems.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Endpoint;
+
+class GetFlatItems extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/flat-items';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Expected\Model\FlatItem
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Expected\Model\FlatItem', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Endpoint/Ops/Monitoring/GetTaggedItems.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Endpoint/Ops/Monitoring/GetTaggedItems.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Endpoint\Ops\Monitoring;
+
+class GetTaggedItems extends \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi31\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/tagged-items';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\Expected\Model\Catalog\TaggedItem
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\Expected\Model\Catalog\TaggedItem', 'json');
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Model/Admin/Reports/NamespacedReportGetResponse200.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Model/Admin/Reports/NamespacedReportGetResponse200.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model\Admin\Reports;
+
+class NamespacedReportGetResponse200
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $title;
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+    /**
+     * @param string $title
+     *
+     * @return self
+     */
+    public function setTitle(string $title): self
+    {
+        $this->initialized['title'] = true;
+        $this->title = $title;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Model/Catalog/TaggedItem.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Model/Catalog/TaggedItem.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model\Catalog;
+
+class TaggedItem
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $label;
+    /**
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+    /**
+     * @param string $label
+     *
+     * @return self
+     */
+    public function setLabel(string $label): self
+    {
+        $this->initialized['label'] = true;
+        $this->label = $label;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Model/FlatItem.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Model/FlatItem.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Model;
+
+class FlatItem
+{
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $name;
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    /**
+     * @param string $name
+     *
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->initialized['name'] = true;
+        $this->name = $name;
+        return $this;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Normalizer/Admin/Reports/NamespacedReportGetResponse200Normalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Normalizer/Admin/Reports/NamespacedReportGetResponse200Normalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer\Admin\Reports;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class NamespacedReportGetResponse200Normalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('title', $data)) {
+            $object->setTitle($data['title']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('title') && null !== $data->getTitle()) {
+            $dataArray['title'] = $data->getTitle();
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Normalizer/Catalog/TaggedItemNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Normalizer/Catalog/TaggedItemNormalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer\Catalog;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class TaggedItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Expected\Model\Catalog\TaggedItem::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Expected\Model\Catalog\TaggedItem::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Expected\Model\Catalog\TaggedItem();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('label', $data)) {
+            $object->setLabel($data['label']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('label') && null !== $data->getLabel()) {
+            $dataArray['label'] = $data->getLabel();
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Expected\Model\Catalog\TaggedItem::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Normalizer/FlatItemNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Normalizer/FlatItemNormalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class FlatItemNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\Expected\Model\FlatItem::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\Expected\Model\FlatItem::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\Expected\Model\FlatItem();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('name', $data)) {
+            $object->setName($data['name']);
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('name') && null !== $data->getName()) {
+            $dataArray['name'] = $data->getName();
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\Expected\Model\FlatItem::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi31\Tests\Expected\Model\FlatItem::class => \Jane\Component\OpenApi31\Tests\Expected\Normalizer\FlatItemNormalizer::class,
+        
+        \Jane\Component\OpenApi31\Tests\Expected\Model\Catalog\TaggedItem::class => \Jane\Component\OpenApi31\Tests\Expected\Normalizer\Catalog\TaggedItemNormalizer::class,
+        
+        \Jane\Component\OpenApi31\Tests\Expected\Model\Admin\Reports\NamespacedReportGetResponse200::class => \Jane\Component\OpenApi31\Tests\Expected\Normalizer\Admin\Reports\NamespacedReportGetResponse200Normalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return array_combine(array_keys($this->normalizers), array_fill(0, count($this->normalizers), false));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/x-namespace/openapi.json
+++ b/src/Component/OpenApi31/Tests/fixtures/x-namespace/openapi.json
@@ -1,0 +1,93 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "x-namespace API",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://api.example.com/v1"
+        }
+    ],
+    "paths": {
+        "/flat-items": {
+            "get": {
+                "operationId": "getFlatItems",
+                "responses": {
+                    "200": {
+                        "description": "A flat item",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlatItem"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/namespaced-report": {
+            "get": {
+                "operationId": "getNamespacedReport",
+                "x-namespace": "Admin\\Reports",
+                "responses": {
+                    "200": {
+                        "description": "An inline report model, namespaced by the operation extension",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/tagged-items": {
+            "get": {
+                "operationId": "getTaggedItems",
+                "x-namespace": "Ops\\Monitoring",
+                "responses": {
+                    "200": {
+                        "description": "A schema declaring its own x-namespace keeps it",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TaggedItem"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "FlatItem": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "TaggedItem": {
+                "type": "object",
+                "x-namespace": "Catalog",
+                "properties": {
+                    "label": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Component/OpenApi31/version31.json
+++ b/src/Component/OpenApi31/version31.json
@@ -364,6 +364,9 @@
     "operation": {
       "$comment": "https://spec.openapis.org/oas/v3.1.0#operation-object",
       "type": "object",
+      "patternProperties": {
+        "^x-": {}
+      },
       "properties": {
         "tags": {
           "type": "array",

--- a/src/Component/OpenApiCommon/Generator/ModelGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/ModelGenerator.php
@@ -28,7 +28,18 @@ class ModelGenerator extends BaseModelGenerator
         $extends = null;
         if ($class instanceof ClassGuess
             && $class->getParentClass() instanceof ParentClass) {
-            $extends = $this->getNaming()->getClassName($class->getParentClass()->getName());
+            $parentClass = $class->getParentClass();
+            $parentClassName = $this->getNaming()->getClassName($parentClass->getName());
+
+            if ($parentClass->getSubNamespace() === $class->getSubNamespace()) {
+                // same sub-namespace: the relative class name resolves to the parent
+                $extends = $parentClassName;
+            } elseif (null !== $parentClass->getModelNamespace()) {
+                // different sub-namespace: reference the parent by its fully qualified name
+                $extends = '\\' . $parentClass->getModelNamespace() . '\\' . $parentClassName;
+            } else {
+                $extends = $parentClassName;
+            }
         }
 
         return $this->createModel(

--- a/src/Component/OpenApiCommon/Guesser/Guess/OperationGuess.php
+++ b/src/Component/OpenApiCommon/Guesser/Guess/OperationGuess.php
@@ -15,6 +15,8 @@ class OperationGuess
     private string $path;
     private array $parameters;
     private array $securityScopes;
+    /** @var string[] Sub-namespace segments from the "x-namespace" extension; empty when the endpoint uses the flat layout */
+    private array $subNamespace = [];
 
     public function __construct(
         object $pathItem,
@@ -60,5 +62,21 @@ class OperationGuess
     public function getSecurityScopes(): array
     {
         return $this->securityScopes;
+    }
+
+    /**
+     * @return string[] Sub-namespace segments (already sanitized), empty when the endpoint uses the flat layout
+     */
+    public function getSubNamespace(): array
+    {
+        return $this->subNamespace;
+    }
+
+    /**
+     * @param string[] $subNamespace
+     */
+    public function setSubNamespace(array $subNamespace): void
+    {
+        $this->subNamespace = $subNamespace;
     }
 }

--- a/src/Component/OpenApiCommon/Guesser/Guess/ParentClass.php
+++ b/src/Component/OpenApiCommon/Guesser/Guess/ParentClass.php
@@ -4,6 +4,9 @@ namespace Jane\Component\OpenApiCommon\Guesser\Guess;
 
 class ParentClass extends ClassGuess
 {
+    /** Full namespace prefix of this parent's generated model (e.g. "App\Model\Animals"), used by children living in another sub-namespace */
+    private ?string $modelNamespace = null;
+
     public function __construct(
         ClassGuess $classGuess,
         protected string $discriminator,
@@ -14,6 +17,16 @@ class ParentClass extends ClassGuess
         $this->setProperties($classGuess->getProperties());
         $this->setExtensionsType($classGuess->getExtensionsType());
         $this->setConstraints($classGuess->getConstraints());
+    }
+
+    public function getModelNamespace(): ?string
+    {
+        return $this->modelNamespace;
+    }
+
+    public function setModelNamespace(?string $modelNamespace): void
+    {
+        $this->modelNamespace = $modelNamespace;
     }
 
     public function setDiscriminator(string $discriminator): self

--- a/src/Component/OpenApiCommon/JaneOpenApi.php
+++ b/src/Component/OpenApiCommon/JaneOpenApi.php
@@ -158,6 +158,8 @@ abstract class JaneOpenApi extends ChainGenerator
     {
         foreach ($schema->getClasses() as $class) {
             if ($class instanceof ParentClass) { // is parent class
+                $class->setModelNamespace($this->naming->getModelNamespace($schema->getNamespace(), $class->getSubNamespace()));
+
                 foreach ($class->getChildReferences() as $reference) {
                     $guess = $registry->getClass($reference);
                     if ($guess instanceof ClassGuess) { // is child class

--- a/src/Component/OpenApiCommon/Naming/XNamespaceResolver.php
+++ b/src/Component/OpenApiCommon/Naming/XNamespaceResolver.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Jane\Component\OpenApiCommon\Naming;
+
+use Jane\Component\JsonSchema\Generator\Naming;
+use Jane\Component\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\Component\JsonSchema\Registry\Registry;
+use Jane\Component\JsonSchema\Registry\Schema;
+use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
+
+/**
+ * Resolves the "x-namespace" vendor extension into sanitized namespace segments.
+ *
+ * The attribute is opt-in per artifact: an operation annotated with "x-namespace"
+ * moves its endpoint (and its inline request/response models) into that namespace,
+ * while a schema annotated with "x-namespace" moves its model, normalizer and
+ * validator there. Artifacts without the attribute keep the flat layout.
+ *
+ * The value may contain several segments separated by "\" or "/", e.g.
+ * "Users\Admin" or "Users/Admin". Each segment is sanitized with the same rules
+ * used for class names (invalid characters, reserved words, leading digits).
+ */
+class XNamespaceResolver
+{
+    public const ATTRIBUTE_NAME = 'x-namespace';
+
+    private Naming $naming;
+
+    public function __construct(?Naming $naming = null)
+    {
+        $this->naming = $naming ?? new Naming();
+    }
+
+    /**
+     * Reads the extension from a parsed specification object. Parsed OpenAPI
+     * models keep specification extensions (keys matching "^x-") in their
+     * \ArrayObject storage, so anything else is reported as absent.
+     *
+     * @return string[] Sanitized namespace segments, empty when the attribute is absent or invalid
+     */
+    public function resolveFromObject(object $object): array
+    {
+        if (!$object instanceof \ArrayObject) {
+            return [];
+        }
+
+        if (!isset($object[self::ATTRIBUTE_NAME]) || !\is_string($object[self::ATTRIBUTE_NAME])) {
+            return [];
+        }
+
+        return $this->resolve($object[self::ATTRIBUTE_NAME]);
+    }
+
+    /**
+     * @return string[] Sanitized namespace segments, empty when nothing usable remains
+     */
+    public function resolve(string $value): array
+    {
+        $parts = preg_split('#[\\\\/]+#', $value);
+        if (false === $parts) {
+            return [];
+        }
+
+        $segments = [];
+        foreach ($parts as $part) {
+            $segment = $this->naming->getClassName(trim($part));
+            if ('' === $segment) {
+                continue;
+            }
+
+            $segments[] = $segment;
+        }
+
+        return $segments;
+    }
+
+    /**
+     * @return string "\"-prefixed sub-namespace (e.g. "\Users"), empty string when the class uses the flat layout
+     */
+    public static function subNamespaceSuffix(ClassGuess $classGuess): string
+    {
+        $subNamespace = $classGuess->getSubNamespace();
+
+        return [] === $subNamespace ? '' : '\\' . implode('\\', $subNamespace);
+    }
+
+    /**
+     * Applies the "x-namespace" declared on a parsed schema object to the class
+     * guessed for it. Explicit attributes always win over inherited namespaces.
+     */
+    public function stampClassGuess(Registry $registry, string $reference, object $object): void
+    {
+        $subNamespace = $this->resolveFromObject($object);
+        if ([] === $subNamespace) {
+            return;
+        }
+
+        $classGuess = $registry->getClass($reference);
+        if ($classGuess instanceof ClassGuess && [] === $classGuess->getSubNamespace()) {
+            $classGuess->setSubNamespace($subNamespace);
+        }
+    }
+
+    /**
+     * Propagates an operation's sub-namespace to every model guessed from that
+     * operation (inline request bodies / responses and their nested objects),
+     * unless those declare their own "x-namespace".
+     *
+     * @param string[] $subNamespace
+     */
+    public function propagateToOperationModels(Schema $schema, OperationGuess $operationGuess, array $subNamespace): void
+    {
+        if ([] === $subNamespace) {
+            return;
+        }
+
+        $operationReference = $operationGuess->getReference() . '/';
+        foreach ($schema->getClasses() as $classGuess) {
+            if ([] !== $classGuess->getSubNamespace()) {
+                continue;
+            }
+
+            if (str_starts_with($classGuess->getReference(), $operationReference)) {
+                $classGuess->setSubNamespace($subNamespace);
+            }
+        }
+    }
+}

--- a/src/Component/OpenApiCommon/Tests/Naming/XNamespaceResolverTest.php
+++ b/src/Component/OpenApiCommon/Tests/Naming/XNamespaceResolverTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jane\Component\OpenApiCommon\Tests\Naming;
+
+use Jane\Component\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
+use PHPUnit\Framework\TestCase;
+
+final class XNamespaceResolverTest extends TestCase
+{
+    public static function provideValues(): iterable
+    {
+        yield 'single segment' => ['Users', ['Users']];
+        yield 'backslash separated segments' => ['Users\Admin', ['Users', 'Admin']];
+        yield 'slash separated segments' => ['Users/Admin', ['Users', 'Admin']];
+        yield 'mixed separators' => ['Users\Admin/Deep', ['Users', 'Admin', 'Deep']];
+        yield 'sanitized segments' => ['users-area\admin zone', ['UsersArea', 'AdminZone']];
+        yield 'reserved word is prefixed' => ['list', ['_List']];
+        yield 'leading digit is prefixed' => ['2fa', ['_2fa']];
+        yield 'multiple leading digits are prefixed' => ['42', ['_42']];
+    }
+
+    /**
+     * @dataProvider provideValues
+     */
+    public function testResolveSplitsAndSanitizesSegments(string $value, array $expected): void
+    {
+        self::assertSame($expected, (new XNamespaceResolver())->resolve($value));
+    }
+
+    public static function provideInvalidValues(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'separators only' => ['\\//'];
+        yield 'blank segments only' => [' \\ // '];
+    }
+
+    /**
+     * @dataProvider provideInvalidValues
+     */
+    public function testResolveReturnsEmptyArrayForUnusableValues(string $value): void
+    {
+        self::assertSame([], (new XNamespaceResolver())->resolve($value));
+    }
+
+    public function testResolveFromObjectReadsArrayObjectStorage(): void
+    {
+        $resolver = new XNamespaceResolver();
+        $object = new \ArrayObject(['x-namespace' => 'Users\Admin']);
+
+        self::assertSame(['Users', 'Admin'], $resolver->resolveFromObject($object));
+    }
+
+    public function testResolveFromObjectIgnoresObjectsWithoutTheAttribute(): void
+    {
+        $resolver = new XNamespaceResolver();
+
+        self::assertSame([], $resolver->resolveFromObject(new \ArrayObject()));
+        self::assertSame([], $resolver->resolveFromObject(new \stdClass()));
+        self::assertSame([], $resolver->resolveFromObject(new \ArrayObject(['x-namespace' => 42])));
+    }
+
+    public function testSubNamespaceSuffixBuildsPrefixedNamespace(): void
+    {
+        $classGuess = new ClassGuess(new \stdClass(), '#/components/schemas/User', 'User');
+        $classGuess->setSubNamespace(['Users', 'Admin']);
+
+        self::assertSame('\\Users\\Admin', XNamespaceResolver::subNamespaceSuffix($classGuess));
+    }
+
+    public function testSubNamespaceSuffixIsEmptyForFlatLayout(): void
+    {
+        $classGuess = new ClassGuess(new \stdClass(), '#/components/schemas/User', 'User');
+
+        self::assertSame('', XNamespaceResolver::subNamespaceSuffix($classGuess));
+    }
+}


### PR DESCRIPTION
## Description

Adds support for the OpenAPI Specification Extensions mechanism to namespace generated code: declaring an `x-namespace` attribute on an operation moves its Endpoint class (and the models generated from its inline request bodies / responses) into a sub-namespace; declaring it on a schema moves its Model, Normalizer and Validator there. Artifacts without the attribute keep the flat layout, so existing specifications generate unchanged output.

Closes #838.

## Changes

- New `XNamespaceResolver` (`OpenApiCommon\Naming`): reads `x-namespace` from parsed specification objects, splits the value on `\` or `/`, sanitizes each segment with the standard class-name rules (reserved words prefixed with `_`, e.g. `list` → `_List`)
- `ClassGuess` / `OperationGuess` carry the resolved sub-namespace segments; guessers stamp it on component schemas, operation-level inline bodies/responses (all three OpenAPI versions) and propagate an operation's namespace to its nested models — explicit attributes always win over inheritance
- Generators place artifacts accordingly: `Endpoint\<ns>\`, `Model\<ns>\`, `Normalizer\<ns>\`, `Validator\<ns>\`, including constraint FQCNs in denormalizers, `ExternalNormalizersResolver`, parent-class references across sub-namespaces, and `ObjectType` / `EnumType` FQDN resolution
- **OpenAPI 3.1 parser gap fix**: the 3.1 meta-schema only declared specification extensions through a `$ref` indirection, so all `x-*` data was dropped at parse time. `version31.json` now declares `"patternProperties": {"^x-": {}}` inline on the `operation` definition, and the internal `Operation` model / normalizer were updated accordingly (hand-applied, see Notes). The shared `JsonSchema` model used for 3.1 schemas was regenerated to capture `x-*` keys in its `\ArrayObject` storage
- New `x-namespace` fixture per supported version (2.0, 3.0.x, 3.1.x) covering: no annotation, operation-only, schema-only, and both (explicit schema attribute wins over operation propagation)
- Unit tests for `XNamespaceResolver`; documentation section in `docs/openapi/component.md`; CHANGELOG entries; new ADR 0006 ("Follow upstream specifications faithfully") recording the parser-parity rule surfaced by this work

## How to test

1. `composer install`
2. `vendor/bin/phpunit --filter x-namespace` — runs the new fixture tests for the three OpenAPI versions plus the resolver unit tests
3. `vendor/bin/phpunit` for the full suite

## Notes

- The internal OpenAPI 3.1 `Operation` model/normalizer changes are hand-applied to match what generation produces from the updated meta-schema. A full regeneration of `src/Component/OpenApi31/JsonSchema/` (via `src/Component/OpenApi31/.jane`) additionally surfaces broad drift between the committed tree and the current toolchain output (file headers, `JsonObject` migration, moved null-checks) that predates this PR — left out to keep the diff reviewable, worth a dedicated regeneration pass.
- Generator-level resolution of `$ref`'d extension declarations (which would benefit all ~30 extensible definitions, not just `operation` + schemas) is intentionally deferred as a follow-up issue.
- The `fixtures-issue-831` test failure present on this branch is pre-existing on `next` and fixed upstream by #1011.
