### PR TITLE
fix(tests): add per-component testsuites for scoped phpunit runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ This file gives coding agents the minimum project context needed to work safely 
   - `composer install`
 - Run tests:
   - `vendor/bin/phpunit`
+- Run tests for a single component (never pass a path — it loads fixture classes and fatals):
+  - `vendor/bin/phpunit --testsuite <Component>` (e.g. `JsonSchema`; see `vendor/bin/phpunit --list-suites`)
 - Run static analysis:
   - `castor qa:phpstan`
 - Run coding standards (dry run):

--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -14,11 +14,14 @@ composer update
 vendor/bin/phpunit
 ```
 
-You can also run same commands to test a single component, you just have to cd inside the component first:
+You can also test a single component by using its named test suite (running phpunit with a path argument would
+bypass the fixture excludes and fatal on generated classes, so use `--testsuite` instead):
 
 ```bash
-vendor/bin/phpunit src/Component/JsonSchema
+vendor/bin/phpunit --testsuite JsonSchema
 ```
+
+You can list all available suite names with `vendor/bin/phpunit --list-suites`.
 
 ## Fixture based tests
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,6 +28,37 @@
       <exclude>./src/Component/OpenApi3/Tests/fixtures</exclude>
       <exclude>./src/Component/OpenApi31/Tests/fixtures</exclude>
     </testsuite>
+    <testsuite name="JsonSchema">
+      <directory>./src/Component/JsonSchema/Tests</directory>
+      <exclude>./src/Component/JsonSchema/Tests/fixtures</exclude>
+    </testsuite>
+    <testsuite name="JsonSchemaRuntime">
+      <directory>./src/Component/JsonSchemaRuntime/Tests</directory>
+    </testsuite>
+    <testsuite name="OpenApi2">
+      <directory>./src/Component/OpenApi2/Tests</directory>
+      <exclude>./src/Component/OpenApi2/Tests/fixtures</exclude>
+    </testsuite>
+    <testsuite name="OpenApi3">
+      <directory>./src/Component/OpenApi3/Tests</directory>
+      <exclude>./src/Component/OpenApi3/Tests/fixtures</exclude>
+    </testsuite>
+    <testsuite name="OpenApi31">
+      <directory>./src/Component/OpenApi31/Tests</directory>
+      <exclude>./src/Component/OpenApi31/Tests/fixtures</exclude>
+    </testsuite>
+    <testsuite name="OpenApiCommon">
+      <directory>./src/Component/OpenApiCommon/Tests</directory>
+    </testsuite>
+    <testsuite name="OpenApiRuntime">
+      <directory>./src/Component/OpenApiRuntime/Tests</directory>
+    </testsuite>
+    <testsuite name="JsonSchemaBundle">
+      <directory>./src/Bundle/JsonSchemaBundle/Tests</directory>
+    </testsuite>
+    <testsuite name="OpenApiBundle">
+      <directory>./src/Bundle/OpenApiBundle/Tests</directory>
+    </testsuite>
   </testsuites>
   <groups>
     <exclude>


### PR DESCRIPTION
Closes #1040

## What

- Adds named per-component testsuites to the root `phpunit.xml` (one per existing
  `Tests/` dir: `JsonSchema`, `JsonSchemaRuntime`, `OpenApi2`, `OpenApi3`,
  `OpenApi31`, `OpenApiCommon`, `OpenApiRuntime`, `JsonSchemaBundle`,
  `OpenApiBundle`), each excluding `Tests/fixtures` where present. The default
  "Jane Unit Test Suite", the prism group exclusion, and coverage config are
  unchanged, so bare `vendor/bin/phpunit` (what CI runs) behaves identically.
- Updates `docs/contributing/tests.md` and `AGENTS.md` to document
  `vendor/bin/phpunit --testsuite <Component>` (see `--list-suites`) instead of
  the path-argument invocation.

## Why

As described in #1040, `vendor/bin/phpunit src/Component/JsonSchema` (the
previously documented per-component run) bypasses the testsuite excludes:
PHPUnit loads every `*Test.php` under the path, including generated fixture
models named `Test.php`, and fatals with `Cannot redeclare class
Jane\Component\JsonSchema\Tests\Expected\Model\Test` before running a single
test. `--testsuite` goes through the configured suites, so the fixture
excludes apply.

The component-local `src/Component/*/phpunit.xml` files are deliberately left
untouched: they bootstrap a per-component `vendor/autoload.php` that only
exists in the split repositories, where they keep working as before.

## Validation

- `vendor/bin/phpunit --testsuite JsonSchema` — OK (300 tests, 1301 assertions); previously an instant fatal
- `vendor/bin/phpunit --testsuite OpenApi3` — OK (166 tests, 19331 assertions)
- `vendor/bin/phpunit --testsuite OpenApi31` — OK (51 tests, 1238 assertions)
- Bare `vendor/bin/phpunit` — OK (677 tests, 38479 assertions), unchanged from `next` @ 5c63e8ee

🤖 Generated with [Claude Code](https://claude.com/claude-code)