### PR TITLE
feat(open-api): reject malformed securitySchemes entries (#565)

### DIFF
--- a/docs/guides/compatibility.md
+++ b/docs/guides/compatibility.md
@@ -85,4 +85,33 @@ Unsupported feature(s) found in your schema:
 Object-typed parameters (e.g. `deepObject` style) and schemas relying on an
 `enum` alone remain fully supported.
 
+### Malformed `securitySchemes` entries
+
+`securitySchemes` (in OpenAPI 3.x) and `securityDefinitions` (in OpenAPI 2.0)
+are maps of name => scheme definition. Feeding them a bare scheme definition —
+for instance pasting the scheme object directly under `securitySchemes`:
+
+```yaml
+# Rejected by all jane-php/open-api-* components:
+components:
+  securitySchemes:
+    type: http
+    scheme: basic
+```
+
+used to be silently ignored: generation succeeded but produced no
+authentication classes. Such entries now stop generation with the offending
+location and the expected shape:
+
+```text
+Unsupported feature(s) found in your schema:
+Security scheme entry is not a valid Security Scheme Object (string given) at "/components/securitySchemes/type". `securitySchemes` must be a map of name => scheme definition, e.g. {"myAuth": {"type": "http", "scheme": "basic"}}.
+```
+
+Entries referencing an unknown scheme `type`, or missing the fields required by
+their type (`name` / `in` for `apiKey`, `scheme` for `http` in OpenAPI 3.0.x,
+`flows` for `oauth2`, ...), are rejected the same way. Scheme types that are
+valid but produce no authentication classes with Jane (`oauth2`,
+`openIdConnect`, ...) remain accepted.
+
 

--- a/src/Component/OpenApi2/SchemaParser/SchemaParser.php
+++ b/src/Component/OpenApi2/SchemaParser/SchemaParser.php
@@ -18,4 +18,14 @@ class SchemaParser extends CommonSchemaParser
     {
         return \is_array($openApiSpecData) && \array_key_exists('swagger', $openApiSpecData) && version_compare($openApiSpecData['swagger'], '2.0', '>=') && version_compare($openApiSpecData['swagger'], '3.0', '<');
     }
+
+    /**
+     * @param array<mixed> $openApiSpecData
+     *
+     * @return array<string>
+     */
+    protected function validateSchema(array $openApiSpecData): array
+    {
+        return SecuritySchemeValidator::validate($openApiSpecData);
+    }
 }

