### PR TITLE
feat(open-api): handle parameters key as parameter name (#501)

### DIFF
--- a/src/Component/OpenApi3/SchemaParser/ParameterNameResolver.php
+++ b/src/Component/OpenApi3/SchemaParser/ParameterNameResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Jane\Component\OpenApi3\SchemaParser;
+
+/**
+ * Resolves parameter names from the keys of map-shaped `parameters` blocks.
+ *
+ * The OpenAPI specification describes operation and path parameters as an
+ * array of Parameter Objects, each one carrying its own `name` member. For
+ * better readability, a map keyed by parameter name is also accepted, the
+ * same way object properties are handled elsewhere. As those keys cannot be
+ * represented by the generated OpenApi models (`parameters` is denormalized
+ * as a plain list), every string key is copied into the `name` member of its
+ * associated parameter before the document reaches the denormalizer. An
+ * explicit `name` always takes precedence over the key.
+ */
+final class ParameterNameResolver
+{
+    /** @var array<string> */
+    private const HTTP_METHODS = [
+        'get',
+        'put',
+        'post',
+        'delete',
+        'options',
+        'head',
+        'patch',
+        'trace',
+    ];
+
+    /**
+     * @param array<mixed> $document
+     *
+     * @return array<mixed>
+     */
+    public static function resolve(array $document): array
+    {
+        if (!isset($document['paths']) || !\is_array($document['paths'])) {
+            return $document;
+        }
+
+        foreach ($document['paths'] as &$pathItem) {
+            if (!\is_array($pathItem)) {
+                continue;
+            }
+
+            if (isset($pathItem['parameters']) && \is_array($pathItem['parameters'])) {
+                self::resolveParameterNames($pathItem['parameters']);
+            }
+
+            foreach (self::HTTP_METHODS as $method) {
+                if (isset($pathItem[$method]['parameters']) && \is_array($pathItem[$method]['parameters'])) {
+                    self::resolveParameterNames($pathItem[$method]['parameters']);
+                }
+            }
+        }
+        unset($pathItem);
+
+        return $document;
+    }
+
+    /**
+     * @param array<mixed> $parameters
+     */
+    private static function resolveParameterNames(array &$parameters): void
+    {
+        foreach ($parameters as $key => &$parameter) {
+            if (!\is_string($key) || !\is_array($parameter) || isset($parameter['$ref']) || isset($parameter['name'])) {
+                continue;
+            }
+
+            $parameter['name'] = $key;
+        }
+        unset($parameter);
+    }
+}

--- a/src/Component/OpenApi3/SchemaParser/SchemaParser.php
+++ b/src/Component/OpenApi3/SchemaParser/SchemaParser.php
@@ -19,6 +19,15 @@ class SchemaParser extends CommonSchemaParser
         return \is_array($openApiSpecData) && \array_key_exists('openapi', $openApiSpecData) && version_compare($openApiSpecData['openapi'], '3.0.0', '>=') && version_compare($openApiSpecData['openapi'], '3.1.0', '<');
     }
 
