### PR TITLE
ci: skip the CI workflow for markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ on:
   push:
     branches:
       - next
-  pull_request: ~
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 jobs:
   cs-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,25 @@ on:
       - next
     paths-ignore:
       - '**.md'
+      - 'docs/**'
+      - 'mkdocs.yaml'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - 'LICENSE'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     paths-ignore:
       - '**.md'
+      - 'docs/**'
+      - 'mkdocs.yaml'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - 'LICENSE'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.github/ISSUE_TEMPLATE/**'
 jobs:
   cs-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Skip the whole CI workflow (cs-check, phpstan, the 11-leg test matrix, tests-lowest) when a push or pull request only touches files that cannot influence any CI job: markdown (CHANGELOG, docs pages), `docs/**` assets, the MkDocs/Python docs tooling (`mkdocs.yaml`, `pyproject.toml`, `poetry.lock`), `LICENSE`, `.editorconfig`, `.gitattributes` and issue templates. The docs site keeps deploying — `documentation.yml` has its own unfiltered push trigger.

Deliberately **not** on the list: `castor.composer.json` / `castor.composer.lock` (they pin the QA tooling castor runs in CI), the QA/test configs themselves, and `.github/workflows/**` (a workflow edit should always run CI against itself).

Uses the built-in [`paths-ignore`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) filter on both triggers. Semantics: the workflow is skipped only when **every** changed file matches an ignored path; as soon as one other file is part of the push / PR, everything runs as before. For pull requests the filter is evaluated against the full changeset of the PR, not the last commit, so a code PR that later adds a docs commit keeps its checks.

One caveat to be aware of: if `next` ever gets branch protection with *required* status checks, markdown-only PRs would show those checks as permanently "Expected" and be unmergeable — that setup would need [dummy pass-through jobs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks) instead. With merges done manually as today, `paths-ignore` is the simple correct tool.

---

*Disclosure: this change was prepared with the help of an AI agent (Claude Code).*