--- a/src/Component/OpenApi2/SchemaParser/SecuritySchemeValidator.php
+++ b/src/Component/OpenApi2/SchemaParser/SecuritySchemeValidator.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Jane\Component\OpenApi2\SchemaParser;
+
+/**
+ * Detects `securityDefinitions` entries that cannot be denormalized into a
+ * Security Scheme model by this component.
+ *
+ * `securityDefinitions` is a map of name => Security Scheme Object: feeding it
+ * a bare scheme definition directly under `securityDefinitions` used to be
+ * silently ignored, generating no authentication classes and leaving the user
+ * without any explanation.
+ */
+final class SecuritySchemeValidator
+{
+    /** @var array<string> */
+    private const API_KEY_LOCATIONS = ['header', 'query'];
+
+    /**
+     * Returns one human readable error per unusable security definition entry,
+     * each pointing at the offending location as a JSON pointer (RFC 6901).
+     *
+     * @param array<mixed> $document
+     *
+     * @return array<string>
+     */
+    public static function validate(array $document): array
+    {
+        $errors = [];
+
+        if (!isset($document['securityDefinitions']) || !\is_array($document['securityDefinitions'])) {
+            return $errors;
+        }
+
+        foreach ($document['securityDefinitions'] as $name => $scheme) {
+            self::validateScheme($scheme, '/securityDefinitions/' . self::escapePointerToken((string) $name), $errors);
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string> $errors
+     */
+    private static function validateScheme(mixed $scheme, string $pointer, array &$errors): void
+    {
+        if (\is_array($scheme) && isset($scheme['$ref'])) {
+            return;
+        }
+
+        if (!\is_array($scheme)) {
+            $errors[] = \sprintf(
+                'Security scheme entry is not a valid Security Scheme Object (%s given) at "%s". `securityDefinitions` must be a map of name => scheme definition, e.g. {"myAuth": {"type": "basic"}}.',
+                get_debug_type($scheme),
+                $pointer
+            );
+
+            return;
+        }
+
+        $type = $scheme['type'] ?? null;
+
+        if (!\is_string($type)) {
+            $errors[] = \sprintf(
+                'Missing `type` for security scheme at "%s", expected one of "basic", "apiKey" or "oauth2".',
+                $pointer . '/type'
+            );
+
+            return;
+        }
+
+        switch ($type) {
+            case 'basic':
+                break;
+            case 'apiKey':
+                $missingFields = [];
+                foreach (['name', 'in'] as $field) {
+                    if (!isset($scheme[$field])) {
+                        $missingFields[] = \sprintf('`%s`', $field);
+                    }
+                }
+
+                if ([] !== $missingFields) {
+                    $errors[] = \sprintf(
+                        'Missing %s for security scheme at "%s".',
+                        implode(' and ', $missingFields),
+                        $pointer
+                    );
+                } elseif (!\in_array($scheme['in'], self::API_KEY_LOCATIONS, true)) {
+                    $errors[] = \sprintf(
+                        '`in` must be one of "header" or "query" for "apiKey" security schemes at "%s/in".',
+                        $pointer
+                    );
+                }
+                break;
+            case 'oauth2':
+                self::validateOauth2Flow($scheme, $pointer, $errors);
+                break;
+            default:
+                $errors[] = \sprintf(
+                    '`type` "%s" is not a valid security scheme type at "%s/type", expected one of "basic", "apiKey" or "oauth2".',
+                    $type,
+                    $pointer
+                );
+        }
+    }
+
+    /**
+     * @param array<mixed>  $scheme
+     * @param array<string> $errors
+     */
+    private static function validateOauth2Flow(array $scheme, string $pointer, array &$errors): void
+    {
+        $flow = $scheme['flow'] ?? null;
+
+        if (!\is_string($flow)) {
+            $errors[] = \sprintf(
+                'Missing `flow` for "oauth2" security scheme at "%s/flow", expected one of "implicit", "password", "application" or "accessCode".',
+                $pointer
+            );
+
+            return;
+        }
+
+        $requiredFields = match ($flow) {
+            'implicit' => ['authorizationUrl'],
+            'password', 'application' => ['tokenUrl'],
+            'accessCode' => ['authorizationUrl', 'tokenUrl'],
+            default => null,
+        };
+
+        if (null === $requiredFields) {
+            $errors[] = \sprintf(
+                '`flow` "%s" is not a valid oauth2 flow at "%s/flow", expected one of "implicit", "password", "application" or "accessCode".',
+                $flow,
+                $pointer
+            );
+
+            return;
+        }
+
+        $missingFields = [];
+        foreach ($requiredFields as $field) {
+            if (!isset($scheme[$field])) {
+                $missingFields[] = \sprintf('`%s`', $field);
+            }
+        }
+
+        if ([] !== $missingFields) {
+            $errors[] = \sprintf(
+                'Missing %s for "%s" flow security scheme at "%s".',
+                implode(' and ', $missingFields),
+                $flow,
+                $pointer
+            );
+        }
+    }
+
+    private static function escapePointerToken(string $token): string
+    {
+        return str_replace(['~', '/'], ['~0', '~1'], $token);
+    }
+}

--- a/src/Component/OpenApi2/Tests/SecuritySchemeValidatorTest.php
+++ b/src/Component/OpenApi2/Tests/SecuritySchemeValidatorTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Jane\Component\OpenApi2\Tests;
+
+use Jane\Component\OpenApi2\SchemaParser\SecuritySchemeValidator;
+use PHPUnit\Framework\TestCase;
+
+class SecuritySchemeValidatorTest extends TestCase
+{
+    /**
+     * @dataProvider provideDocumentsWithSecurityDefinitions
+     *
+     * @param array<mixed>  $document
+     * @param array<string> $expectedPointers
+     */
+    public function testCollectsEveryInvalidSecurityDefinitionEntry(array $document, array $expectedPointers): void
+    {
+        $errors = SecuritySchemeValidator::validate($document);
+
+        $this->assertCount(\count($expectedPointers), $errors, implode("\n", $errors));
+
+        foreach ($expectedPointers as $index => $expectedPointer) {
+            $this->assertStringContainsString(
+                \sprintf('at "%s"', $expectedPointer),
+                $errors[$index],
+                \sprintf('Error #%d does not point at "%s": %s', $index, $expectedPointer, $errors[$index])
+            );
+        }
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<mixed>, 1: array<string>}>
+     */
+    public function provideDocumentsWithSecurityDefinitions(): \Generator
+    {
+        yield 'bare scheme definition instead of named map' => [
+            [
+                'swagger' => '2.0',
+                'securityDefinitions' => [
+                    'type' => 'basic',
+                ],
+            ],
+            ['/securityDefinitions/type'],
+        ];
+
+        yield 'null entry' => [
+            [
+                'swagger' => '2.0',
+                'securityDefinitions' => [
+                    'broken' => null,
+                ],
+            ],
+            ['/securityDefinitions/broken'],
+        ];
+
+        yield 'missing type' => [
+            [
+                'swagger' => '2.0',
+                'securityDefinitions' => [
+                    'auth' => ['description' => 'no type'],
+                ],
+            ],
+            ['/securityDefinitions/auth/type'],
+        ];
+
+        yield 'unknown type' => [
+            [
+                'swagger' => '2.0',
+                'securityDefinitions' => [
+                    'auth' => ['type' => 'digest'],
+                ],
+            ],
+            ['/securityDefinitions/auth/type'],
+        ];
+
+        yield 'apiKey without name and in' => [
+            [
+                'swagger' => '2.0',
+                'securityDefinitions' => [
+                    'auth' => ['type' => 'apiKey'],
+                ],
+            ],
+            ['/securityDefinitions/auth'],
+        ];
+
+        yield 'apiKey with invalid location (cookie does not exist in OpenAPI 2.0)' => [
+            [
+                'swagger' => '2.0',
+                'securityDefinitions' => [
+                    'auth' => ['type' => 'apiKey', 'name' => 'session', 'in' => 'cookie'],
+                ],
+            ],
+            ['/securityDefinitions/auth/in'],
+        ];
+
+        yield 'oauth2 without flow' => [
+            [
+                'swagger' => '2.0',
+                'securityDefinitions' => [
+                    'auth' => ['type' => 'oauth2'],
+                ],
+            ],
+            ['/securityDefinitions/auth/flow'],
+        ];
+
+        yield 'oauth2 implicit without authorizationUrl' => [
+            [
+                'swagger' => '2.0',
+                'securityDefinitions' => [
+                    'auth' => ['type' => 'oauth2', 'flow' => 'implicit'],
+                ],
+            ],
+            ['/securityDefinitions/auth'],
+        ];
+
+        yield 'oauth2 accessCode without tokenUrl' => [
+            [
+                'swagger' => '2.0',
+                'securityDefinitions' => [
+                    'auth' => ['type' => 'oauth2', 'flow' => 'accessCode', 'authorizationUrl' => 'https://example.com/authorize'],
+                ],
+            ],
+            ['/securityDefinitions/auth'],
+        ];
+
+        yield 'oauth2 with unknown flow' => [
+            [
+                'swagger' => '2.0',
+                'securityDefinitions' => [
+                    'auth' => ['type' => 'oauth2', 'flow' => 'clientCredentials'],
+                ],
+            ],
+            ['/securityDefinitions/auth/flow'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDocumentsWithValidSecurityDefinitions
+     *
+     * @param array<mixed> $document
+     */
+    public function testValidSecurityDefinitionsProduceNoError(array $document): void
+    {
+        $this->assertSame([], SecuritySchemeValidator::validate($document));
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<mixed>}>
+     */
+    public function provideDocumentsWithValidSecurityDefinitions(): \Generator
+    {
+        yield 'basic' => [['securityDefinitions' => ['auth' => ['type' => 'basic']]]];
+        yield 'apiKey header' => [['securityDefinitions' => ['auth' => ['type' => 'apiKey', 'name' => 'api_key', 'in' => 'header']]]];
+        yield 'oauth2 implicit' => [['securityDefinitions' => ['auth' => ['type' => 'oauth2', 'flow' => 'implicit', 'authorizationUrl' => 'https://example.com/authorize']]]];
+        yield 'oauth2 password' => [['securityDefinitions' => ['auth' => ['type' => 'oauth2', 'flow' => 'password', 'tokenUrl' => 'https://example.com/token']]]];
+        yield 'oauth2 application' => [['securityDefinitions' => ['auth' => ['type' => 'oauth2', 'flow' => 'application', 'tokenUrl' => 'https://example.com/token']]]];
+        yield 'oauth2 accessCode' => [['securityDefinitions' => ['auth' => ['type' => 'oauth2', 'flow' => 'accessCode', 'authorizationUrl' => 'https://example.com/authorize', 'tokenUrl' => 'https://example.com/token']]]];
+        yield 'reference entry' => [['securityDefinitions' => ['auth' => ['$ref' => '#/securityDefinitions/other']]]];
+        yield 'no securityDefinitions at all' => [['paths' => []]];
+        yield 'non array securityDefinitions is left to denormalization' => [['securityDefinitions' => 'oops']];
+    }
+}

--- a/src/Component/OpenApi3/SchemaParser/SchemaParser.php
+++ b/src/Component/OpenApi3/SchemaParser/SchemaParser.php
@@ -37,7 +37,8 @@ class SchemaParser extends CommonSchemaParser
     {
         return array_merge(
             TypeArrayValidator::validate($openApiSpecData),
-            NonBodyParameterTypeValidator::validate($openApiSpecData)
+            NonBodyParameterTypeValidator::validate($openApiSpecData),
+            SecuritySchemeValidator::validate($openApiSpecData)
         );
     }
 }

--- a/src/Component/OpenApi3/SchemaParser/SecuritySchemeValidator.php
+++ b/src/Component/OpenApi3/SchemaParser/SecuritySchemeValidator.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Jane\Component\OpenApi3\SchemaParser;
+
+/**
+ * Detects `components.securitySchemes` entries that cannot be denormalized
+ * into a Security Scheme model by this component.
+ *
+ * `securitySchemes` is a map of name => Security Scheme Object: feeding it a
+ * bare scheme definition (e.g. `{"type": "http", "scheme": "basic"}` directly
+ * under `securitySchemes`) used to be silently ignored, generating no
+ * authentication classes and leaving the user without any explanation.
+ */
+final class SecuritySchemeValidator
+{
+    /** @var array<string> */
+    private const API_KEY_LOCATIONS = ['header', 'query', 'cookie'];
+
+    /**
+     * Returns one human readable error per unusable security scheme entry,
+     * each pointing at the offending location as a JSON pointer (RFC 6901).
+     *
+     * @param array<mixed> $document
+     *
+     * @return array<string>
+     */
+    public static function validate(array $document): array
+    {
+        $errors = [];
+
+        if (!isset($document['components']['securitySchemes']) || !\is_array($document['components']['securitySchemes'])) {
+            return $errors;
+        }
+
+        foreach ($document['components']['securitySchemes'] as $name => $scheme) {
+            self::validateScheme($scheme, '/components/securitySchemes/' . self::escapePointerToken((string) $name), $errors);
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string> $errors
+     */
+    private static function validateScheme(mixed $scheme, string $pointer, array &$errors): void
+    {
+        if (\is_array($scheme) && isset($scheme['$ref'])) {
+            return;
+        }
+
+        if (!\is_array($scheme)) {
+            $errors[] = \sprintf(
+                'Security scheme entry is not a valid Security Scheme Object (%s given) at "%s". `securitySchemes` must be a map of name => scheme definition, e.g. {"myAuth": {"type": "http", "scheme": "basic"}}.',
+                get_debug_type($scheme),
+                $pointer
+            );
+
+            return;
+        }
+
+        $type = $scheme['type'] ?? null;
+
+        if (!\is_string($type)) {
+            $errors[] = \sprintf(
+                'Missing `type` for security scheme at "%s", expected one of "apiKey", "http", "oauth2" or "openIdConnect".',
+                $pointer . '/type'
+            );
+
+            return;
+        }
+
+        switch ($type) {
+            case 'apiKey':
+                self::validateRequiredFields($scheme, ['name'], $pointer, $errors);
+                if (!isset($scheme['in']) || !\is_string($scheme['in']) || !\in_array($scheme['in'], self::API_KEY_LOCATIONS, true)) {
+                    $errors[] = \sprintf(
+                        '`in` must be one of "header", "query" or "cookie" for "apiKey" security schemes at "%s/in".',
+                        $pointer
+                    );
+                }
+                break;
+            case 'http':
+                self::validateRequiredFields($scheme, ['scheme'], $pointer, $errors);
+                break;
+            case 'oauth2':
+                self::validateRequiredFields($scheme, ['flows'], $pointer, $errors);
+                break;
+            case 'openIdConnect':
+                self::validateRequiredFields($scheme, ['openIdConnectUrl'], $pointer, $errors);
+                break;
+            default:
+                $errors[] = \sprintf(
+                    '`type` "%s" is not a valid security scheme type at "%s/type", expected one of "apiKey", "http", "oauth2" or "openIdConnect".',
+                    $type,
+                    $pointer
+                );
+        }
+    }
+
+    /**
+     * @param array<mixed>  $scheme
+     * @param array<string> $requiredFields
+     * @param array<string> $errors
+     */
+    private static function validateRequiredFields(array $scheme, array $requiredFields, string $pointer, array &$errors): void
+    {
+        $missingFields = [];
+
+        foreach ($requiredFields as $field) {
+            if (!isset($scheme[$field])) {
+                $missingFields[] = \sprintf('`%s`', $field);
+            }
+        }
+
+        if ([] !== $missingFields) {
+            $errors[] = \sprintf(
+                'Missing %s for security scheme at "%s".',
+                implode(' and ', $missingFields),
+                $pointer
+            );
+        }
+    }
+
+    private static function escapePointerToken(string $token): string
+    {
+        return str_replace(['~', '/'], ['~0', '~1'], $token);
+    }
+}

--- a/src/Component/OpenApi3/Tests/Issue565InvalidSecuritySchemeErrorTest.php
+++ b/src/Component/OpenApi3/Tests/Issue565InvalidSecuritySchemeErrorTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Jane\Component\OpenApiCommon\Console\Command\GenerateCommand;
+use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
+use Jane\Component\OpenApiCommon\Console\Loader\OpenApiMatcher;
+use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @see https://github.com/janephp/janephp/issues/565
+ */
+class Issue565InvalidSecuritySchemeErrorTest extends TestCase
+{
+    public function testBareSecuritySchemeDefinitionFailsWithCleanError(): void
+    {
+        $fixtureDirectory = sys_get_temp_dir() . '/jane-openapi3-issue565-error-' . bin2hex(random_bytes(8));
+        mkdir($fixtureDirectory . '/generated', 0777, true);
+
+        $openApiFile = $fixtureDirectory . '/openapi.json';
+        file_put_contents($openApiFile, json_encode([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test',
+                'version' => '1.0.0',
+            ],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'operationId' => 'listPets',
+                        'responses' => [
+                            '200' => ['description' => 'Ok'],
+                        ],
+                    ],
+                ],
+            ],
+            // exactly the malformed document from issue #565: the scheme
+            // definition is pasted directly under `securitySchemes` instead
+            // of being nested under a scheme name
+            'components' => [
+                'securitySchemes' => [
+                    'type' => 'http',
+                    'scheme' => 'basic',
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $configFile = $this->createConfigFile($fixtureDirectory);
+
+        try {
+            $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+            $input = new ArrayInput(['--config-file' => $configFile], $command->getDefinition());
+            $output = new BufferedOutput();
+
+            $returnCode = $command->execute($input, $output);
+            $rendered = $output->fetch();
+
+            $this->assertSame(Command::FAILURE, $returnCode);
+            // every unusable entry is reported with its exact location
+            $this->assertStringContainsString('/components/securitySchemes/type', $rendered);
+            $this->assertStringContainsString('/components/securitySchemes/scheme', $rendered);
+            $this->assertStringContainsString('map of name => scheme definition', $rendered);
+            $this->assertStringNotContainsString('TypeError', $rendered);
+            $this->assertStringNotContainsString('Undefined array key', $rendered);
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    public function testNamedSecuritySchemeStillGeneratesAuthentication(): void
+    {
+        $fixtureDirectory = sys_get_temp_dir() . '/jane-openapi3-issue565-ok-' . bin2hex(random_bytes(8));
+        mkdir($fixtureDirectory . '/generated', 0777, true);
+
+        $openApiFile = $fixtureDirectory . '/openapi.json';
+        file_put_contents($openApiFile, json_encode([
+            'openapi' => '3.0.2',
+            'info' => [
+                'title' => 'Test',
+                'version' => '1.0.0',
+            ],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'operationId' => 'listPets',
+                        'responses' => [
+                            '200' => ['description' => 'Ok'],
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'securitySchemes' => [
+                    'basicAuth' => [
+                        'type' => 'http',
+                        'scheme' => 'basic',
+                    ],
+                ],
+            ],
+        ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+        $configFile = $this->createConfigFile($fixtureDirectory);
+
+        try {
+            $command = new GenerateCommand(new ConfigLoader(), new SchemaLoader(), new OpenApiMatcher());
+            $input = new ArrayInput(['--config-file' => $configFile], $command->getDefinition());
+            $output = new BufferedOutput();
+
+            $returnCode = $command->execute($input, $output);
+
+            $this->assertSame(Command::SUCCESS, $returnCode, $output->fetch());
+            $this->assertFileExists($fixtureDirectory . '/generated/Authentication/BasicAuthAuthentication.php');
+        } finally {
+            $this->removeDirectory($fixtureDirectory);
+        }
+    }
+
+    private function createConfigFile(string $fixtureDirectory): string
+    {
+        $configFile = $fixtureDirectory . '/.jane-openapi';
+        file_put_contents($configFile, \sprintf(
+            "<?php\n\nreturn [\n    'openapi-file' => %s,\n    'namespace' => 'Jane\\\\Component\\\\OpenApi3\\\\Tests\\\\Issue565Generated',\n    'directory' => %s,\n];\n",
+            var_export($fixtureDirectory . '/openapi.json', true),
+            var_export($fixtureDirectory . '/generated', true)
+        ));
+
+        return $configFile;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $entries = scandir($path);
+        if (false === $entries) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+
+            $entryPath = $path . '/' . $entry;
+            if (is_dir($entryPath)) {
+                $this->removeDirectory($entryPath);
+                continue;
+            }
+
+            unlink($entryPath);
+        }
+
+        rmdir($path);
+    }
+}

--- a/src/Component/OpenApi3/Tests/SecuritySchemeValidatorTest.php
+++ b/src/Component/OpenApi3/Tests/SecuritySchemeValidatorTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Jane\Component\OpenApi3\SchemaParser\SecuritySchemeValidator;
+use PHPUnit\Framework\TestCase;
+
+class SecuritySchemeValidatorTest extends TestCase
+{
+    /**
+     * @dataProvider provideDocumentsWithSecuritySchemes
+     *
+     * @param array<mixed>  $document
+     * @param array<string> $expectedPointers
+     */
+    public function testCollectsEveryInvalidSecuritySchemeEntry(array $document, array $expectedPointers): void
+    {
+        $errors = SecuritySchemeValidator::validate($document);
+
+        $this->assertCount(\count($expectedPointers), $errors, implode("\n", $errors));
+
+        foreach ($expectedPointers as $index => $expectedPointer) {
+            $this->assertStringContainsString(
+                \sprintf('at "%s"', $expectedPointer),
+                $errors[$index],
+                \sprintf('Error #%d does not point at "%s": %s', $index, $expectedPointer, $errors[$index])
+            );
+        }
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<mixed>, 1: array<string>}>
+     */
+    public function provideDocumentsWithSecuritySchemes(): \Generator
+    {
+        yield 'issue 565: bare scheme definition instead of named map' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'securitySchemes' => [
+                        'type' => 'http',
+                        'scheme' => 'basic',
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/type', '/components/securitySchemes/scheme'],
+        ];
+
+        yield 'null entry' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'securitySchemes' => [
+                        'broken' => null,
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/broken'],
+        ];
+
+        yield 'missing type' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'securitySchemes' => [
+                        'auth' => ['scheme' => 'basic'],
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/auth/type'],
+        ];
+
+        yield 'unknown type' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'securitySchemes' => [
+                        'auth' => ['type' => 'digest'],
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/auth/type'],
+        ];
+
+        yield 'apiKey without name and in' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'securitySchemes' => [
+                        'auth' => ['type' => 'apiKey'],
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/auth', '/components/securitySchemes/auth/in'],
+        ];
+
+        yield 'http without scheme' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'securitySchemes' => [
+                        'auth' => ['type' => 'http'],
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/auth'],
+        ];
+
+        yield 'oauth2 without flows' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'securitySchemes' => [
+                        'auth' => ['type' => 'oauth2'],
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/auth'],
+        ];
+
+        yield 'openIdConnect without openIdConnectUrl' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'securitySchemes' => [
+                        'auth' => ['type' => 'openIdConnect'],
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/auth'],
+        ];
+
+        yield 'pointer tokens are escaped' => [
+            [
+                'openapi' => '3.0.2',
+                'components' => [
+                    'securitySchemes' => [
+                        'a/b~c' => 'nope',
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/a~1b~0c'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDocumentsWithValidSecuritySchemes
+     *
+     * @param array<mixed> $document
+     */
+    public function testValidSecuritySchemesProduceNoError(array $document): void
+    {
+        $this->assertSame([], SecuritySchemeValidator::validate($document));
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<mixed>}>
+     */
+    public function provideDocumentsWithValidSecuritySchemes(): \Generator
+    {
+        yield 'http basic' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'http', 'scheme' => 'basic']]]]];
+        yield 'http bearer with format' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'http', 'scheme' => 'bearer', 'bearerFormat' => 'JWT']]]]];
+        yield 'apiKey header' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'apiKey', 'name' => 'X-Api-Key', 'in' => 'header']]]]];
+        yield 'oauth2' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'oauth2', 'flows' => []]]]]];
+        yield 'openIdConnect' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'openIdConnect', 'openIdConnectUrl' => 'https://example.com/.well-known/openid-configuration']]]]];
+        yield 'reference entry' => [['components' => ['securitySchemes' => ['auth' => ['$ref' => '#/components/securitySchemes/other']]]]];
+        yield 'unsupported types are not rejected (valid OpenAPI)' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'oauth2', 'flows' => ['implicit' => ['scopes' => []]]]]]]];
+        yield 'no securitySchemes at all' => [['components' => ['schemas' => []]]];
+        yield 'non array securitySchemes is left to denormalization' => [['components' => ['securitySchemes' => 'oops']]];
+    }
+
+    public function testHintExplainsTheMapStructure(): void
+    {
+        $errors = SecuritySchemeValidator::validate([
+            'openapi' => '3.0.2',
+            'components' => [
+                'securitySchemes' => [
+                    'type' => 'http',
+                ],
+            ],
+        ]);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('map of name => scheme definition', $errors[0]);
+        $this->assertStringContainsString('{"myAuth": {"type": "http", "scheme": "basic"}}', $errors[0]);
+    }
+}