+    protected function denormalize($openApiSpecData, $openApiSpecPath)
+    {
+        if (\is_array($openApiSpecData)) {
+            $openApiSpecData = ParameterNameResolver::resolve($openApiSpecData);
+        }
+
+        return parent::denormalize($openApiSpecData, $openApiSpecPath);
+    }
+
     /**
      * @param array<mixed> $openApiSpecData
      *

--- a/src/Component/OpenApi3/Tests/ParameterNameResolverTest.php
+++ b/src/Component/OpenApi3/Tests/ParameterNameResolverTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Jane\Component\OpenApi3\SchemaParser\ParameterNameResolver;
+use PHPUnit\Framework\TestCase;
+
+class ParameterNameResolverTest extends TestCase
+{
+    /**
+     * @dataProvider provideDocumentsWithMapParameters
+     *
+     * @param array<mixed> $document
+     * @param array<mixed> $expectedDocument
+     */
+    public function testResolvesParameterNamesFromKeys(array $document, array $expectedDocument): void
+    {
+        $this->assertEquals($expectedDocument, ParameterNameResolver::resolve($document));
+    }
+
+    /**
+     * @return \Generator<array{0: array<mixed>, 1: array<mixed>}>
+     */
+    public static function provideDocumentsWithMapParameters(): \Generator
+    {
+        yield 'operation level parameters' => [
+            [
+                'openapi' => '3.0.0',
+                'paths' => [
+                    '/orders/{order_id}' => [
+                        'get' => [
+                            'parameters' => [
+                                'site' => [
+                                    'in' => 'query',
+                                    'schema' => ['type' => 'string'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'openapi' => '3.0.0',
+                'paths' => [
+                    '/orders/{order_id}' => [
+                        'get' => [
+                            'parameters' => [
+                                'site' => [
+                                    'name' => 'site',
+                                    'in' => 'query',
+                                    'schema' => ['type' => 'string'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'path item level parameters' => [
+            [
+                'paths' => [
+                    '/orders/{order_id}' => [
+                        'parameters' => [
+                            'order_id' => [
+                                'in' => 'path',
+                                'schema' => ['type' => 'integer'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'paths' => [
+                    '/orders/{order_id}' => [
+                        'parameters' => [
+                            'order_id' => [
+                                'name' => 'order_id',
+                                'in' => 'path',
+                                'schema' => ['type' => 'integer'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'explicit name wins over key' => [
+            [
+                'paths' => [
+                    '/orders' => [
+                        'get' => [
+                            'parameters' => [
+                                'key_name' => [
+                                    'name' => 'explicit_name',
+                                    'in' => 'query',
+                                    'schema' => ['type' => 'string'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'paths' => [
+                    '/orders' => [
+                        'get' => [
+                            'parameters' => [
+                                'key_name' => [
+                                    'name' => 'explicit_name',
+                                    'in' => 'query',
+                                    'schema' => ['type' => 'string'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'references are left untouched' => [
+            [
+                'paths' => [
+                    '/orders' => [
+                        'get' => [
+                            'parameters' => [
+                                'siteRef' => [
+                                    '$ref' => '#/components/parameters/SiteParam',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'paths' => [
+                    '/orders' => [
+                        'get' => [
+                            'parameters' => [
+                                'siteRef' => [
+                                    '$ref' => '#/components/parameters/SiteParam',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'array shaped parameters keep working' => [
+            [
+                'paths' => [
+                    '/orders' => [
+                        'get' => [
+                            'parameters' => [
+                                [
+                                    'name' => 'site',
+                                    'in' => 'query',
+                                    'schema' => ['type' => 'string'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'paths' => [
+                    '/orders' => [
+                        'get' => [
+                            'parameters' => [
+                                [
+                                    'name' => 'site',
+                                    'in' => 'query',
+                                    'schema' => ['type' => 'string'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'every http method is covered' => [
+            [
+                'paths' => [
+                    '/orders' => [
+                        'put' => ['parameters' => ['putParam' => ['in' => 'query']]],
+                        'post' => ['parameters' => ['postParam' => ['in' => 'query']]],
+                        'delete' => ['parameters' => ['deleteParam' => ['in' => 'query']]],
+                        'options' => ['parameters' => ['optionsParam' => ['in' => 'query']]],
+                        'head' => ['parameters' => ['headParam' => ['in' => 'query']]],
+                        'patch' => ['parameters' => ['patchParam' => ['in' => 'query']]],
+                        'trace' => ['parameters' => ['traceParam' => ['in' => 'query']]],
+                    ],
+                ],
+            ],
+            [
+                'paths' => [
+                    '/orders' => [
+                        'put' => ['parameters' => ['putParam' => ['name' => 'putParam', 'in' => 'query']]],
+                        'post' => ['parameters' => ['postParam' => ['name' => 'postParam', 'in' => 'query']]],
+                        'delete' => ['parameters' => ['deleteParam' => ['name' => 'deleteParam', 'in' => 'query']]],
+                        'options' => ['parameters' => ['optionsParam' => ['name' => 'optionsParam', 'in' => 'query']]],
+                        'head' => ['parameters' => ['headParam' => ['name' => 'headParam', 'in' => 'query']]],
+                        'patch' => ['parameters' => ['patchParam' => ['name' => 'patchParam', 'in' => 'query']]],
+                        'trace' => ['parameters' => ['traceParam' => ['name' => 'traceParam', 'in' => 'query']]],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testLeavesDocumentsWithoutPathsUntouched(): void
+    {
+        $document = [
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'No paths', 'version' => '1.0.0'],
+        ];
+
+        $this->assertEquals($document, ParameterNameResolver::resolve($document));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/swagger.json',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\Expected',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Client.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected;
+
+class Client extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Client
+{
+    /**
+     * Retrieve an Order
+     * @param int $orderId Order or cart ID
+     * @param array{
+     *    "shared_limit"?: int, //Rate limit shared across operations
+     *    "site": string, //Order or cart ID
+     *    "explicit_name"?: string, //Explicit name takes precedence over the key
+     * } $queryParameters
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     *
+     * @return ($fetch is 'object' ? null : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getOrder(int $orderId, array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\Expected\Endpoint\GetOrder($orderId, $queryParameters), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\Expected\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Endpoint/GetOrder.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Endpoint/GetOrder.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Endpoint;
+
+class GetOrder extends \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\Endpoint
+{
+    protected $order_id;
+    /**
+     * Retrieve an Order
+     * @param int $orderId Order or cart ID
+     * @param array{
+     *    "shared_limit"?: int, //Rate limit shared across operations
+     *    "site": string, //Order or cart ID
+     *    "explicit_name"?: string, //Explicit name takes precedence over the key
+     * } $queryParameters
+     */
+    public function __construct(int $orderId, array $queryParameters = [])
+    {
+        $this->order_id = $orderId;
+        $this->queryParameters = $queryParameters;
+    }
+    use \Jane\Component\OpenApi3\Tests\Expected\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return str_replace(['{order_id}'], [$this->order_id], '/orders/{order_id}');
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(['shared_limit', 'site', 'explicit_name']);
+        $optionsResolver->setRequired(['site']);
+        $optionsResolver->setDefaults([]);
+        $optionsResolver->addAllowedTypes('shared_limit', ['int']);
+        $optionsResolver->addAllowedTypes('site', ['string']);
+        $optionsResolver->addAllowedTypes('explicit_name', ['string']);
+        return $optionsResolver;
+    }
+    /**
+     * {@inheritdoc}
+     *
+     *
+     * @return null
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (200 === $status) {
+            return null;
+        }
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return array_combine(array_keys($this->normalizers), array_fill(0, count($this->normalizers), false));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$definition[1]}();
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$definition[1]}();
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\Expected\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/swagger.json
+++ b/src/Component/OpenApi3/Tests/fixtures/parameters-map-keys/swagger.json
@@ -1,0 +1,58 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Parameters map keys",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/orders/{order_id}": {
+            "parameters": {
+                "shared_limit": {
+                    "in": "query",
+                    "required": false,
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "description": "Rate limit shared across operations"
+                }
+            },
+            "get": {
+                "summary": "Get an Order",
+                "description": "Retrieve an Order",
+                "operationId": "getOrder",
+                "parameters": {
+                    "site": {
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Order or cart ID"
+                    },
+                    "order_id": {
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Order or cart ID"
+                    },
+                    "explicit": {
+                        "name": "explicit_name",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Explicit name takes precedence over the key"
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "The order"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Component/OpenApi31/SchemaParser/ParameterNameResolver.php
+++ b/src/Component/OpenApi31/SchemaParser/ParameterNameResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Jane\Component\OpenApi31\SchemaParser;
+
+/**
+ * Resolves parameter names from the keys of map-shaped `parameters` blocks.
+ *
+ * The OpenAPI specification describes operation and path parameters as an
+ * array of Parameter Objects, each one carrying its own `name` member. For
+ * better readability, a map keyed by parameter name is also accepted, the
+ * same way object properties are handled elsewhere. As those keys cannot be
+ * represented by the generated OpenApi models (`parameters` is denormalized
+ * as a plain list), every string key is copied into the `name` member of its
+ * associated parameter before the document reaches the denormalizer. An
+ * explicit `name` always takes precedence over the key.
+ */
+final class ParameterNameResolver
+{
+    /** @var array<string> */
+    private const HTTP_METHODS = [
+        'get',
+        'put',
+        'post',
+        'delete',
+        'options',
+        'head',
+        'patch',
+        'trace',
+    ];
+
+    /**
+     * @param array<mixed> $document
+     *
+     * @return array<mixed>
+     */
+    public static function resolve(array $document): array
+    {
+        if (!isset($document['paths']) || !\is_array($document['paths'])) {
+            return $document;
+        }
+
+        foreach ($document['paths'] as &$pathItem) {
+            if (!\is_array($pathItem)) {
+                continue;
+            }
+
+            if (isset($pathItem['parameters']) && \is_array($pathItem['parameters'])) {
+                self::resolveParameterNames($pathItem['parameters']);
+            }
+
+            foreach (self::HTTP_METHODS as $method) {
+                if (isset($pathItem[$method]['parameters']) && \is_array($pathItem[$method]['parameters'])) {
+                    self::resolveParameterNames($pathItem[$method]['parameters']);
+                }
+            }
+        }
+        unset($pathItem);
+
+        return $document;
+    }
+
+    /**
+     * @param array<mixed> $parameters
+     */
+    private static function resolveParameterNames(array &$parameters): void
+    {
+        foreach ($parameters as $key => &$parameter) {
+            if (!\is_string($key) || !\is_array($parameter) || isset($parameter['$ref']) || isset($parameter['name'])) {
+                continue;
+            }
+
+            $parameter['name'] = $key;
+        }
+        unset($parameter);
+    }
+}

--- a/src/Component/OpenApi31/SchemaParser/SchemaParser.php
+++ b/src/Component/OpenApi31/SchemaParser/SchemaParser.php
@@ -18,4 +18,13 @@ class SchemaParser extends CommonSchemaParser
     {
         return \is_array($openApiSpecData) && \array_key_exists('openapi', $openApiSpecData) && version_compare($openApiSpecData['openapi'], '3.1.0', '>=');
     }
+
+    protected function denormalize($openApiSpecData, $openApiSpecPath)
+    {
+        if (\is_array($openApiSpecData)) {
+            $openApiSpecData = ParameterNameResolver::resolve($openApiSpecData);
+        }
+
+        return parent::denormalize($openApiSpecData, $openApiSpecPath);
+    }
 }


### PR DESCRIPTION
## Description

Adds support for writing operation and path parameters as a map keyed by parameter name in OpenAPI specifications, instead of an array of objects each repeating its own `name` member. Fixes #501.

## Changes

- Add `ParameterNameResolver` in `OpenApi3` and `OpenApi31` `SchemaParser` namespaces: before denormalization, every string key of a map-shaped `parameters` block is copied into the `name` member of its parameter. `$ref` entries are left untouched and an explicit `name` always takes precedence over the key.
- Hook the resolver into both `SchemaParser::denormalize()`, covering both JSON and YAML parse paths.
- New `parameters-map-keys` fixture covering path-level and operation-level map parameters plus explicit-name precedence.
- New unit tests (`ParameterNameResolverTest`) covering all HTTP methods, array-form passthrough, references and documents without paths.

## How to test

1. `vendor/bin/phpunit --filter ParameterNameResolverTest`
2. `vendor/bin/phpunit` (full suite, includes the new fixture comparison test)

## Notes

- Deliberately does not modify `version3.json` / generated code: regenerating the committed models with the current generator rewrites all files (~4000 lines), so names are resolved at parse time instead.
- Swagger 2.0 (OpenApi2 component) has the same limitation but is intentionally out of scope.
- No backward-compatibility impact: array-shaped parameters behave identically.
