### PR TITLE
feat(open-api): support status code range responses (#724)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,3 +23,4 @@ parameters:
 		-
 			message: '#^Call to method [a-zA-Z]+\(\) on an unknown class Jane\\Component\\OpenApi31\\Tests\\DiscriminatorExpected\\(Model|Normalizer)\\[A-Za-z0-9]+\.$#'
 			path: src/Component/OpenApi31/Tests/DiscriminatorDispatchRuntimeTest.php
+

--- a/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi3/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -12,6 +12,7 @@ use Jane\Component\OpenApi3\JsonSchema\Normalizer\ResponseNormalizer;
 use Jane\Component\OpenApiCommon\Generator\ContentType;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
 use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
+use Jane\Component\OpenApiCommon\Generator\Traits\StatusCodeRangeTrait;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
 use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
 use Jane\Component\OpenApiCommon\Registry\Registry;
@@ -27,6 +28,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 trait GetTransformResponseBodyTrait
 {
     use OpenApiNumberTypeResolverTrait;
+    use StatusCodeRangeTrait;
 
     public function getTransformResponseBody(OperationGuess $operation, string $endpointName, GuessClass $guessClass, ExceptionGenerator $exceptionGenerator, Context $context): array
     {
@@ -41,7 +43,12 @@ trait GetTransformResponseBodyTrait
         $throwTypes = [];
 
         if ($operation->getOperation()->getResponses()) {
-            foreach ($operation->getOperation()->getResponses() as $status => $response) {
+            $responses = $operation->getOperation()->getResponses();
+            $statuses = array_keys(iterator_to_array($responses));
+            usort($statuses, fn (int|string $a, int|string $b): int => (int) $this->isStatusCodeRange($a) <=> (int) $this->isStatusCodeRange($b));
+
+            foreach ($statuses as $status) {
+                $response = $responses[$status];
                 $reference = $operation->getReference() . '/responses/' . $status;
 
                 if ($response instanceof Reference) {
@@ -195,10 +202,7 @@ EOD
             }
 
             return [$returnTypes, $throwTypes, [new Stmt\If_(
-                new Expr\BinaryOp\Identical(
-                    new Scalar\LNumber((int) $status),
-                    new Expr\Variable('status')
-                ),
+                $this->createStatusCondition($status),
                 [
                     'stmts' => [$returnStatement],
                 ]
@@ -266,10 +270,7 @@ EOD
                         new Expr\ConstFetch(new Name('false'))
                     ),
                     new Expr\BinaryOp\BooleanAnd(
-                        new Expr\BinaryOp\Identical(
-                            new Scalar\LNumber((int) $status),
-                            new Expr\Variable('status')
-                        ),
+                        $this->createStatusCondition($status),
                         $statements[0]->cond
                     )
                 ),
@@ -280,10 +281,7 @@ EOD
         }
 
         return [$returnTypes, $throwTypes, [new Stmt\If_(
-            new Expr\BinaryOp\Identical(
-                new Scalar\LNumber((int) $status),
-                new Expr\Variable('status')
-            ),
+            $this->createStatusCondition($status),
             [
                 'stmts' => $statements,
             ]
@@ -331,10 +329,11 @@ EOD
 
         /** @var Registry $registry */
         $registry = $context->getRegistry();
-        if ((int) $status >= 400 && $registry->getGenerateErrorExceptions()) {
+        $lowerBound = $this->isStatusCodeRange($status) ? $this->statusCodeRangeBounds($status)[0] : (int) $status;
+        if ($lowerBound >= 400 && $registry->getGenerateErrorExceptions()) {
             $exceptionName = $exceptionGenerator->generate(
                 $name,
-                (int) $status,
+                $status,
                 $context,
                 $classGuess,
                 $array,
@@ -375,5 +374,22 @@ EOD
             'array' => 'array',
             default => null,
         };
+    }
+
+    private function createStatusCondition(int|string $status): Expr\BinaryOp
+    {
+        if ($this->isStatusCodeRange($status)) {
+            [$min, $max] = $this->statusCodeRangeBounds((string) $status);
+
+            return new Expr\BinaryOp\BooleanAnd(
+                new Expr\BinaryOp\GreaterOrEqual(new Expr\Variable('status'), new Scalar\LNumber($min)),
+                new Expr\BinaryOp\SmallerOrEqual(new Expr\Variable('status'), new Scalar\LNumber($max))
+            );
+        }
+
+        return new Expr\BinaryOp\Identical(
+            new Scalar\LNumber((int) $status),
+            new Expr\Variable('status')
+        );
     }
 }

--- a/src/Component/OpenApi3/Tests/StatusCodeRangeTest.php
+++ b/src/Component/OpenApi3/Tests/StatusCodeRangeTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests;
+
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Endpoint\GetFoo;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\ClientErrorException;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\ClientException;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooClientErrorException;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooNotFoundException;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooServerErrorException;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\ServerErrorException;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\ServerException;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client\Client;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @see https://github.com/janephp/janephp/issues/724
+ */
+class StatusCodeRangeTest extends TestCase
+{
+    private const FIXTURE_DIR = __DIR__ . '/fixtures/status-code-range/expected';
+
+    protected function setUp(): void
+    {
+        foreach ([
+            'Runtime/AdditionalPropertiesInterface',
+            'Runtime/AdditionalAndPatternProperties',
+            'Model/Message',
+            'Runtime/Client/Client',
+            'Runtime/Client/Endpoint',
+            'Runtime/Client/EndpointTrait',
+            'Runtime/Client/BaseEndpoint',
+            'Endpoint/GetFoo',
+            'Exception/ApiException',
+            'Exception/ClientException',
+            'Exception/ServerException',
+            'Exception/WithResponseInterface',
+            'Exception/ClientErrorException',
+            'Exception/ServerErrorException',
+            'Exception/NotFoundException',
+            'Exception/GetFooNotFoundException',
+            'Exception/GetFooClientErrorException',
+            'Exception/GetFooServerErrorException',
+        ] as $file) {
+            require_once self::FIXTURE_DIR . '/' . $file . '.php';
+        }
+    }
+
+    private function parse(Response $response, ?SerializerInterface $serializer = null): mixed
+    {
+        $endpoint = new GetFoo();
+
+        return $endpoint->parseResponse($response, $serializer ?? $this->createMock(SerializerInterface::class), Client::FETCH_OBJECT);
+    }
+
+    public function testExactStatusCodeTakesPrecedenceOverRange(): void
+    {
+        $response = new Response(404);
+
+        try {
+            $this->parse($response);
+            self::fail('No exception thrown for documented exact status.');
+        } catch (GetFooNotFoundException $e) {
+            self::assertSame('Not found', $e->getMessage());
+            self::assertSame($response, $e->getResponse());
+        }
+    }
+
+    public function testClientErrorRangeCatchesAll4xxStatuses(): void
+    {
+        foreach ([400, 409, 422, 499] as $statusCode) {
+            $response = new Response($statusCode);
+
+            try {
+                $this->parse($response);
+                self::fail(\sprintf('No exception thrown for status %d.', $statusCode));
+            } catch (GetFooClientErrorException $e) {
+                self::assertInstanceOf(ClientErrorException::class, $e);
+                self::assertInstanceOf(ClientException::class, $e);
+                self::assertSame('Client error', $e->getMessage());
+                self::assertSame($response, $e->getResponse());
+            }
+        }
+    }
+
+    public function testServerErrorRangeCatchesAll5xxStatuses(): void
+    {
+        $payload = new Message();
+        $payload->setMessage('error');
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('deserialize')->willReturn($payload);
+
+        foreach ([500, 503, 599] as $statusCode) {
+            $response = new Response($statusCode, ['Content-Type' => 'application/json'], '{"message":"error"}');
+
+            try {
+                $this->parse($response, $serializer);
+                self::fail(\sprintf('No exception thrown for status %d.', $statusCode));
+            } catch (GetFooServerErrorException $e) {
+                self::assertInstanceOf(ServerErrorException::class, $e);
+                self::assertInstanceOf(ServerException::class, $e);
+                self::assertSame('Server error', $e->getMessage());
+                self::assertSame($payload, $e->getMessageObject());
+                self::assertSame($response, $e->getResponse());
+            }
+        }
+    }
+
+    public function testUndocumentedStatusFallsBackToDefaultResponse(): void
+    {
+        self::assertNull($this->parse(new Response(302)));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/.jane-openapi
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\Component\OpenApi3\Tests\StatusCodeRange',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Client.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange;
+
+class Client extends \Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooNotFoundException
+     * @throws \Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooClientErrorException
+     * @throws \Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooServerErrorException
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getFoo(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi3\Tests\StatusCodeRange\Endpoint\GetFoo(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi3\Tests\StatusCodeRange\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Endpoint/GetFoo.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Endpoint/GetFoo.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Endpoint;
+
+class GetFoo extends \Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/foo';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooNotFoundException
+     * @throws \Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooClientErrorException
+     * @throws \Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooServerErrorException
+     *
+     * @return null|\Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message', 'json');
+        }
+        if (404 === $status) {
+            throw new \Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooNotFoundException($response);
+        }
+        if ($status >= 400 && $status <= 499) {
+            throw new \Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooClientErrorException($response);
+        }
+        if (is_null($contentType) === false && ($status >= 500 && $status <= 599 && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception\GetFooServerErrorException($serializer->deserialize($body, 'Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message', 'json'), $response);
+        }
+        return null;
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/ApiException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/ClientErrorException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/ClientErrorException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception;
+
+abstract class ClientErrorException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/ClientException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/GetFooClientErrorException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/GetFooClientErrorException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception;
+
+class GetFooClientErrorException extends ClientErrorException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Client error');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/GetFooNotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/GetFooNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception;
+
+class GetFooNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/GetFooServerErrorException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/GetFooServerErrorException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception;
+
+class GetFooServerErrorException extends ServerErrorException
+{
+    /**
+     * @var \Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message
+     */
+    private $messageObject;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message $message, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Server error');
+        $this->messageObject = $message;
+        $this->response = $response;
+    }
+    public function getMessageObject(): \Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message
+    {
+        return $this->messageObject;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/NotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception;
+
+abstract class NotFoundException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 404);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/ServerErrorException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/ServerErrorException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception;
+
+abstract class ServerErrorException extends \RuntimeException implements ServerException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/ServerException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/WithResponseInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Exception/WithResponseInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Exception;
+
+interface WithResponseInterface
+{
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Model/Message.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Model/Message.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Model;
+
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\AdditionalPropertiesInterface;
+class Message implements AdditionalPropertiesInterface
+{
+    use AdditionalAndPatternProperties;
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $message;
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+    /**
+     * @param string $message
+     *
+     * @return self
+     */
+    public function setMessage(string $message): self
+    {
+        $this->initialized['message'] = true;
+        $this->message = $message;
+        return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['message' => ['message', 'getMessage', 'setMessage']];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Normalizer;
+
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message::class => \Jane\Component\OpenApi3\Tests\StatusCodeRange\Normalizer\MessageNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return array_combine(array_keys($this->normalizers), array_fill(0, count($this->normalizers), false));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Normalizer/MessageNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Normalizer/MessageNormalizer.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class MessageNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('message', $data)) {
+            $object->setMessage($data['message']);
+            unset($data['message']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('message') && null !== $data->getMessage()) {
+            $dataArray['message'] = $data->getMessage();
+        }
+        foreach ($data->additionalPropertyEntries() as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi3\Tests\StatusCodeRange\Model\Message::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$definition[1]}();
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$definition[1]}();
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi3\Tests\StatusCodeRange\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi3/Tests/fixtures/status-code-range/openapi.json
+++ b/src/Component/OpenApi3/Tests/fixtures/status-code-range/openapi.json
@@ -1,0 +1,62 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "version": "1.0.0",
+        "title": "Status code range"
+    },
+    "servers": [
+        {
+            "url": "/"
+        }
+    ],
+    "paths": {
+        "/foo": {
+            "get": {
+                "operationId": "getFoo",
+                "responses": {
+                    "4XX": {
+                        "description": "Client error"
+                    },
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "5XX": {
+                        "description": "Server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected response"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Message": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Component/OpenApi31/Generator/Endpoint/GetTransformResponseBodyTrait.php
+++ b/src/Component/OpenApi31/Generator/Endpoint/GetTransformResponseBodyTrait.php
@@ -12,6 +12,7 @@ use Jane\Component\OpenApi31\JsonSchema\Normalizer\ResponseNormalizer;
 use Jane\Component\OpenApiCommon\Generator\ContentType;
 use Jane\Component\OpenApiCommon\Generator\ExceptionGenerator;
 use Jane\Component\OpenApiCommon\Generator\Traits\OpenApiNumberTypeResolverTrait;
+use Jane\Component\OpenApiCommon\Generator\Traits\StatusCodeRangeTrait;
 use Jane\Component\OpenApiCommon\Guesser\Guess\OperationGuess;
 use Jane\Component\OpenApiCommon\Naming\XNamespaceResolver;
 use Jane\Component\OpenApiCommon\Registry\Registry;
@@ -27,6 +28,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 trait GetTransformResponseBodyTrait
 {
     use OpenApiNumberTypeResolverTrait;
+    use StatusCodeRangeTrait;
 
     public function getTransformResponseBody(OperationGuess $operation, string $endpointName, GuessClass $guessClass, ExceptionGenerator $exceptionGenerator, Context $context): array
     {
@@ -41,7 +43,12 @@ trait GetTransformResponseBodyTrait
         $throwTypes = [];
 
         if ($operation->getOperation()->getResponses()) {
-            foreach ($operation->getOperation()->getResponses() as $status => $response) {
+            $responses = $operation->getOperation()->getResponses();
+            $statuses = array_keys(iterator_to_array($responses));
+            usort($statuses, fn (int|string $a, int|string $b): int => (int) $this->isStatusCodeRange($a) <=> (int) $this->isStatusCodeRange($b));
+
+            foreach ($statuses as $status) {
+                $response = $responses[$status];
                 $reference = $operation->getReference() . '/responses/' . $status;
 
                 if ($response instanceof Reference) {
@@ -194,10 +201,7 @@ EOD
             }
 
             return [$returnTypes, $throwTypes, [new Stmt\If_(
-                new Expr\BinaryOp\Identical(
-                    new Scalar\LNumber((int) $status),
-                    new Expr\Variable('status')
-                ),
+                $this->createStatusCondition($status),
                 [
                     'stmts' => [$returnStatement],
                 ]
@@ -264,10 +268,7 @@ EOD
                         new Expr\ConstFetch(new Name('false'))
                     ),
                     new Expr\BinaryOp\BooleanAnd(
-                        new Expr\BinaryOp\Identical(
-                            new Scalar\LNumber((int) $status),
-                            new Expr\Variable('status')
-                        ),
+                        $this->createStatusCondition($status),
                         $statements[0]->cond
                     )
                 ),
@@ -278,10 +279,7 @@ EOD
         }
 
         return [$returnTypes, $throwTypes, [new Stmt\If_(
-            new Expr\BinaryOp\Identical(
-                new Scalar\LNumber((int) $status),
-                new Expr\Variable('status')
-            ),
+            $this->createStatusCondition($status),
             [
                 'stmts' => $statements,
             ]
@@ -329,10 +327,11 @@ EOD
 
         /** @var Registry $registry */
         $registry = $context->getRegistry();
-        if ((int) $status >= 400 && $registry->getGenerateErrorExceptions()) {
+        $lowerBound = $this->isStatusCodeRange($status) ? $this->statusCodeRangeBounds($status)[0] : (int) $status;
+        if ($lowerBound >= 400 && $registry->getGenerateErrorExceptions()) {
             $exceptionName = $exceptionGenerator->generate(
                 $name,
-                (int) $status,
+                $status,
                 $context,
                 $classGuess,
                 $array,
@@ -377,5 +376,22 @@ EOD
             'array' => 'array',
             default => null,
         };
+    }
+
+    private function createStatusCondition(int|string $status): Expr\BinaryOp
+    {
+        if ($this->isStatusCodeRange($status)) {
+            [$min, $max] = $this->statusCodeRangeBounds((string) $status);
+
+            return new Expr\BinaryOp\BooleanAnd(
+                new Expr\BinaryOp\GreaterOrEqual(new Expr\Variable('status'), new Scalar\LNumber($min)),
+                new Expr\BinaryOp\SmallerOrEqual(new Expr\Variable('status'), new Scalar\LNumber($max))
+            );
+        }
+
+        return new Expr\BinaryOp\Identical(
+            new Scalar\LNumber((int) $status),
+            new Expr\Variable('status')
+        );
     }
 }

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/.jane-openapi
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/.jane-openapi
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'openapi-file' => __DIR__ . '/openapi.json',
+    'namespace' => 'Jane\Component\OpenApi31\Tests\StatusCodeRange',
+    'directory' => __DIR__ . '/generated',
+];

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Client.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange;
+
+class Client extends \Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client\Client
+{
+    /**
+     * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
+     * @throws \Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception\GetFooNotFoundException
+     * @throws \Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception\GetFooClientErrorException
+     * @throws \Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception\GetFooServerErrorException
+     *
+     * @return ($fetch is 'object' ? null|\Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message : \Psr\Http\Message\ResponseInterface)
+     */
+    public function getFoo(string $fetch = self::FETCH_OBJECT)
+    {
+        return $this->executeEndpoint(new \Jane\Component\OpenApi31\Tests\StatusCodeRange\Endpoint\GetFoo(), $fetch);
+    }
+    public static function create($httpClient = null, array $additionalPlugins = [], array $additionalNormalizers = [])
+    {
+        if (null === $httpClient) {
+            $httpClient = \Http\Discovery\Psr18ClientDiscovery::find();
+            $plugins = [];
+            if (count($additionalPlugins) > 0) {
+                $plugins = array_merge($plugins, $additionalPlugins);
+            }
+            $httpClient = new \Http\Client\Common\PluginClient($httpClient, $plugins);
+        }
+        $requestFactory = \Http\Discovery\Psr17FactoryDiscovery::findRequestFactory();
+        $streamFactory = \Http\Discovery\Psr17FactoryDiscovery::findStreamFactory();
+        $normalizers = [new \Symfony\Component\Serializer\Normalizer\ArrayDenormalizer(), new \Jane\Component\OpenApi31\Tests\StatusCodeRange\Normalizer\JaneObjectNormalizer()];
+        if (count($additionalNormalizers) > 0) {
+            $normalizers = array_merge($normalizers, $additionalNormalizers);
+        }
+        $serializer = new \Symfony\Component\Serializer\Serializer($normalizers, [new \Symfony\Component\Serializer\Encoder\JsonEncoder(new \Symfony\Component\Serializer\Encoder\JsonEncode(), new \Symfony\Component\Serializer\Encoder\JsonDecode(['json_decode_associative' => true]))]);
+        return new static($httpClient, $requestFactory, $serializer, $streamFactory);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Endpoint/GetFoo.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Endpoint/GetFoo.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Endpoint;
+
+class GetFoo extends \Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client\BaseEndpoint implements \Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client\Endpoint
+{
+    use \Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client\EndpointTrait;
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
+    public function getUri(): string
+    {
+        return '/foo';
+    }
+    public function getBody(\Symfony\Component\Serializer\SerializerInterface $serializer, $streamFactory = null): array
+    {
+        return [[], null];
+    }
+    public function getExtraHeaders(): array
+    {
+        return ['Accept' => ['application/json']];
+    }
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception\GetFooNotFoundException
+     * @throws \Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception\GetFooClientErrorException
+     * @throws \Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception\GetFooServerErrorException
+     *
+     * @return null|\Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message
+     */
+    protected function transformResponseBody(\Psr\Http\Message\ResponseInterface $response, \Symfony\Component\Serializer\SerializerInterface $serializer, ?string $contentType = null)
+    {
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        if (is_null($contentType) === false && (200 === $status && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            return $serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message', 'json');
+        }
+        if (404 === $status) {
+            throw new \Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception\GetFooNotFoundException($response);
+        }
+        if ($status >= 400 && $status <= 499) {
+            throw new \Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception\GetFooClientErrorException($response);
+        }
+        if (is_null($contentType) === false && ($status >= 500 && $status <= 599 && mb_strpos(strtolower($contentType), 'application/json') !== false)) {
+            throw new \Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception\GetFooServerErrorException($serializer->deserialize($body, 'Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message', 'json'), $response);
+        }
+        return null;
+    }
+    public function getAuthenticationScopes(): array
+    {
+        return [];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/ApiException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/ApiException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception;
+
+interface ApiException extends \Throwable
+{
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/ClientErrorException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/ClientErrorException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception;
+
+abstract class ClientErrorException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/ClientException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/ClientException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception;
+
+interface ClientException extends ApiException
+{
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/GetFooClientErrorException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/GetFooClientErrorException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception;
+
+class GetFooClientErrorException extends ClientErrorException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Client error');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/GetFooNotFoundException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/GetFooNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception;
+
+class GetFooNotFoundException extends NotFoundException
+{
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(?\Psr\Http\Message\ResponseInterface $response = null)
+    {
+        parent::__construct('Not found');
+        $this->response = $response;
+    }
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/GetFooServerErrorException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/GetFooServerErrorException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception;
+
+class GetFooServerErrorException extends ServerErrorException
+{
+    /**
+     * @var \Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message
+     */
+    private $messageObject;
+    /**
+     * @var \Psr\Http\Message\ResponseInterface
+     */
+    private $response;
+    public function __construct(\Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message $message, \Psr\Http\Message\ResponseInterface $response)
+    {
+        parent::__construct('Server error');
+        $this->messageObject = $message;
+        $this->response = $response;
+    }
+    public function getMessageObject(): \Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message
+    {
+        return $this->messageObject;
+    }
+    public function getResponse(): \Psr\Http\Message\ResponseInterface
+    {
+        return $this->response;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/NotFoundException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/NotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception;
+
+abstract class NotFoundException extends \RuntimeException implements ClientException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message, 404);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/ServerErrorException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/ServerErrorException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception;
+
+abstract class ServerErrorException extends \RuntimeException implements ServerException, WithResponseInterface
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/ServerException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/ServerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception;
+
+interface ServerException extends ApiException
+{
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/WithResponseInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Exception/WithResponseInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Exception;
+
+interface WithResponseInterface
+{
+    public function getResponse(): ?\Psr\Http\Message\ResponseInterface;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Model/Message.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Model/Message.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Model;
+
+use Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\AdditionalAndPatternProperties;
+use Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\AdditionalPropertiesInterface;
+class Message implements AdditionalPropertiesInterface
+{
+    use AdditionalAndPatternProperties;
+    /**
+     * @var array
+     */
+    protected $initialized = [];
+    public function isInitialized($property): bool
+    {
+        return array_key_exists($property, $this->initialized);
+    }
+    /**
+     * @var string
+     */
+    protected $message;
+    /**
+     * @return string
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+    /**
+     * @param string $message
+     *
+     * @return self
+     */
+    public function setMessage(string $message): self
+    {
+        $this->initialized['message'] = true;
+        $this->message = $message;
+        return $this;
+    }
+    public function definedProperties(): array
+    {
+        return ['message' => ['message', 'getMessage', 'setMessage']];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Normalizer/JaneObjectNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Normalizer/JaneObjectNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Normalizer;
+
+use Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class JaneObjectNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    protected $normalizers = [
+        
+        \Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message::class => \Jane\Component\OpenApi31\Tests\StatusCodeRange\Normalizer\MessageNormalizer::class,
+        
+        \Jane\Component\JsonSchemaRuntime\Reference::class => \Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Normalizer\ReferenceNormalizer::class,
+    ], $normalizersCache = [];
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return array_key_exists($type, $this->normalizers);
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && array_key_exists(get_class($data), $this->normalizers);
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $normalizerClass = $this->normalizers[get_class($data)];
+        $normalizer = $this->getNormalizer($normalizerClass);
+        return $normalizer->normalize($data, $format, $context);
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $denormalizerClass = $this->normalizers[$type];
+        $denormalizer = $this->getNormalizer($denormalizerClass);
+        return $denormalizer->denormalize($data, $type, $format, $context);
+    }
+    private function getNormalizer(string $normalizerClass)
+    {
+        return $this->normalizersCache[$normalizerClass] ?? $this->initNormalizer($normalizerClass);
+    }
+    private function initNormalizer(string $normalizerClass)
+    {
+        $normalizer = new $normalizerClass();
+        $normalizer->setNormalizer($this->normalizer);
+        $normalizer->setDenormalizer($this->denormalizer);
+        $this->normalizersCache[$normalizerClass] = $normalizer;
+        return $normalizer;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return array_combine(array_keys($this->normalizers), array_fill(0, count($this->normalizers), false));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Normalizer/MessageNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Normalizer/MessageNormalizer.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Normalizer\CheckArray;
+use Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Normalizer\ValidatorTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class MessageNormalizer implements DenormalizerInterface, NormalizerInterface, DenormalizerAwareInterface, NormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+    use NormalizerAwareTrait;
+    use CheckArray;
+    use ValidatorTrait;
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
+    {
+        return $type === \Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message::class;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return is_object($data) && get_class($data) === \Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message::class;
+    }
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        $object = new \Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message();
+        if (null === $data || false === \is_array($data)) {
+            return $object;
+        }
+        if (isset($data['$ref']) && !isset($data['type']) && !isset($data['properties']) && !isset($data['allOf'])) {
+            return new Reference($data['$ref'], $context['document-origin']);
+        }
+        if (isset($data['$recursiveRef'])) {
+            return new Reference($data['$recursiveRef'], $context['document-origin']);
+        }
+        if (\array_key_exists('message', $data)) {
+            $object->setMessage($data['message']);
+            unset($data['message']);
+        }
+        foreach ($data as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $object[$key] = $value;
+            }
+        }
+        return $object;
+    }
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $dataArray = [];
+        if ($data->isInitialized('message') && null !== $data->getMessage()) {
+            $dataArray['message'] = $data->getMessage();
+        }
+        foreach ($data->additionalPropertyEntries() as $key => $value) {
+            if (preg_match('/.*/', (string) $key)) {
+                $dataArray[$key] = $value;
+            }
+        }
+        return $dataArray;
+    }
+    public function getSupportedTypes(?string $format = null): array
+    {
+        return [\Jane\Component\OpenApi31\Tests\StatusCodeRange\Model\Message::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/AdditionalAndPatternProperties.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/AdditionalAndPatternProperties.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime;
+
+trait AdditionalAndPatternProperties
+{
+    private array $extraProperties = [];
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public function definedProperties(): array
+    {
+        return [];
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            if ($definition[0] === $offset) {
+                return $this->isInitialized($phpName) || null !== $this->{$definition[1]}();
+            }
+        }
+        return \array_key_exists($offset, $this->extraProperties);
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                return $this->{$definition[1]}();
+            }
+        }
+        return $this->extraProperties[$offset] ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}($value);
+                return;
+            }
+        }
+        $this->extraProperties[$offset] = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        foreach ($this->definedProperties() as $definition) {
+            if ($definition[0] === $offset) {
+                $this->{$definition[2]}(null);
+                return;
+            }
+        }
+        unset($this->extraProperties[$offset]);
+    }
+    public function count(): int
+    {
+        return \count($this->toArray());
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->toArray());
+    }
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $values = [];
+        foreach ($this->definedProperties() as $phpName => $definition) {
+            $value = $this->{$definition[1]}();
+            if ($this->isInitialized($phpName) || null !== $value) {
+                $values[$definition[0]] = $value;
+            }
+        }
+        return array_merge($values, $this->extraProperties);
+    }
+    public function getArrayCopy(): array
+    {
+        return $this->toArray();
+    }
+    public function additionalPropertyEntries(): \Iterator
+    {
+        yield from $this->extraProperties;
+    }
+    public function jsonSerialize(): mixed
+    {
+        $values = $this->toArray();
+        // An empty PHP array would encode as [], so hand out an empty object instead,
+        // keeping json_encode consistent with every other JSON object payload.
+        if ([] === $values) {
+            return new \stdClass();
+        }
+        return $values;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/AdditionalPropertiesInterface.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/AdditionalPropertiesInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime;
+
+interface AdditionalPropertiesInterface extends \IteratorAggregate, \Countable, \ArrayAccess, \JsonSerializable
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+    /**
+     * @return iterable<string, mixed>
+     */
+    public function additionalPropertyEntries(): iterable;
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/BaseEndpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/BaseEndpoint.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client;
+
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class BaseEndpoint implements Endpoint
+{
+    protected array $formParameters = [];
+    protected array $queryParameters = [];
+    protected array $headerParameters = [];
+    protected mixed $body;
+    abstract public function getMethod(): string;
+    abstract public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    abstract public function getUri(): string;
+    abstract public function getAuthenticationScopes(): array;
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    protected function getExtraHeaders(): array
+    {
+        return [];
+    }
+    public function getQueryString(): string
+    {
+        $optionsResolved = $this->getQueryOptionsResolver()->resolve($this->queryParameters);
+        $styles = $this->getQueryStyles();
+        $allowReserved = $this->getQueryAllowReserved();
+        $queryParameters = [];
+        foreach ($optionsResolved as $key => $value) {
+            if (\array_key_exists($key, $styles)) {
+                if (null === $value) {
+                    continue;
+                }
+                foreach ($this->encodeStyledValue($key, $value, $styles[$key], \in_array($key, $allowReserved, true)) as $encodedValue) {
+                    $queryParameters[] = $encodedValue;
+                }
+                continue;
+            }
+            $value = $value ?? '';
+            $allowReservedKey = \in_array($key, $allowReserved, true);
+            $queryParameters[] = $this->encodeValue($key, $value, $allowReservedKey);
+        }
+        return implode('&', $queryParameters);
+    }
+    public function getHeaders(array $baseHeaders = []): array
+    {
+        $headersResolver = $this->getHeadersOptionsResolver();
+        $definedOptions = $headersResolver->getDefinedOptions();
+        $headerParameters = [];
+        foreach ($this->headerParameters as $name => $value) {
+            foreach ($definedOptions as $definedOption) {
+                if (strcasecmp((string) $name, $definedOption) === 0) {
+                    $name = $definedOption;
+                    break;
+                }
+            }
+            $headerParameters[$name] = $value;
+        }
+        return array_merge($this->getExtraHeaders(), $baseHeaders, $headersResolver->resolve($headerParameters));
+    }
+    protected function getQueryOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getQueryAllowReserved(): array
+    {
+        return [];
+    }
+    /**
+     * Declares the OpenAPI serialization style of query parameters.
+     *
+     * Keys are query parameter names, values follow the shape
+     * ['style' => string, 'explode' => bool]. Parameters with an
+     * explicit `content` must not be declared here: content based
+     * serialization takes precedence over styles.
+     *
+     * @return array<string, array{style?: string, explode?: bool}>
+     */
+    protected function getQueryStyles(): array
+    {
+        return [];
+    }
+    protected function getHeadersOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    // ----------------------------------------------------------------------------------------------------
+    // Used for OpenApi2 compatibility
+    protected function getFormBody(): array
+    {
+        return [['Content-Type' => ['application/x-www-form-urlencoded']], http_build_query($this->getFormOptionsResolver()->resolve($this->formParameters))];
+    }
+    protected function getMultipartBody($streamFactory = null): array
+    {
+        $bodyBuilder = new MultipartStreamBuilder($streamFactory);
+        $formParameters = $this->getFormOptionsResolver()->resolve($this->formParameters);
+        foreach ($formParameters as $key => $value) {
+            $bodyBuilder->addResource($key, $value);
+        }
+        return [['Content-Type' => ['multipart/form-data; boundary="' . ($bodyBuilder->getBoundary() . '"')]], $bodyBuilder->build()];
+    }
+    protected function getFormOptionsResolver(): OptionsResolver
+    {
+        return new OptionsResolver();
+    }
+    protected function getSerializedBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], $serializer->serialize($this->body, 'json')];
+    }
+    protected function getSerializedObjectBody(SerializerInterface $serializer): array
+    {
+        return [['Content-Type' => ['application/json']], JsonPayload::encode($serializer, $this->body)];
+    }
+    private function encodeValue(string $key, mixed $value, bool $allowReserved): string
+    {
+        return match (true) {
+            is_int($value) => $this->encodeIntValue($key, $value, $allowReserved),
+            is_bool($value) => $this->encodeIntValue($key, (int) $value, $allowReserved),
+            is_string($value) => $this->encodeStringValue($key, $value, $allowReserved),
+            is_float($value) => $this->encodeStringValue($key, (string) $value, $allowReserved),
+            is_array($value) => $this->encodeArrayValue($key, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Query value for key %s must be either int|string|float|array|bool, %s given', $key, gettype($value))),
+        };
+    }
+    private function encodeIntValue(string $queryParamName, int $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode((string) $value));
+    }
+    private function encodeStringValue(string $queryParamName, string $value, bool $allowReserved): string
+    {
+        $queryParamName = rawurlencode($queryParamName);
+        return sprintf('%s=%s', $queryParamName, $allowReserved ? $value : rawurlencode($value));
+    }
+    private function encodeArrayValue(string $queryParamName, array $value, bool $allowReserved): string
+    {
+        $params = [];
+        foreach ($value as $subKey => $subValue) {
+            $arrayKey = $queryParamName . '[' . rawurlencode((string) $subKey) . ']';
+            $params[] = $this->encodeValue($arrayKey, $subValue, $allowReserved);
+        }
+        return implode('&', $params);
+    }
+    /**
+     * @param array{style?: string, explode?: bool} $styleConfig
+     *
+     * @return string[]
+     */
+    private function encodeStyledValue(string $name, mixed $value, array $styleConfig, bool $allowReserved): array
+    {
+        $style = $styleConfig['style'] ?? 'form';
+        $explode = $styleConfig['explode'] ?? false;
+        return match ($style) {
+            'form' => $this->encodeFormStyle($name, $value, $explode, $allowReserved),
+            'spaceDelimited' => $this->encodeDelimitedStyle($name, $value, 'spaceDelimited', $allowReserved),
+            'pipeDelimited' => $this->encodeDelimitedStyle($name, $value, 'pipeDelimited', $allowReserved),
+            'deepObject' => $this->encodeDeepObjectStyle($name, $value, $allowReserved),
+            default => throw new \InvalidArgumentException(sprintf('Unsupported query parameter style "%s" for parameter "%s".', $style, $name)),
+        };
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeFormStyle(string $name, mixed $value, bool $explode, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        if (!$explode) {
+            return [$this->implodeStyledValues($name, $value, 'form', $allowReserved)];
+        }
+        $pairs = [];
+        if (\array_is_list($value)) {
+            // Exploded arrays repeat the parameter name for each item.
+            foreach ($value as $index => $item) {
+                if (\is_array($item)) {
+                    // Nested levels use bracket notation.
+                    $pairs = array_merge($pairs, $this->flattenBracketPairs($name . '[' . rawurlencode((string) $index) . ']', $item, $allowReserved));
+                    continue;
+                }
+                if (null === $item) {
+                    continue;
+                }
+                $pairs[] = $this->encodeValue($name, $item, $allowReserved);
+            }
+            return $pairs;
+        }
+        // Exploded objects drop the parent key: each property becomes a top level pair.
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                $pairs = array_merge($pairs, $this->flattenBracketPairs(rawurlencode((string) $subKey), $subValue, $allowReserved));
+                continue;
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            $pairs[] = $this->encodeValue((string) $subKey, $subValue, $allowReserved);
+        }
+        return $pairs;
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDelimitedStyle(string $name, mixed $value, string $style, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        return [$this->implodeStyledValues($name, $value, $style, $allowReserved)];
+    }
+    /**
+     * @return string[]
+     */
+    private function encodeDeepObjectStyle(string $name, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            return [$this->encodeValue($name, $value, $allowReserved)];
+        }
+        if ([] === $value) {
+            return [];
+        }
+        // deepObject uses bracket notation at every level, including the first one.
+        return $this->flattenBracketPairs($name, $value, $allowReserved);
+    }
+    /**
+     * Flattens nested values using PHP bracket notation with explicit indices
+     * (e.g. `filter[from]=a` or `tags[0]=b`).
+     *
+     * @return string[]
+     */
+    private function flattenBracketPairs(string $prefix, mixed $value, bool $allowReserved): array
+    {
+        if (!\is_array($value)) {
+            if (null === $value) {
+                return [];
+            }
+            return [$this->encodeValue($prefix, $value, $allowReserved)];
+        }
+        $pairs = [];
+        foreach ($value as $subKey => $subValue) {
+            $pairs = array_merge($pairs, $this->flattenBracketPairs($prefix . '[' . rawurlencode((string) $subKey) . ']', $subValue, $allowReserved));
+        }
+        return $pairs;
+    }
+    private function implodeStyledValues(string $name, array $value, string $style, bool $allowReserved): string
+    {
+        // Delimiters stay literal (except spaces), values are percent encoded: this matches the OpenAPI examples.
+        $separator = match ($style) {
+            'spaceDelimited' => '%20',
+            'pipeDelimited' => '|',
+            default => ',',
+        };
+        $isList = \array_is_list($value);
+        $parts = [];
+        foreach ($value as $subKey => $subValue) {
+            if (\is_array($subValue)) {
+                throw new \InvalidArgumentException(sprintf('Query parameter "%s" only supports flat values with style "%s", nested arrays or objects are not supported.', $name, $style));
+            }
+            if (null === $subValue) {
+                continue;
+            }
+            if (!$isList) {
+                // Non exploded objects interleave keys and values.
+                $parts[] = rawurlencode((string) $subKey);
+            }
+            $parts[] = $allowReserved ? $this->stringifyScalar($subValue) : rawurlencode($this->stringifyScalar($subValue));
+        }
+        return sprintf('%s=%s', rawurlencode($name), implode($separator, $parts));
+    }
+    private function stringifyScalar(mixed $value): string
+    {
+        return match (true) {
+            \is_bool($value) => (string) (int) $value,
+            \is_int($value), \is_float($value), \is_string($value) => (string) $value,
+            default => throw new \InvalidArgumentException(sprintf('Query value must be either int|string|float|bool|array|null, %s given', gettype($value))),
+        };
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/Client.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/Client.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client;
+
+use Jane\Component\OpenApiRuntime\Client\Plugin\AuthenticationRegistry;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+abstract class Client
+{
+    public const FETCH_RESPONSE = 'response';
+    public const FETCH_OBJECT = 'object';
+    protected ClientInterface $httpClient;
+    protected RequestFactoryInterface $requestFactory;
+    protected SerializerInterface $serializer;
+    protected StreamFactoryInterface $streamFactory;
+    public function __construct(ClientInterface $httpClient, RequestFactoryInterface $requestFactory, SerializerInterface $serializer, StreamFactoryInterface $streamFactory)
+    {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->serializer = $serializer;
+        $this->streamFactory = $streamFactory;
+    }
+    public function executeEndpoint(Endpoint $endpoint, string $fetch = self::FETCH_OBJECT)
+    {
+        if (self::FETCH_RESPONSE === $fetch) {
+            trigger_deprecation('jane-php/open-api-common', '7.3', 'Using %s::%s method with $fetch parameter equals to response is deprecated, use %s::%s instead.', __CLASS__, __METHOD__, __CLASS__, 'executeRawEndpoint');
+            return $this->executeRawEndpoint($endpoint);
+        }
+        return $endpoint->parseResponse($this->processEndpoint($endpoint), $this->serializer, $fetch);
+    }
+    public function executeRawEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        return $this->processEndpoint($endpoint);
+    }
+    private function processEndpoint(Endpoint $endpoint): ResponseInterface
+    {
+        [$bodyHeaders, $body] = $endpoint->getBody($this->serializer, $this->streamFactory);
+        $queryString = $endpoint->getQueryString();
+        $uriGlue = !str_contains($endpoint->getUri(), '?') ? '?' : '&';
+        $uri = $queryString !== '' ? $endpoint->getUri() . $uriGlue . $queryString : $endpoint->getUri();
+        $request = $this->requestFactory->createRequest($endpoint->getMethod(), $uri);
+        if ($body) {
+            if ($body instanceof StreamInterface) {
+                $request = $request->withBody($body);
+            } elseif (is_resource($body)) {
+                $request = $request->withBody($this->streamFactory->createStreamFromResource($body));
+            } elseif (strlen($body) <= 4000 && @file_exists($body)) {
+                // more than 4096 chars will trigger an error
+                $request = $request->withBody($this->streamFactory->createStreamFromFile($body));
+            } else {
+                $request = $request->withBody($this->streamFactory->createStream($body));
+            }
+        }
+        foreach ($endpoint->getHeaders($bodyHeaders) as $name => $value) {
+            $request = $request->withHeader($name, !is_bool($value) ? $value : ($value ? 'true' : 'false'));
+        }
+        if (count($endpoint->getAuthenticationScopes()) > 0) {
+            $scopes = [];
+            foreach ($endpoint->getAuthenticationScopes() as $scope) {
+                $scopes[] = $scope;
+            }
+            $request = $request->withHeader(AuthenticationRegistry::SCOPES_HEADER, $scopes);
+        }
+        return $this->httpClient->sendRequest($request);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/CustomQueryResolver.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/CustomQueryResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client;
+
+use Symfony\Component\OptionsResolver\Options;
+interface CustomQueryResolver
+{
+    public function __invoke(Options $options, $value);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/Endpoint.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/Endpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+interface Endpoint
+{
+    /**
+     * Get body for an endpoint.
+     *
+     * Return value consist of an array where the first item will be a list of headers to add on the request (like the Content Type)
+     * And the second value consist of the body object.
+     */
+    public function getBody(SerializerInterface $serializer, $streamFactory = null): array;
+    /**
+     * Get the query string of an endpoint without the starting ? (like foo=foo&bar=bar).
+     */
+    public function getQueryString(): string;
+    /**
+     * Get the URI of an endpoint (like /foo-uri).
+     */
+    public function getUri(): string;
+    /**
+     * Get the HTTP method of an endpoint (like GET, POST, ...).
+     */
+    public function getMethod(): string;
+    /**
+     * Get the headers of an endpoint.
+     */
+    public function getHeaders(array $baseHeaders = []): array;
+    /**
+     * Get security scopes of an endpoint.
+     */
+    public function getAuthenticationScopes(): array;
+    /**
+     * Parse and transform a PSR7 Response into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT);
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/EndpointTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/EndpointTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client;
+
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+trait EndpointTrait
+{
+    abstract protected function transformResponseBody(ResponseInterface $response, SerializerInterface $serializer, ?string $contentType = null);
+    public function parseResponse(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
+    {
+        $contentType = $response->hasHeader('Content-Type') ? current($response->getHeader('Content-Type')) : null;
+        return $this->transformResponseBody($response, $serializer, $contentType);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/JsonPayload.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Client/JsonPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Client;
+
+use Symfony\Component\Serializer\SerializerInterface;
+final class JsonPayload
+{
+    /**
+     * Encodes an object-shaped payload for a JSON request body.
+     *
+     * Only called for bodies resolving to a generated model class: a
+     * normalized empty PHP array must go on the wire as a JSON object ('{}'),
+     * not as an empty JSON array ('[]').
+     */
+    public static function encode(SerializerInterface $serializer, mixed $body): string
+    {
+        $serialized = $serializer->serialize($body, 'json');
+        if ('[]' === $serialized) {
+            return '{}';
+        }
+        return $serialized;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/JsonObject.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/JsonObject.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime;
+
+class JsonObject extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
+{
+    public function __construct(iterable $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+    public function offsetExists(mixed $offset): bool
+    {
+        return \array_key_exists($offset, get_object_vars($this));
+    }
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->{$offset} ?? null;
+    }
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        $this->{$offset} = $value;
+    }
+    public function offsetUnset(mixed $offset): void
+    {
+        unset($this->{$offset});
+    }
+    public function count(): int
+    {
+        return \count(get_object_vars($this));
+    }
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+    public function toArray(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/CheckArray.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/CheckArray.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Normalizer;
+
+trait CheckArray
+{
+    public function isOnlyNumericKeys(array $array): bool
+    {
+        return count(array_filter($array, function ($key) {
+            return is_numeric($key);
+        }, ARRAY_FILTER_USE_KEY)) === count($array);
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/InvalidDateException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/InvalidDateException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Normalizer;
+
+use RuntimeException;
+class InvalidDateException extends RuntimeException
+{
+    public function __construct(mixed $value, string $format)
+    {
+        parent::__construct(sprintf('Invalid date value "%s": does not match the expected format "%s".', is_scalar($value) ? (string) $value : get_debug_type($value), $format));
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ReferenceNormalizer.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ReferenceNormalizer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Normalizer;
+
+use Jane\Component\JsonSchemaRuntime\Reference;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+class ReferenceNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        $ref = [];
+        $ref['$ref'] = (string) $data->getReferenceUri();
+        return $ref;
+    }
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof Reference;
+    }
+    public function getSupportedTypes(?string $format): array
+    {
+        return [Reference::class => false];
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ValidationException.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Normalizer;
+
+use RuntimeException;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+class ValidationException extends RuntimeException
+{
+    public function __construct(private readonly ConstraintViolationListInterface $violationList)
+    {
+        parent::__construct(sprintf('Model validation failed with %d errors.', $violationList->count()), 400);
+    }
+    public function getViolationList(): ConstraintViolationListInterface
+    {
+        return $this->violationList;
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ValidatorTrait.php
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/expected/Runtime/Normalizer/ValidatorTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jane\Component\OpenApi31\Tests\StatusCodeRange\Runtime\Normalizer;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+trait ValidatorTrait
+{
+    protected function validate(array $data, Constraint $constraint): void
+    {
+        $validator = Validation::createValidator();
+        $violations = $validator->validate($data, $constraint);
+        if ($violations->count() > 0) {
+            throw new ValidationException($violations);
+        }
+    }
+}

--- a/src/Component/OpenApi31/Tests/fixtures/status-code-range/openapi.json
+++ b/src/Component/OpenApi31/Tests/fixtures/status-code-range/openapi.json
@@ -1,0 +1,62 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Status code range"
+    },
+    "servers": [
+        {
+            "url": "/"
+        }
+    ],
+    "paths": {
+        "/foo": {
+            "get": {
+                "operationId": "getFoo",
+                "responses": {
+                    "4XX": {
+                        "description": "Client error"
+                    },
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "5XX": {
+                        "description": "Server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Message"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected response"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Message": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
+++ b/src/Component/OpenApiCommon/Generator/ExceptionGenerator.php
@@ -5,6 +5,7 @@ namespace Jane\Component\OpenApiCommon\Generator;
 use Jane\Component\JsonSchema\Generator\Context\Context;
 use Jane\Component\JsonSchema\Generator\File;
 use Jane\Component\JsonSchema\Guesser\Guess\ClassGuess;
+use Jane\Component\OpenApiCommon\Generator\Traits\StatusCodeRangeTrait;
 use Jane\Component\OpenApiCommon\Naming\ExceptionNaming;
 use Jane\Component\OpenApiCommon\Registry\Registry;
 use PhpParser\Comment\Doc;
@@ -18,6 +19,8 @@ use PhpParser\Node\Stmt;
 
 class ExceptionGenerator
 {
+    use StatusCodeRangeTrait;
+
     /** @var array<int, string> */
     public static array $statusTexts = [
         400 => 'Bad Request',
@@ -71,14 +74,19 @@ class ExceptionGenerator
         $this->exceptionNaming = new ExceptionNaming();
     }
 
-    public function generate(string $functionName, int $status, Context $context, ?ClassGuess $classGuess, bool $isArray, ?string $classFqdn, ?string $description): ?string
+    public function generate(string $functionName, int|string $status, Context $context, ?ClassGuess $classGuess, bool $isArray, ?string $classFqdn, ?string $description): ?string
     {
-        if ($status < 400) {
+        $isRange = $this->isStatusCodeRange((string) $status);
+        $lowerBound = $isRange ? $this->statusCodeRangeBounds((string) $status)[0] : (int) $status;
+
+        if ($lowerBound < 400) {
             return null;
         }
 
-        if ((null === $description || '' === $description) && \array_key_exists($status, self::$statusTexts)) {
-            $description = self::$statusTexts[$status];
+        $status = $isRange ? (string) $status : (int) $status;
+
+        if ((null === $description || '' === $description) && \array_key_exists((int) $status, self::$statusTexts)) {
+            $description = self::$statusTexts[(int) $status];
         }
 
         $schema = $context->getCurrentSchema();
@@ -396,16 +404,25 @@ EOD
         }
     }
 
-    private function createHighLevelException(Context $context, int $code): string
+    private function createHighLevelException(Context $context, int|string $status): string
     {
         $schema = $context->getCurrentSchema();
-        $highLevelExceptionName = $this->exceptionNaming->generateExceptionName($code);
+        $isRange = $this->isStatusCodeRange((string) $status);
+        $lowerBound = $isRange ? $this->statusCodeRangeBounds((string) $status)[0] : (int) $status;
+        $highLevelExceptionName = $this->exceptionNaming->generateExceptionName($status);
         $unique = $schema->getRootName() . $schema->getDirectory();
 
-        if (\array_key_exists($unique, $this->initialized) && ($this->initialized[$unique] ?? false) && ($this->initialized[$unique][$code] ?? false)) {
+        if (\array_key_exists($unique, $this->initialized) && ($this->initialized[$unique] ?? false) && ($this->initialized[$unique][$status] ?? false)) {
             return $highLevelExceptionName;
         }
-        $this->initialized[$unique][$code] = true;
+        $this->initialized[$unique][$status] = true;
+
+        $parentConstructorArgs = [
+            new Node\Arg(new Expr\Variable('message')),
+        ];
+        if (!$isRange) {
+            $parentConstructorArgs[] = new Node\Arg(new Scalar\LNumber((int) $status));
+        }
 
         $highLevelException = new Stmt\Namespace_(new Name($schema->getNamespace() . '\\Exception'), [
             new Stmt\Class_(
@@ -414,7 +431,7 @@ EOD
                     'flags' => Modifiers::ABSTRACT,
                     'extends' => new Name('\\RuntimeException'),
                     'implements' => [
-                        new Name($code >= 500 ? 'ServerException' : 'ClientException'),
+                        new Name($lowerBound >= 500 ? 'ServerException' : 'ClientException'),
                         new Name('WithResponseInterface'),
                     ],
                     'stmts' => [
@@ -424,10 +441,7 @@ EOD
                                 new Param(new Expr\Variable('message'), null, new Name('string')),
                             ],
                             'stmts' => [
-                                new Stmt\Expression(new Expr\StaticCall(new Name('parent'), '__construct', [
-                                    new Node\Arg(new Expr\Variable('message')),
-                                    new Node\Arg(new Scalar\LNumber($code)),
-                                ])),
+                                new Stmt\Expression(new Expr\StaticCall(new Name('parent'), '__construct', $parentConstructorArgs)),
                             ],
                         ]),
                     ],

--- a/src/Component/OpenApiCommon/Generator/Traits/StatusCodeRangeTrait.php
+++ b/src/Component/OpenApiCommon/Generator/Traits/StatusCodeRangeTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jane\Component\OpenApiCommon\Generator\Traits;
+
+trait StatusCodeRangeTrait
+{
+    private function isStatusCodeRange(int|string $status): bool
+    {
+        return \is_string($status) && 1 === preg_match('/^[1-5]XX$/', $status);
+    }
+
+    /**
+     * @return array{int, int}
+     */
+    private function statusCodeRangeBounds(string $status): array
+    {
+        $hundreds = ((int) $status[0]) * 100;
+
+        return [$hundreds, $hundreds + 99];
+    }
+}

--- a/src/Component/OpenApiCommon/Naming/ExceptionNaming.php
+++ b/src/Component/OpenApiCommon/Naming/ExceptionNaming.php
@@ -48,13 +48,17 @@ class ExceptionNaming
         511 => 'NetworkAuthenticationRequired',
     ];
 
-    public function generateExceptionName(int $status, ?string $functionName = null): string
+    public function generateExceptionName(int|string $status, ?string $functionName = null): string
     {
-        $genericName = (string) $status;
-        if (\array_key_exists($status, $this->statusNamingMapping)) {
-            $genericName = $this->statusNamingMapping[$status];
+        if (\is_string($status) && 1 === preg_match('/^[1-5]XX$/', $status)) {
+            $genericName = '5XX' === $status ? 'ServerError' : 'ClientError';
         } else {
-            $genericName = \sprintf('Custom%s', $genericName);
+            $genericName = (string) $status;
+            if (\array_key_exists($status, $this->statusNamingMapping)) {
+                $genericName = $this->statusNamingMapping[$status];
+            } else {
+                $genericName = \sprintf('Custom%s', $genericName);
+            }
         }
 
         $exceptionName = \sprintf('%sException', $genericName);


### PR DESCRIPTION
## Description

Adds support for OpenAPI 3.x status code range responses (`4XX`, `5XX`, etc.) in generated clients, as allowed by the Responses Object patterned fields in OAS 3.0/3.1 and reported in #724. Previously a `"4XX"` response key was cast to `(int)`, generating an unreachable condition (`if (4 === $status)`) and skipping error exception generation entirely. OpenAPI 2 is intentionally untouched since range keys are not part of the v2 specification (ADR 0006).

## Changes

- Add `StatusCodeRangeTrait` in OpenApiCommon providing `isStatusCodeRange()` (matches `^[1-5]XX$`) and `statusCodeRangeBounds()` (e.g. `4XX` → `[400, 499]`).
- In OpenApi3/OpenApi31 `GetTransformResponseBodyTrait`: generate `$status >= 400 && $status <= 499` style conditions for range keys via a new `createStatusCondition()`, and sort generated branches so exact status codes are matched before ranges (most-specific-wins), regardless of key order in the spec.
- Extend `ExceptionGenerator::generate()` to accept `int|string $status`; range-based errors now produce abstract `ClientErrorException`/`ServerErrorException` parents (implementing `ClientException`/`ServerException` + `WithResponseInterface`) without a hardcoded exit code, plus per-operation leaves such as `getFooClientErrorException`.
- Extend `ExceptionNaming::generateExceptionName()` with range naming (`4XX` → `ClientError`, `5XX` → `ServerError`), guarded by the same range pattern so numeric strings still resolve to exact-code names.
- New fixtures `status-code-range` for both components (deliberately listing `4XX` before exact codes to cover precedence) and a runtime `StatusCodeRangeTest` covering precedence, 4xx/5xx breadth, deserialized payload on 5XX exceptions, and default-response fallback.
- Add phpstan `ignoreErrors` entries for fixture classes loaded at runtime in the new test (same pattern as existing tests).

## How to test

1. `vendor/bin/phpunit src/Component/OpenApi3/Tests/StatusCodeRangeTest.php`
2. `vendor/bin/phpunit src/Component/OpenApi3/Tests/JaneOpenApiResourceTest.php --filter status-code-range`
3. Full suites: `vendor/bin/phpunit`, then `castor qa:phpstan && castor qa:cs:check`

## Notes

- Generated code only changes for specs using range keys; previously such branches were unreachable, so no working behavior can regress.
- Statuses documented both by exact code and by range now deterministically match the exact code first.
- Range parent exceptions do not pass a fixed `$code` to `parent::__construct()` since a range has no single status code.