--- a/src/Component/OpenApi31/SchemaParser/SchemaParser.php
+++ b/src/Component/OpenApi31/SchemaParser/SchemaParser.php
@@ -27,4 +27,14 @@ class SchemaParser extends CommonSchemaParser
 
         return parent::denormalize($openApiSpecData, $openApiSpecPath);
     }
+
+    /**
+     * @param array<mixed> $openApiSpecData
+     *
+     * @return array<string>
+     */
+    protected function validateSchema(array $openApiSpecData): array
+    {
+        return SecuritySchemeValidator::validate($openApiSpecData);
+    }
 }

--- a/src/Component/OpenApi31/SchemaParser/SecuritySchemeValidator.php
+++ b/src/Component/OpenApi31/SchemaParser/SecuritySchemeValidator.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Jane\Component\OpenApi31\SchemaParser;
+
+/**
+ * Detects `components.securitySchemes` entries that cannot be denormalized
+ * into a Security Scheme model by this component.
+ *
+ * `securitySchemes` is a map of name => Security Scheme Object: feeding it a
+ * bare scheme definition (e.g. `{"type": "http", "scheme": "basic"}` directly
+ * under `securitySchemes`) used to be silently ignored, generating no
+ * authentication classes and leaving the user without any explanation.
+ */
+final class SecuritySchemeValidator
+{
+    /** @var array<string> */
+    private const VALID_TYPES = ['apiKey', 'http', 'mutualTLS', 'oauth2', 'openIdConnect'];
+
+    /** @var array<string> */
+    private const API_KEY_LOCATIONS = ['header', 'query', 'cookie'];
+
+    /**
+     * Returns one human readable error per unusable security scheme entry,
+     * each pointing at the offending location as a JSON pointer (RFC 6901).
+     *
+     * @param array<mixed> $document
+     *
+     * @return array<string>
+     */
+    public static function validate(array $document): array
+    {
+        $errors = [];
+
+        if (!isset($document['components']['securitySchemes']) || !\is_array($document['components']['securitySchemes'])) {
+            return $errors;
+        }
+
+        foreach ($document['components']['securitySchemes'] as $name => $scheme) {
+            self::validateScheme($scheme, '/components/securitySchemes/' . self::escapePointerToken((string) $name), $errors);
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string> $errors
+     */
+    private static function validateScheme(mixed $scheme, string $pointer, array &$errors): void
+    {
+        if (\is_array($scheme) && isset($scheme['$ref'])) {
+            return;
+        }
+
+        if (!\is_array($scheme)) {
+            $errors[] = \sprintf(
+                'Security scheme entry is not a valid Security Scheme Object (%s given) at "%s". `securitySchemes` must be a map of name => scheme definition, e.g. {"myAuth": {"type": "http", "scheme": "basic"}}.',
+                get_debug_type($scheme),
+                $pointer
+            );
+
+            return;
+        }
+
+        $type = $scheme['type'] ?? null;
+
+        if (!\is_string($type)) {
+            $errors[] = \sprintf(
+                'Missing `type` for security scheme at "%s", expected one of "apiKey", "http", "mutualTLS", "oauth2" or "openIdConnect".',
+                $pointer . '/type'
+            );
+
+            return;
+        }
+
+        if (!\in_array($type, self::VALID_TYPES, true)) {
+            $errors[] = \sprintf(
+                '`type` "%s" is not a valid security scheme type at "%s/type", expected one of "apiKey", "http", "mutualTLS", "oauth2" or "openIdConnect".',
+                $type,
+                $pointer
+            );
+
+            return;
+        }
+
+        if ('apiKey' === $type) {
+            $missingFields = [];
+            foreach (['name', 'in'] as $field) {
+                if (!isset($scheme[$field])) {
+                    $missingFields[] = \sprintf('`%s`', $field);
+                }
+            }
+
+            if ([] !== $missingFields) {
+                $errors[] = \sprintf(
+                    'Missing %s for security scheme at "%s".',
+                    implode(' and ', $missingFields),
+                    $pointer
+                );
+            } elseif (!\in_array($scheme['in'], self::API_KEY_LOCATIONS, true)) {
+                $errors[] = \sprintf(
+                    '`in` must be one of "header", "query" or "cookie" for "apiKey" security schemes at "%s/in".',
+                    $pointer
+                );
+            }
+        }
+    }
+
+    private static function escapePointerToken(string $token): string
+    {
+        return str_replace(['~', '/'], ['~0', '~1'], $token);
+    }
+}

--- a/src/Component/OpenApi31/Tests/SecuritySchemeValidatorTest.php
+++ b/src/Component/OpenApi31/Tests/SecuritySchemeValidatorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests;
+
+use Jane\Component\OpenApi31\SchemaParser\SecuritySchemeValidator;
+use PHPUnit\Framework\TestCase;
+
+class SecuritySchemeValidatorTest extends TestCase
+{
+    /**
+     * @dataProvider provideDocumentsWithSecuritySchemes
+     *
+     * @param array<mixed>  $document
+     * @param array<string> $expectedPointers
+     */
+    public function testCollectsEveryInvalidSecuritySchemeEntry(array $document, array $expectedPointers): void
+    {
+        $errors = SecuritySchemeValidator::validate($document);
+
+        $this->assertCount(\count($expectedPointers), $errors, implode("\n", $errors));
+
+        foreach ($expectedPointers as $index => $expectedPointer) {
+            $this->assertStringContainsString(
+                \sprintf('at "%s"', $expectedPointer),
+                $errors[$index],
+                \sprintf('Error #%d does not point at "%s": %s', $index, $expectedPointer, $errors[$index])
+            );
+        }
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<mixed>, 1: array<string>}>
+     */
+    public function provideDocumentsWithSecuritySchemes(): \Generator
+    {
+        yield 'issue 565: bare scheme definition instead of named map' => [
+            [
+                'openapi' => '3.1.0',
+                'components' => [
+                    'securitySchemes' => [
+                        'type' => 'http',
+                        'scheme' => 'basic',
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/type', '/components/securitySchemes/scheme'],
+        ];
+
+        yield 'null entry' => [
+            [
+                'openapi' => '3.1.0',
+                'components' => [
+                    'securitySchemes' => [
+                        'broken' => null,
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/broken'],
+        ];
+
+        yield 'missing type' => [
+            [
+                'openapi' => '3.1.0',
+                'components' => [
+                    'securitySchemes' => [
+                        'auth' => ['description' => 'no type'],
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/auth/type'],
+        ];
+
+        yield 'unknown type' => [
+            [
+                'openapi' => '3.1.0',
+                'components' => [
+                    'securitySchemes' => [
+                        'auth' => ['type' => 'digest'],
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/auth/type'],
+        ];
+
+        yield 'apiKey without name and in' => [
+            [
+                'openapi' => '3.1.0',
+                'components' => [
+                    'securitySchemes' => [
+                        'auth' => ['type' => 'apiKey'],
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/auth'],
+        ];
+
+        yield 'apiKey with invalid location' => [
+            [
+                'openapi' => '3.1.0',
+                'components' => [
+                    'securitySchemes' => [
+                        'auth' => ['type' => 'apiKey', 'name' => 'X-Api-Key', 'in' => 'body'],
+                    ],
+                ],
+            ],
+            ['/components/securitySchemes/auth/in'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDocumentsWithValidSecuritySchemes
+     *
+     * @param array<mixed> $document
+     */
+    public function testValidSecuritySchemesProduceNoError(array $document): void
+    {
+        $this->assertSame([], SecuritySchemeValidator::validate($document));
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<mixed>}>
+     */
+    public function provideDocumentsWithValidSecuritySchemes(): \Generator
+    {
+        // in OpenAPI 3.1 `scheme` is optional for http schemes (RFC 7235 defaults)
+        yield 'http without scheme' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'http']]]]];
+        yield 'http bearer' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'http', 'scheme' => 'bearer', 'bearerFormat' => 'JWT']]]]];
+        yield 'apiKey cookie' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'apiKey', 'name' => 'session', 'in' => 'cookie']]]]];
+        yield 'mutualTLS has no required companion fields' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'mutualTLS']]]]];
+        yield 'oauth2' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'oauth2', 'flows' => []]]]]];
+        yield 'openIdConnect' => [['components' => ['securitySchemes' => ['auth' => ['type' => 'openIdConnect', 'openIdConnectUrl' => 'https://example.com/.well-known/openid-configuration']]]]];
+        yield 'reference entry' => [['components' => ['securitySchemes' => ['auth' => ['$ref' => '#/components/securitySchemes/other']]]]];
+        yield 'no securitySchemes at all' => [['components' => ['schemas' => []]]];
+        yield 'non array securitySchemes is left to denormalization' => [['components' => ['securitySchemes' => 'oops']]];
+    }
+}


### PR DESCRIPTION
## Description

Adds pre-generation validation of `securitySchemes` / `securityDefinitions` entries, following ADR 0002. Feeding a malformed security scheme section — for example pasting a bare scheme definition (`{"type": "http", "scheme": "basic"}`) directly under `securitySchemes` instead of nesting it under a scheme name — used to be silently ignored: generation succeeded but produced no authentication classes and no explanation (issue #565). Such documents now fail fast with one readable error per violation.

## Changes

- New `SecuritySchemeValidator` per component, registered on the existing ADR 0002 `SchemaParser::validateSchema()` hook:
  - OpenApi3: entries must be `$ref` or match a denormalizable shape — `apiKey` (+`name`, +`in` ∈ header/query/cookie), `http` (+`scheme`), `oauth2` (+`flows`), `openIdConnect` (+`openIdConnectUrl`)
  - OpenApi31: same map rule; accepts the five 3.1 types (`apiKey`, `http`, `mutualTLS`, `oauth2`, `openIdConnect`), `scheme` stays optional
  - OpenApi2: validates `securityDefinitions` — `basic`, `apiKey` (+`name`, +`in` ∈ header/query), `oauth2` with flow-specific required fields (`implicit`/`password`/`application`/`accessCode`)
- Errors carry an RFC 6901 JSON pointer per entry plus a hint showing the expected map shape; all violations are reported in a single run via the existing `[ERROR]` console rendering (`InvalidSchemaException`)
- Scheme types that are valid but unsupported for generation (`oauth2`, `openIdConnect`, swagger2 `basic`) remain accepted to avoid breaking real-world specs
- Documented the new behavior under "Malformed `securitySchemes` entries" in the compatibility guide

No generated fixture changes: valid documents generate identical code.

## How to test

1. `vendor/bin/phpunit src/Component/OpenApi3/Tests/SecuritySchemeValidatorTest.php src/Component/OpenApi31/Tests/SecuritySchemeValidatorTest.php src/Component/OpenApi2/Tests/SecuritySchemeValidatorTest.php`
2. `vendor/bin/phpunit src/Component/OpenApi3/Tests/Issue565InvalidSecuritySchemeErrorTest.php` — runs the exact document from issue #565 through `GenerateCommand` and asserts a clean failure pointing at both offending entries
3. Full suite: `vendor/bin/phpunit`

## Notes

- Behavioral change limited to error reporting: previously silently-skipped unusable entries now stop generation (same philosophy as #759/#771)
- Verified zero false positives against all 21 existing fixtures containing security schemes across the three components

